### PR TITLE
Calculate periodic workload risk scores for CSOs

### DIFF
--- a/cert_analyzer.py
+++ b/cert_analyzer.py
@@ -188,6 +188,54 @@ class CertificateInfo:
         return ""
 
 
+# Risk score weights for workload risk assessment.
+# Expiry proximity dominates; structural issues are secondary.
+_RISK_EXPIRED          = 100
+_RISK_EXPIRING_7D      = 80
+_RISK_EXPIRING_30D     = 50
+_RISK_EXPIRING_90D     = 25
+_RISK_SELF_SIGNED_LEAF = 20
+_RISK_FIPS_VIOLATION   = 15
+
+
+def _cert_risk_score(cert: 'CertificateInfo') -> int:
+    """Return a 0-100 risk score for a single certificate.
+
+    Expiry proximity is the dominant signal. Structural issues (self-signed
+    leaf, FIPS violations) contribute only when no expiry risk is present, and
+    can combine additively up to the 100 cap.
+    """
+    if cert.is_expired:
+        return _RISK_EXPIRED
+    days = cert.days_until_expiry
+    if days < 7:
+        return _RISK_EXPIRING_7D
+    if days < 30:
+        return _RISK_EXPIRING_30D
+    if days < 90:
+        return _RISK_EXPIRING_90D
+    score = 0
+    if cert.is_self_signed and cert.is_ca is False:
+        score += _RISK_SELF_SIGNED_LEAF
+    if cert.fips_violations:
+        score += _RISK_FIPS_VIOLATION
+    return min(score, 100)
+
+
+def _workload_key(cert: 'CertificateInfo') -> tuple:
+    """Return a grouping key for workload-level risk aggregation.
+
+    For Kubernetes workloads, groups by (namespace, workload_kind, workload_name)
+    so all replicas of a workload share one score regardless of node.
+    For bare-metal processes, falls back to (node_name, process).
+    The tuple always has 5 elements matching the workload_risk_score label order:
+    (namespace, workload_kind, workload_name, node_name, process).
+    """
+    if cert.workload_kind and cert.workload_name:
+        return (cert.namespace, cert.workload_kind, cert.workload_name, "", "")
+    return ("", "", "", cert.node_name, cert.process)
+
+
 class PrometheusMetrics:
     """Prometheus metrics for certificate monitoring"""
 
@@ -333,6 +381,15 @@ class PrometheusMetrics:
             'tetragon_policies_total',
             'Number of Tetragon tracing policies by state',
             ['state'],
+        )
+
+        self.workload_risk_score = Gauge(
+            'cert_workload_risk_score',
+            'Highest certificate risk score across all certs in a workload '
+            '(0=clean, 100=critical). Driven by expiry proximity, self-signed '
+            'leaf certs, and FIPS violations. Updated on each cert event and '
+            'refreshed every 60 seconds to reflect expiry drift.',
+            ['namespace', 'workload_kind', 'workload_name', 'node_name', 'process'],
         )
 
     def update_certificate_metrics(self, info: CertificateInfo):
@@ -944,12 +1001,43 @@ class CertificateAnalyzer:
         self.password_failed_paths: LRUCache = LRUCache()
         self.health_server = health_server
         self._known_policy_labels: Set[Tuple[str, str, str]] = set()
+        self._known_workload_risk_labels: Set[Tuple[str, str, str, str, str]] = set()
 
     def _update_cache_metrics(self) -> None:
         """Update Prometheus gauges reflecting current LRU cache occupancy."""
         self.metrics.cache_known_certs_size.set(len(self.known_certs))
         self.metrics.cache_processed_paths_size.set(len(self.processed_paths))
         self.metrics.cache_password_failed_size.set(len(self.password_failed_paths))
