### PR TITLE
FIX certificate_file_access policy under Tetragon v1.7.0

### DIFF
--- a/tetragon-policies/certificate-file-access.yaml
+++ b/tetragon-policies/certificate-file-access.yaml
@@ -12,8 +12,6 @@ spec:
       type: "int"
     - index: 1
       type: "file"
-    returnArg:
-      type: "int"
     selectors:
     - matchArgs:
       - index: 1


### PR DESCRIPTION
Policy already had `return: false` in addition to `returnArg`. This was tolerated in v1.1.0 but not in the stricter v1.7.0.