### PR TITLE
Add tls_certificate_last_accessed_timestamp Prometheus gauge

### DIFF
--- a/cert_analyzer.py
+++ b/cert_analyzer.py
@@ -223,6 +223,15 @@ class PrometheusMetrics:
              'node_name', 'app_label', 'container_name', 'checksum', 'parent_process']
         )
 
+        self.cert_last_accessed = Gauge(
+            'tls_certificate_last_accessed_timestamp',
+            'Unix timestamp of the most recent certificate access event',
+            ['cert_path', 'subject', 'issuer', 'serial', 'process', 'common_name',
+             'san_dns_names', 'san_ip_addresses',
+             'cert_index', 'pod_name', 'namespace', 'workload_kind', 'workload_name',
+             'node_name', 'app_label', 'container_name', 'checksum', 'parent_process']
+        )
+
         # Event counters
         self.cert_events_total = Counter(
             'tls_certificate_events_total',
@@ -375,6 +384,7 @@ class PrometheusMetrics:
         self.cert_expiry_days.labels(**labels).set(info.days_until_expiry)
         self.cert_expiry_timestamp.labels(**labels).set(info.not_after.timestamp())
         self.cert_valid_from.labels(**labels).set(info.not_before.timestamp())
+        self.cert_last_accessed.labels(**labels).set(datetime.utcnow().timestamp())
 
         self.cert_expired.labels(
             cert_path=info.path,

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -13,7 +13,7 @@ or consuming the Kafka topic.
 
 ### Certificate expiry and validity
 
-Three gauges carry the full certificate identity as labels and are updated
+Four gauges carry the full certificate identity as labels and are updated
 every time a certificate is seen.
 
 | Metric | Type | Description |
@@ -21,6 +21,7 @@ every time a certificate is seen.
 | `tls_certificate_expiry_days` | Gauge | Floating-point days until the certificate expires (negative when expired) |
 | `tls_certificate_expiry_timestamp` | Gauge | Unix timestamp of `not_after` |
 | `tls_certificate_valid_from_timestamp` | Gauge | Unix timestamp of `not_before` |
+| `tls_certificate_last_accessed_timestamp` | Gauge | Unix timestamp of the most recent access event for this certificate |
 
 All three share the same label set:
 

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -94,7 +94,7 @@
   "timezone": "browser",
   "title": "CertSight",
   "uid": "certsight-v1",
-  "version": 2,
+  "version": 3,
   "templating": {
     "list": [
       {
@@ -1232,6 +1232,131 @@
       }
     },
     {
+      "id": 36,
+      "title": "Recently Accessed Certificates",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "tls_certificate_last_accessed_timestamp{namespace=~\"$namespace\",node_name=~\"$node\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "cert_index": true,
+              "checksum": true,
+              "serial": true,
+              "subject": true,
+              "issuer": true,
+              "san_dns_names": true,
+              "san_ip_addresses": true,
+              "workload_kind": true,
+              "app_label": true,
+              "container_name": true,
+              "parent_process": true
+            },
+            "indexByName": {
+              "Value": 0,
+              "common_name": 1,
+              "cert_path": 2,
+              "process": 3,
+              "namespace": 4,
+              "workload_name": 5,
+              "pod_name": 6,
+              "node_name": 7
+            },
+            "renameByName": {
+              "Value": "Last Accessed",
+              "common_name": "Common Name",
+              "cert_path": "Path",
+              "process": "Process",
+              "namespace": "Namespace",
+              "workload_name": "Workload",
+              "pod_name": "Pod",
+              "node_name": "Node"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": [
+              {
+                "displayName": "Last Accessed",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Last Accessed",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Accessed"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": 11,
       "title": "Expiry Distribution",
       "type": "piechart",
@@ -1239,7 +1364,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "datasource": {
         "type": "prometheus",
@@ -1411,7 +1536,7 @@
         "h": 8,
         "w": 17,
         "x": 7,
-        "y": 21
+        "y": 29
       },
       "datasource": {
         "type": "prometheus",
@@ -1492,7 +1617,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 37
       },
       "panels": []
     },
@@ -1504,7 +1629,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 30
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -1601,7 +1726,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 30
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -1658,7 +1783,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -1766,7 +1891,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 46
       },
       "panels": []
     },
@@ -1778,7 +1903,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 47
       },
       "datasource": {
         "type": "prometheus",
@@ -1863,7 +1988,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "datasource": {
         "type": "prometheus",
@@ -1916,7 +2041,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 59
       },
       "datasource": {
         "type": "prometheus",
@@ -2092,7 +2217,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "datasource": {
         "type": "prometheus",
@@ -2233,7 +2358,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 75
       },
       "panels": []
     },
@@ -2245,7 +2370,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "datasource": {
         "type": "prometheus",
@@ -2297,7 +2422,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 76
       },
       "datasource": {
         "type": "prometheus",
@@ -2362,7 +2487,7 @@
         "h": 6,
         "w": 16,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "datasource": {
         "type": "prometheus",
@@ -2469,7 +2594,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 84
       },
       "datasource": {
         "type": "prometheus",
@@ -2565,7 +2690,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 90
       },
       "panels": []
     },
@@ -2581,7 +2706,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 91
       },
       "targets": [
         {


### PR DESCRIPTION
Surfaces a per-certificate access event timestamp with the full cert-identifying label set, matching tls_certificate_expiry_timestamp and tls_certificate_valid_from_timestamp. Updates FIELDS-README and adds a "Recently Accessed Certificates" table panel to the Grafana dashboard (sorted most-recent-first, Last Accessed formatted as ISO datetime).