+
+    def _update_workload_risk_scores(self) -> None:
+        """Recompute and emit workload risk scores from the current cert cache.
+
+        Groups certs by workload key, takes the worst (max) score across all
+        certs in each group, and removes stale Prometheus series for workloads
+        that are no longer in the cache.
+        """
+        workloads: Dict[tuple, List[CertificateInfo]] = {}
+        for cert in self.known_certs.values():
+            key = _workload_key(cert)
+            workloads.setdefault(key, []).append(cert)
+
+        new_labels: Set[Tuple[str, str, str, str, str]] = set()
+        for (namespace, workload_kind, workload_name, node_name, process), certs in workloads.items():
+            score = max(_cert_risk_score(c) for c in certs)
+            label_tuple = (namespace, workload_kind, workload_name, node_name, process)
+            new_labels.add(label_tuple)
+            self.metrics.workload_risk_score.labels(
+                namespace=namespace,
+                workload_kind=workload_kind,
+                workload_name=workload_name,
+                node_name=node_name,
+                process=process,
+            ).set(score)
+
+        for label_tuple in self._known_workload_risk_labels - new_labels:
+            self.metrics.workload_risk_score.remove(*label_tuple)
+
+        self._known_workload_risk_labels = new_labels
 
     def is_cert_path(self, path: str) -> bool:
         """Check if a path looks like a certificate or keystore file"""
@@ -1816,6 +1904,7 @@ class CertificateAnalyzer:
             self.kafka_publisher.publish(cert_info)
 
         self._update_cache_metrics()
+        self._update_workload_risk_scores()
         return True
 
     def _handle_nsc_find_objects_init(self, event) -> bool:
@@ -1944,6 +2033,7 @@ class CertificateAnalyzer:
             self.kafka_publisher.publish(cert_info)
 
         self._update_cache_metrics()
+        self._update_workload_risk_scores()
         return True
 
     def process_event(self, event):
@@ -2026,6 +2116,7 @@ class CertificateAnalyzer:
                 self.kafka_publisher.publish(cert_info)
 
         self._update_cache_metrics()
+        self._update_workload_risk_scores()
 
     def get_runtime_tetragon_version(self, stub) -> str:
         """
@@ -2196,6 +2287,31 @@ class CertificateAnalyzer:
         thread.start()
         logger.info(f"Started Tetragon policy monitor (interval: {interval}s)")
 
+    def _start_risk_score_monitor(self) -> None:
+        """Start a background thread that periodically refreshes workload risk scores.
+
+        Ensures scores reflect current expiry proximity even when no new Tetragon
+        events arrive — e.g. a cert aging through the 90-day or 30-day threshold
+        between events will trigger a score update at the next refresh cycle.
+
+        Interval is configurable via RISK_SCORE_REFRESH_INTERVAL env var
+        (default: 60 seconds).
+        """
+        interval = int(os.getenv('RISK_SCORE_REFRESH_INTERVAL', '60'))
+
+        def _monitor():
+            while True:
+                time.sleep(interval)
+                try:
+                    self._update_workload_risk_scores()
+                except Exception as e:
+                    logger.warning(f"Risk score refresh error: {e}")
+
+        thread = threading.Thread(target=_monitor, daemon=True)
+        thread.name = 'risk-score-monitor'
+        thread.start()
+        logger.info(f"Started workload risk score monitor (interval: {interval}s)")
+
     def start(self):
         """
         Start listening to Tetragon events with automatic reconnection.
@@ -2228,6 +2344,7 @@ class CertificateAnalyzer:
         self._start_version_monitor(stub)
         self.check_tetragon_policies(stub)
         self._start_policy_monitor(stub)
