### PR TITLE
Pass pre-extracted public key to FIPS checker correct cost analysis …

### DIFF
--- a/cert_analyzer.py
+++ b/cert_analyzer.py
@@ -1180,7 +1180,11 @@ class CertificateAnalyzer:
         fips_result = None
         if self.fips_compliance_enabled:
             try:
-                fips_result = _fips_check(cert)
+                pub_key = cert.public_key()
+            except Exception:
+                pub_key = None
+            try:
+                fips_result = _fips_check(cert, pub_key=pub_key)
             except Exception as e:
                 logger.debug(f"FIPS check failed for cert {cert_index} in {cert_path}: {e}")
                 fips_result = FipsComplianceResult(

--- a/fips_compliance_checker.py
+++ b/fips_compliance_checker.py
@@ -58,13 +58,16 @@ def _get_key_info(pub_key) -> Tuple[str, int, str]:
     return 'unknown', 0, ''
 
 
-def check_certificate(cert: x509.Certificate) -> FipsComplianceResult:
+def check_certificate(cert: x509.Certificate, *, pub_key=None) -> FipsComplianceResult:
     """
     Check an X.509 certificate against FIPS 140-2/140-3 algorithm requirements.
 
     Checks:
     - Signature hash algorithm (SHA-256 or stronger required; SHA-1 and MD5 are violations)
     - Public key algorithm, minimum key size, and approved EC curve
+
+    pub_key may be supplied by the caller to avoid a second cert.public_key() extraction
+    when the key object was already obtained during certificate info extraction.
 
     Returns a FipsComplianceResult with compliant=True only when no violations are found.
     """
@@ -91,7 +94,7 @@ def check_certificate(cert: x509.Certificate) -> FipsComplianceResult:
     key_size = 0
     curve_name = ''
     try:
-        pub = cert.public_key()
+        pub = pub_key if pub_key is not None else cert.public_key()
         algorithm, key_size, curve_name = _get_key_info(pub)
     except Exception:
         violations.append("Could not read public key")

--- a/perf_tests/README.md
+++ b/perf_tests/README.md
@@ -179,14 +179,22 @@ makes a small round-trip back into OpenSSL.
 
 | Cost source | Approx. μs | Code location |
 |---|---|---|
-| `cert.public_key()` (OpenSSL key extraction) | ~65–75 μs | `fips_compliance_checker.py:94` |
+| `cert.public_key()` (OpenSSL key extraction) | ~65–75 μs | `fips_compliance_checker.py` |
 
-Even though the certificate was already fully parsed, calling `public_key()`
-triggers a separate `X509_get_pubkey()` → `EVP_PKEY` extraction in OpenSSL.
-This is roughly as expensive as the initial `load_pem_x509_certificate()` call
-and is the reason FIPS checking doubles the per-cert cost. The key object is
-then inspected for algorithm, key size, and (for EC keys) approved curve; those
-attribute reads are cheap once the key object exists.
+The FIPS checker calls `cert.public_key()` to inspect algorithm, key size, and
+(for EC keys) approved curve. Even though the certificate struct is already in
+memory from the initial `load_pem_x509_certificate()` call, `public_key()`
+triggers a separate `X509_get_pubkey()` → `EVP_PKEY` extraction in OpenSSL —
+it does not return a cached object. This single call costs roughly as much as
+the initial cert parse and is the reason FIPS checking roughly doubles the
+per-cert cost.
+
+This overhead is inherent to the current design: `cert.public_key()` is called
+exactly once per certificate, but it cannot be avoided without replacing it with
+lower-level ASN.1 inspection. A future optimisation could use
+`cert.public_key_algorithm_oid` (cryptography ≥ 42.0.0) to determine the key
+algorithm and read the key size from the SubjectPublicKeyInfo bit string
+directly, avoiding the full `EVP_PKEY` object construction entirely.
 
 **Checksum adds a fifth bucket:**
 
@@ -208,8 +216,10 @@ negligible.
 - **Checksum has negligible throughput impact** — only ~9% overhead at the
   analysis level and indistinguishable from vanilla at the pipeline level.
 - **FIPS compliance checking is expensive**: +115% analysis overhead, reducing
-  pipeline throughput from ~6 600 to ~4 000 events/second. The cost comes from
-  an additional `cert.public_key()` OpenSSL call per certificate.
+  pipeline throughput from ~6 600 to ~4 000 events/second. The cost is a single
+  `cert.public_key()` OpenSSL call per certificate that is required to inspect
+  the key algorithm and size, and is not currently cached or avoidable within
+  the cryptography library's public API.
 - In practice the LRU cache absorbs most of this cost — only newly-seen cert
   paths incur the full analysis overhead.
 - The cert-analyzer is an **out-of-band observer** and does not sit in the

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -1917,9 +1917,9 @@ class TestFipsComplianceEnabled:
         import cert_analyzer as _ca
         from fips_compliance_checker import check_certificate as _real
 
-        def _spy(cert):
+        def _spy(cert, **kwargs):
             calls.append(cert)
-            return _real(cert)
+            return _real(cert, **kwargs)
 
         monkeypatch.setattr(_ca, '_fips_check', _spy)
 
@@ -1939,9 +1939,9 @@ class TestFipsComplianceEnabled:
         import cert_analyzer as _ca
         from fips_compliance_checker import check_certificate as _real
 
-        def _spy(cert):
+        def _spy(cert, **kwargs):
             calls.append(cert)
-            return _real(cert)
+            return _real(cert, **kwargs)
 
         monkeypatch.setattr(_ca, '_fips_check', _spy)
 
@@ -1956,7 +1956,7 @@ class TestFipsComplianceEnabled:
         """If _fips_check() raises, extract_certificate_info still returns CertificateInfo."""
         import cert_analyzer as _ca
 
-        def _raising(cert):
+        def _raising(cert, **kwargs):
             raise RuntimeError("simulated fips error")
 
         monkeypatch.setattr(_ca, '_fips_check', _raising)


### PR DESCRIPTION
…in README

check_certificate() now accepts an optional pub_key keyword argument so the caller can supply the already-extracted key object and avoid a redundant OpenSSL EVP_PKEY extraction. cert_analyzer extracts cert.public_key() once and passes it through.

Profiling showed this is a structural improvement only cert.public_key() was called exactly once before (inside the checker, not twice), so there is no performance gain. The perf_tests README is updated to reflect this: the FIPS overhead is an inherent single call, not a removable duplication, with a note on what a genuine future optimisation would require.