+        self._start_risk_score_monitor()
 
         request = events_pb2.GetEventsRequest(
             allow_list=[
@@ -2320,6 +2437,8 @@ class CertificateAnalyzer:
 
             except Exception as e:
                 logger.error(f"Error scanning {base_path}: {e}")
+
+        self._update_workload_risk_scores()
 
 
 CONFIG_FILE_PATH = '/etc/cert-analyzer/cert-analyzer.conf'

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -54,6 +54,70 @@ All three share the same label set:
 | `tls_certificate_fips_compliant` | Gauge | `cert_path`, `process`, `cert_index`, `pod_name`, `namespace`, `workload_kind`, `workload_name`, `node_name`, `key_algorithm`, `signature_hash` | `1` if FIPS-compliant, `0` if not. Only emitted when `fips_compliance_enabled=true` |
 | `tls_certificate_self_signed` | Gauge | `cert_path`, `process`, `cert_index`, `pod_name`, `namespace`, `workload_kind`, `workload_name`, `node_name`, `is_ca` | `1` if the certificate is self-signed, `0` if issued by a separate CA. Always emitted. `is_ca` label: `true` / `false` / `unknown` (when Basic Constraints extension is absent) |
 
+### Workload risk score
+
+A single aggregated score per workload, derived from the signals already
+present in the per-certificate metrics above. The score reflects the
+**worst-case certificate** in the workload — one expiring cert raises the
+entire workload's score regardless of how many healthy certs it also holds.
+
+| Metric | Type | Description |
+|---|---|---|
+| `cert_workload_risk_score` | Gauge | Risk score for a workload based on its certificate posture (0 = clean, 100 = critical). Updated on each certificate event and refreshed every 60 seconds so scores drift correctly as certs age between events |
+
+Label set:
+
+| Label | Source | Notes |
+|---|---|---|
+| `namespace` | Tetragon / k8s | Kubernetes namespace; empty on bare metal |
+| `workload_kind` | Tetragon / k8s | e.g. `Deployment`, `DaemonSet`; empty on bare metal |
+| `workload_name` | Tetragon / k8s | Controller name; empty on bare metal |
+| `node_name` | Tetragon | Empty for Kubernetes workloads (all replicas share one score regardless of node); set for bare-metal grouping |
+| `process` | Tetragon event | Empty for Kubernetes workloads; binary path for bare-metal grouping |
+
+> **Grouping**: For Kubernetes, `node_name` and `process` are always empty so all
+> pod replicas of a workload share one score. For bare-metal deployments,
+> `namespace`, `workload_kind`, and `workload_name` are empty and the score is
+> per `(node_name, process)`.
+
+Scoring model — the workload score is the **maximum** across all its certificates:
+
+| Condition | Score |
+|---|---|
+| Any expired certificate | 100 |
+| Any certificate expiring within 7 days | 80 |
+| Any certificate expiring within 30 days | 50 |
+| Any certificate expiring within 90 days | 25 |
+| Self-signed leaf certificate (non-CA) | +20 |
+| FIPS violation | +15 |
+
+Expiry proximity dominates. Structural issues (`+20`, `+15`) combine additively
+but only when no expiry risk is present, and the total is capped at 100.
+Self-signed root CA certificates (`is_ca=true`) are excluded from the self-signed
+penalty as they are legitimately self-signed.
+
+The refresh interval is configurable via the `RISK_SCORE_REFRESH_INTERVAL`
+environment variable (default: 60 seconds). Stale label series are removed
+automatically when a workload's certificates leave the LRU cache.
+
+Alert and dashboard guidance:
+
+```promql
+# Top 10 riskiest workloads — suitable for a board-facing table panel
+topk(10, cert_workload_risk_score)
+
+# Alert when any workload reaches warning threshold
+cert_workload_risk_score > 50
+
+# Alert when any workload is critical
+cert_workload_risk_score > 79
+
+# Scope to a single namespace
+cert_workload_risk_score{namespace="production"}
+```
+
+---
+
 ### Event and error counters
 
 | Metric | Type | Labels | Description |

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -625,6 +625,342 @@
       "panels": []
     },
     {
+      "id": 36,
+      "title": "Workload Risk",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "panels": []
+    },
+    {
+      "id": 37,
+      "title": "High Risk Workloads",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 11
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(cert_workload_risk_score{namespace=~\"$namespace\",node_name=~\"$node\"} > 50) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 38,
+      "title": "Critical Workloads",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 4,
+        "y": 11
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(cert_workload_risk_score{namespace=~\"$namespace\",node_name=~\"$node\"} > 79) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 39,
+      "title": "Workloads by Risk Score",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 11
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(cert_workload_risk_score{namespace=~\"$namespace\",node_name=~\"$node\"})",
+          "instant": true,
+          "legendFormat": "{{workload_kind}}/{{workload_name}} ({{namespace}}){{node_name}}{{process}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "valueMode": "color",
+        "minVizWidth": 0,
+        "minVizHeight": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "displayName": "${__series.name}"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 40,
+      "title": "Workload Risk Scores",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(cert_workload_risk_score{namespace=~\"$namespace\",node_name=~\"$node\"})",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "namespace": 0,
+              "workload_kind": 1,
+              "workload_name": 2,
+              "node_name": 3,
+              "process": 4,
+              "Value": 5
+            },
+            "renameByName": {
+              "namespace": "Namespace",
+              "workload_kind": "Workload Kind",
+              "workload_name": "Workload",
+              "node_name": "Node",
+              "process": "Process",
+              "Value": "Risk Score"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": [
+              {
+                "displayName": "Risk Score",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Risk Score"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 25
+                    },
+                    {
+                      "color": "orange",
+                      "value": 50
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": 2,
       "title": "Total Certificates",
       "type": "stat",
@@ -1062,7 +1398,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 27
       },
       "panels": []
     },
@@ -1074,7 +1410,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 28
       },
       "datasource": {
         "type": "prometheus",
@@ -1239,7 +1575,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 21
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -1411,7 +1747,7 @@
         "h": 8,
         "w": 17,
         "x": 7,
-        "y": 21
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -1492,7 +1828,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 46
       },
       "panels": []
     },
@@ -1504,7 +1840,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 30
+        "y": 47
       },
       "datasource": {
         "type": "prometheus",
@@ -1601,7 +1937,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 30
+        "y": 47
       },
       "datasource": {
         "type": "prometheus",
@@ -1658,7 +1994,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 47
       },
       "datasource": {
         "type": "prometheus",
@@ -1766,7 +2102,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 55
       },
       "panels": []
     },
@@ -1778,7 +2114,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 56
       },
       "datasource": {
         "type": "prometheus",
@@ -1863,7 +2199,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 47
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -1916,7 +2252,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 68
       },
       "datasource": {
         "type": "prometheus",
@@ -2092,7 +2428,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 76
       },
       "datasource": {
         "type": "prometheus",
@@ -2233,7 +2569,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 84
       },
       "panels": []
     },
@@ -2245,7 +2581,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 85
       },
       "datasource": {
         "type": "prometheus",
@@ -2297,7 +2633,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 85
       },
       "datasource": {
         "type": "prometheus",
@@ -2362,7 +2698,7 @@
         "h": 6,
         "w": 16,
         "x": 0,
-        "y": 76
+        "y": 93
       },
       "datasource": {
         "type": "prometheus",
@@ -2469,7 +2805,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 93
       },
       "datasource": {
         "type": "prometheus",
@@ -2565,7 +2901,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 99
       },
       "panels": []
     },
@@ -2581,7 +2917,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 100
       },
       "targets": [
         {

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -24,7 +24,10 @@ from prometheus_client import REGISTRY
 # Import the analyzer (adjust path as needed)
 import sys
 sys.path.insert(0, os.path.dirname(__file__))
-from cert_analyzer import CertificateAnalyzer, CertificateInfo, LRUCache
+from cert_analyzer import (
+    CertificateAnalyzer, CertificateInfo, LRUCache,
+    _cert_risk_score, _workload_key,
+)
 
 
 class TestCertificateGeneration:
@@ -5297,3 +5300,246 @@ class TestTetragonConnected:
     def test_is_independent_of_analyzer_healthy(self, analyzer):
         """tetragon_connected and analyzer_healthy are separate metric objects."""
         assert analyzer.metrics.tetragon_connected is not analyzer.metrics.analyzer_healthy
+
+
+class TestCertRiskScore:
+    """Unit tests for _cert_risk_score()."""
+
+    def test_expired_cert_scores_100(self):
+        cert = _make_cert_info(
+            not_before=datetime.utcnow() - timedelta(days=400),
+            not_after=datetime.utcnow() - timedelta(days=1),
+        )
+        assert _cert_risk_score(cert) == 100
+
+    def test_expiring_within_7_days_scores_80(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=3),
+        )
+        assert _cert_risk_score(cert) == 80
+
+    def test_expiring_within_30_days_scores_50(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=15),
+        )
+        assert _cert_risk_score(cert) == 50
+
+    def test_expiring_within_90_days_scores_25(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=60),
+        )
+        assert _cert_risk_score(cert) == 25
+
+    def test_healthy_cert_scores_0(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=False,
+            fips_violations=[],
+        )
+        assert _cert_risk_score(cert) == 0
+
+    def test_self_signed_leaf_adds_20(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=True,
+            is_ca=False,
+            fips_violations=[],
+        )
+        assert _cert_risk_score(cert) == 20
+
+    def test_self_signed_ca_scores_0(self):
+        """Root CA certs are legitimately self-signed — not a risk signal."""
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=True,
+            is_ca=True,
+            fips_violations=[],
+        )
+        assert _cert_risk_score(cert) == 0
+
+    def test_fips_violation_adds_15(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=False,
+            fips_violations=["RSA key size 1024 is below minimum 2048"],
+        )
+        assert _cert_risk_score(cert) == 15
+
+    def test_self_signed_plus_fips_violation_combines(self):
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=True,
+            is_ca=False,
+            fips_violations=["weak key"],
+        )
+        assert _cert_risk_score(cert) == 35
+
+    def test_expiry_dominates_structural_issues(self):
+        """A cert expiring in 3 days scores 80 regardless of other issues."""
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=3),
+            is_self_signed=True,
+            is_ca=False,
+            fips_violations=["weak key"],
+        )
+        assert _cert_risk_score(cert) == 80
+
+    def test_score_caps_at_100(self):
+        """Score cannot exceed 100 even with multiple structural issues."""
+        cert = _make_cert_info(
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=True,
+            is_ca=False,
+            fips_violations=["v1"] * 10,
+        )
+        assert _cert_risk_score(cert) <= 100
+
+
+class TestWorkloadKey:
+    """Unit tests for _workload_key()."""
+
+    def test_kubernetes_workload_groups_by_workload_identity(self):
+        cert = _make_cert_info(
+            namespace="production",
+            workload_kind="Deployment",
+            workload_name="nginx",
+            node_name="worker-1",
+            process="/usr/sbin/nginx",
+        )
+        key = _workload_key(cert)
+        assert key == ("production", "Deployment", "nginx", "", "")
+
+    def test_kubernetes_workload_drops_node_and_process(self):
+        """Two replicas on different nodes should share the same workload key."""
+        cert1 = _make_cert_info(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            node_name="node-1", process="/app/server",
+        )
+        cert2 = _make_cert_info(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            node_name="node-2", process="/app/server",
+        )
+        assert _workload_key(cert1) == _workload_key(cert2)
+
+    def test_bare_metal_groups_by_node_and_process(self):
+        cert = _make_cert_info(
+            namespace="",
+            workload_kind="",
+            workload_name="",
+            node_name="host-a",
+            process="/usr/bin/nginx",
+        )
+        key = _workload_key(cert)
+        assert key == ("", "", "", "host-a", "/usr/bin/nginx")
+
+    def test_bare_metal_different_processes_get_different_keys(self):
+        nginx = _make_cert_info(
+            workload_kind="", workload_name="", node_name="host-a",
+            process="/usr/sbin/nginx",
+        )
+        curl = _make_cert_info(
+            workload_kind="", workload_name="", node_name="host-a",
+            process="/usr/bin/curl",
+        )
+        assert _workload_key(nginx) != _workload_key(curl)
+
+
+class TestWorkloadRiskScores:
+    """Integration tests for _update_workload_risk_scores()."""
+
+    def test_single_healthy_cert_scores_0(self, analyzer):
+        cert = _make_cert_info(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            not_after=datetime.utcnow() + timedelta(days=365),
+            is_self_signed=False,
+            fips_violations=[],
+        )
+        analyzer.known_certs[cert.unique_key] = cert
+        analyzer._update_workload_risk_scores()
+
+        score = analyzer.metrics.workload_risk_score.labels(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            node_name="", process="",
+        )._value.get()
+        assert score == 0
+
+    def test_expired_cert_raises_workload_to_100(self, analyzer):
+        cert = _make_cert_info(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            not_before=datetime.utcnow() - timedelta(days=400),
+            not_after=datetime.utcnow() - timedelta(days=1),
+        )
+        analyzer.known_certs[cert.unique_key] = cert
+        analyzer._update_workload_risk_scores()
+
+        score = analyzer.metrics.workload_risk_score.labels(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            node_name="", process="",
+        )._value.get()
+        assert score == 100
+
+    def test_worst_cert_dominates_workload_score(self, analyzer):
+        """A workload with one healthy and one expiring cert scores by the worst."""
+        healthy = _make_cert_info(
+            path="/etc/ssl/good.crt", serial_number="1001",
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            not_after=datetime.utcnow() + timedelta(days=365),
+        )
+        expiring = _make_cert_info(
+            path="/etc/ssl/bad.crt", serial_number="1002",
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            not_after=datetime.utcnow() + timedelta(days=3),
+        )
+        analyzer.known_certs[healthy.unique_key] = healthy
+        analyzer.known_certs[expiring.unique_key] = expiring
+        analyzer._update_workload_risk_scores()
+
+        score = analyzer.metrics.workload_risk_score.labels(
+            namespace="prod", workload_kind="Deployment", workload_name="api",
+            node_name="", process="",
+        )._value.get()
+        assert score == 80
+
+    def test_different_workloads_get_independent_scores(self, analyzer):
+        good_cert = _make_cert_info(
+            path="/etc/ssl/good.crt", serial_number="2001",
+            namespace="prod", workload_kind="Deployment", workload_name="frontend",
+            not_after=datetime.utcnow() + timedelta(days=365),
+        )
+        bad_cert = _make_cert_info(
+            path="/etc/ssl/bad.crt", serial_number="2002",
+            namespace="prod", workload_kind="Deployment", workload_name="backend",
+            not_before=datetime.utcnow() - timedelta(days=400),
+            not_after=datetime.utcnow() - timedelta(days=1),
+        )
+        analyzer.known_certs[good_cert.unique_key] = good_cert
+        analyzer.known_certs[bad_cert.unique_key] = bad_cert
+        analyzer._update_workload_risk_scores()
+
+        frontend_score = analyzer.metrics.workload_risk_score.labels(
+            namespace="prod", workload_kind="Deployment", workload_name="frontend",
+            node_name="", process="",
+        )._value.get()
+        backend_score = analyzer.metrics.workload_risk_score.labels(
+            namespace="prod", workload_kind="Deployment", workload_name="backend",
+            node_name="", process="",
+        )._value.get()
+        assert frontend_score == 0
+        assert backend_score == 100
+
+    def test_stale_series_removed_when_cert_evicted(self, analyzer):
+        """When a cert leaves known_certs its workload label set is removed."""
+        cert = _make_cert_info(
+            namespace="prod", workload_kind="Deployment", workload_name="gone",
+            not_after=datetime.utcnow() + timedelta(days=365),
+        )
+        analyzer.known_certs[cert.unique_key] = cert
+        analyzer._update_workload_risk_scores()
+
+        label_tuple = ("prod", "Deployment", "gone", "", "")
+        assert label_tuple in analyzer._known_workload_risk_labels
+
+        del analyzer.known_certs[cert.unique_key]
+        analyzer._update_workload_risk_scores()
+
+        assert label_tuple not in analyzer._known_workload_risk_labels


### PR DESCRIPTION
CSOs don't want to look at finely grained dashboards instead they want high level risk scoring of machines and applications. 

_NB. We might instead want to offload this to a downstream post-processing of the surfaced data. We shouldn't unecessarily burden the agent._