### PR TITLE
Add optional per-process TLS event rate metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ sudo systemctl enable --now cert-analyzer
 | Setting | Default | Description |
 |---|---|---|
 | `port` | `9090` | Prometheus metrics port |
+| `event_rate_metrics_enabled` | `false` | Track `tcp_connect` and socket-bind event counts per process as Prometheus counters (`tls_tcp_connect_events_total`, `tls_socket_bind_events_total`). Useful for identifying which application is driving probe load spikes. Disabled by default to avoid high label cardinality in environments with many distinct process names |
 
 **[health]**
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -81,6 +81,7 @@ class CertificateAnalyzer:
                  checksum_enabled: bool = False,
                  demo_mode: bool = False,
                  fips_compliance_enabled: bool = True,
+                 event_rate_metrics_enabled: bool = False,
                  bind_probe_enabled: bool = False,
                  connect_probe_enabled: bool = False,
                  port_probe_timeout: float = 5.0,
@@ -94,6 +95,7 @@ class CertificateAnalyzer:
         self.checksum_enabled = checksum_enabled
         self.demo_mode = demo_mode
         self.fips_compliance_enabled = fips_compliance_enabled
+        self._event_rate_metrics_enabled = event_rate_metrics_enabled
         self._bind_probe_enabled = bind_probe_enabled
         self._connect_probe_enabled = connect_probe_enabled
         self._port_probe_timeout = port_probe_timeout
@@ -1377,13 +1379,21 @@ class CertificateAnalyzer:
         if event.HasField('process_kprobe'):
             fn = getattr(event.process_kprobe, 'function_name', '')
             if fn in ('security_socket_bind', 'sys_bind'):
+                if self._event_rate_metrics_enabled:
+                    process = event.process_kprobe.process.binary or 'unknown'
+                    self.metrics.tls_socket_bind_events_total.labels(
+                        process=process, node_name=self.metrics._node_name).inc()
                 if self._bind_probe_enabled:
                     self._handle_tls_bind_event(event)
-                    return
+                return
             elif fn == 'tcp_connect':
+                if self._event_rate_metrics_enabled:
+                    process = event.process_kprobe.process.binary or 'unknown'
+                    self.metrics.tls_tcp_connect_events_total.labels(
+                        process=process, node_name=self.metrics._node_name).inc()
                 if self._connect_probe_enabled:
                     self._handle_tls_connect_event(event)
-                    return
+                return
 
         cert_path, process_name, pid, namespace, tetragon_pod, parent_process, parent_pid = \
             self.extract_cert_path_from_event(event)

--- a/agent/config.py
+++ b/agent/config.py
@@ -108,6 +108,8 @@ def main():
     demo_mode               = cfg(cp, 'certificates', 'demo_mode',               'DEMO_MODE',                    'false').lower() == 'true'
     fips_compliance_enabled = cfg(cp, 'certificates', 'fips_compliance_enabled', 'FIPS_COMPLIANCE_ENABLED',      'true').lower() != 'false'
 
+    event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
+
     bind_probe_enabled    = cfg(cp, 'port_probe', 'bind_probe_enabled',    'BIND_PROBE_ENABLED',    'false').lower() == 'true'
     connect_probe_enabled = cfg(cp, 'port_probe', 'connect_probe_enabled', 'CONNECT_PROBE_ENABLED', 'false').lower() == 'true'
     port_probe_timeout       = float(cfg(cp, 'port_probe', 'timeout_seconds',        'PORT_PROBE_TIMEOUT',       '5'))
@@ -156,6 +158,7 @@ def main():
         logger.info(f"Kafka brokers:     {kafka_bootstrap}")
         logger.info(f"Kafka topic:       {kafka_topic}")
         logger.info(f"Kafka security:    {kafka_security}")
+    logger.info(f"Event rate metrics: {'enabled' if event_rate_metrics_enabled else 'disabled'}")
     logger.info(f"Bind probe:        {'enabled' if bind_probe_enabled else 'disabled'}")
     logger.info(f"Connect probe:     {'enabled' if connect_probe_enabled else 'disabled'}")
     if bind_probe_enabled or connect_probe_enabled:
@@ -195,6 +198,7 @@ def main():
                                    checksum_enabled=checksum_enabled,
                                    demo_mode=demo_mode,
                                    fips_compliance_enabled=fips_compliance_enabled,
+                                   event_rate_metrics_enabled=event_rate_metrics_enabled,
                                    bind_probe_enabled=bind_probe_enabled,
                                    connect_probe_enabled=connect_probe_enabled,
                                    port_probe_timeout=port_probe_timeout,

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -178,6 +178,19 @@ class PrometheusMetrics:
             ['status'],  # success, failed, skipped
         )
 
+        self.tls_tcp_connect_events_total = Counter(
+            'tls_tcp_connect_events_total',
+            'Total tcp_connect kprobe events seen per process (TLS-port only); '
+            'useful for diagnosing which application is driving probe load',
+            ['process', 'node_name'],
+        )
+        self.tls_socket_bind_events_total = Counter(
+            'tls_socket_bind_events_total',
+            'Total socket-bind kprobe events seen per process; '
+            'useful for diagnosing which application is driving probe load',
+            ['process', 'node_name'],
+        )
+
         # Tetragon policy tracking
         self.tetragon_policy_info = Gauge(
             'tetragon_policy_info',

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -70,7 +70,7 @@
       }
     ]
   },
-  "description": "CertSight — Real-time TLS certificate monitoring via eBPF. Tracks expiry, FIPS 140-2/140-3 compliance, self-signed certificates, and Java KeyStore visibility across bare metal and Kubernetes.",
+  "description": "CertSight \u2014 Real-time TLS certificate monitoring via eBPF. Tracks expiry, FIPS 140-2/140-3 compliance, self-signed certificates, and Java KeyStore visibility across bare metal and Kubernetes.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -770,8 +770,8 @@
               "node_name": "Node",
               "Value #A": "Total",
               "Value #B": "Expired",
-              "Value #C": "Expiring ≤7d",
-              "Value #D": "Expiring ≤30d",
+              "Value #C": "Expiring \u22647d",
+              "Value #D": "Expiring \u226430d",
               "Value #E": "FIPS Non-Compliant",
               "Value #F": "Self-Signed",
               "Value #G": "Last Event",
@@ -848,7 +848,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Expiring ≤7d"
+              "options": "Expiring \u22647d"
             },
             "properties": [
               {
@@ -882,7 +882,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Expiring ≤30d"
+              "options": "Expiring \u226430d"
             },
             "properties": [
               {
@@ -1405,7 +1405,7 @@
           },
           "expr": "(count(tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 30) or vector(0)) - (count(tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 7) or vector(0))",
           "instant": true,
-          "legendFormat": "Warning (7–30d)",
+          "legendFormat": "Warning (7\u201330d)",
           "refId": "C"
         },
         {
@@ -1415,7 +1415,7 @@
           },
           "expr": "(count(tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 90) or vector(0)) - (count(tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 30) or vector(0))",
           "instant": true,
-          "legendFormat": "Soon (30–90d)",
+          "legendFormat": "Soon (30\u201390d)",
           "refId": "D"
         },
         {
@@ -1490,7 +1490,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Warning (7–30d)"
+              "options": "Warning (7\u201330d)"
             },
             "properties": [
               {
@@ -1505,7 +1505,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Soon (30–90d)"
+              "options": "Soon (30\u201390d)"
             },
             "properties": [
               {
@@ -1557,7 +1557,7 @@
           },
           "expr": "sort(tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 90)",
           "instant": true,
-          "legendFormat": "{{common_name}} · {{cert_path}} ({{namespace}}) [{{node_name}}]",
+          "legendFormat": "{{common_name}} \u00b7 {{cert_path}} ({{namespace}}) [{{node_name}}]",
           "refId": "A"
         }
       ],
@@ -2719,7 +2719,9 @@
           "sort": "none"
         },
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2771,7 +2773,10 @@
           "sort": "none"
         },
         "legend": {
-          "calcs": ["lastNotNull", "max"],
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2960,6 +2965,212 @@
           }
         ]
       }
+    },
+    {
+      "id": 42,
+      "title": "Network Event Rates (optional \u2014 enable event_rate_metrics_enabled)",
+      "type": "row",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 109
+      },
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "showPoints": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "id": 43,
+          "title": "Socket Bind Event Rate by Process",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 110
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "rate(tls_socket_bind_events_total{node_name=~\"$node\"}[5m])",
+              "legendFormat": "{{process}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "showPoints": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "id": 44,
+          "title": "TCP Connect Event Rate by Process",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 110
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "rate(tls_tcp_connect_events_total{node_name=~\"$node\"}[5m])",
+              "legendFormat": "{{process}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 45,
+          "title": "Top Processes by TLS Event Rate",
+          "type": "table",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 118
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sort_desc(sum by (process, node_name) (rate(tls_socket_bind_events_total{node_name=~\"$node\"}[5m])))",
+              "instant": true,
+              "format": "table",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sort_desc(sum by (process, node_name) (rate(tls_tcp_connect_events_total{node_name=~\"$node\"}[5m])))",
+              "instant": true,
+              "format": "table",
+              "refId": "B"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "process",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true,
+                  "node_name 1": true
+                },
+                "indexByName": {
+                  "node_name": 0,
+                  "process": 1,
+                  "Value #A": 2,
+                  "Value #B": 3
+                },
+                "renameByName": {
+                  "node_name": "Node",
+                  "node_name 2": "Node",
+                  "process": "Process",
+                  "Value #A": "Bind/s",
+                  "Value #B": "Connect/s"
+                }
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true
+              }
+            },
+            "overrides": []
+          }
+        }
+      ]
     }
   ]
 }

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -6138,3 +6138,206 @@ class TestPortProbe:
 
         synthetic_path = f'tls-probe://127.0.0.1:{port}'
         assert any(k.startswith(synthetic_path + ':') for k in probe_analyzer.known_certs)
+
+
+class TestEventRateMetrics:
+    """Tests for per-process event-rate counters (event_rate_metrics_enabled).
+
+    Covers:
+      process_event counter increment for socket_bind / tcp_connect events
+      disabled by default (no-op when flag is off)
+      independent of bind_probe_enabled / connect_probe_enabled
+    """
+
+    @pytest.fixture
+    def rate_analyzer(self):
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+        a = CertificateAnalyzer(
+            tetragon_address='unix:///dev/null',
+            event_rate_metrics_enabled=True,
+        )
+        yield a
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _make_bind_event(fn, binary='/usr/sbin/nginx'):
+        from unittest.mock import MagicMock
+        kprobe = MagicMock()
+        kprobe.function_name = fn
+        kprobe.process.binary = binary
+        kprobe.process.pid.value = 1234
+        kprobe.process.HasField.side_effect = lambda f: f == 'pid'
+        kprobe.args = []
+        event = MagicMock()
+        event.HasField.side_effect = lambda f: f == 'process_kprobe'
+        event.process_kprobe = kprobe
+        event.node_name = 'test-node'
+        return event
+
+    @staticmethod
+    def _make_connect_event(binary='/usr/bin/curl'):
+        from unittest.mock import MagicMock
+        kprobe = MagicMock()
+        kprobe.function_name = 'tcp_connect'
+        kprobe.process.binary = binary
+        kprobe.process.pid.value = 2222
+        kprobe.process.HasField.side_effect = lambda f: f == 'pid'
+        kprobe.args = []
+        event = MagicMock()
+        event.HasField.side_effect = lambda f: f == 'process_kprobe'
+        event.process_kprobe = kprobe
+        event.node_name = 'test-node'
+        return event
+
+    @staticmethod
+    def _get_counter(counter, **labels):
+        return counter.labels(**labels)._value.get()
+
+    def test_socket_bind_counter_incremented(self, rate_analyzer):
+        """security_socket_bind event increments tls_socket_bind_events_total for the process."""
+        event = self._make_bind_event('security_socket_bind', '/usr/sbin/nginx')
+        rate_analyzer.process_event(event)
+        val = self._get_counter(
+            rate_analyzer.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/nginx',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        assert val == 1.0
+
+    def test_sys_bind_counter_incremented(self, rate_analyzer):
+        """sys_bind event increments tls_socket_bind_events_total for the process."""
+        event = self._make_bind_event('sys_bind', '/usr/sbin/httpd')
+        rate_analyzer.process_event(event)
+        val = self._get_counter(
+            rate_analyzer.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/httpd',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        assert val == 1.0
+
+    def test_tcp_connect_counter_incremented(self, rate_analyzer):
+        """tcp_connect event increments tls_tcp_connect_events_total for the process."""
+        event = self._make_connect_event('/usr/bin/curl')
+        rate_analyzer.process_event(event)
+        val = self._get_counter(
+            rate_analyzer.metrics.tls_tcp_connect_events_total,
+            process='/usr/bin/curl',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        assert val == 1.0
+
+    def test_counter_accumulates_across_events(self, rate_analyzer):
+        """Multiple events from the same process sum correctly."""
+        for _ in range(3):
+            rate_analyzer.process_event(self._make_bind_event('security_socket_bind', '/usr/sbin/nginx'))
+        val = self._get_counter(
+            rate_analyzer.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/nginx',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        assert val == 3.0
+
+    def test_counters_per_process_are_independent(self, rate_analyzer):
+        """Events from different processes are tracked under separate label values."""
+        rate_analyzer.process_event(self._make_bind_event('security_socket_bind', '/usr/sbin/nginx'))
+        rate_analyzer.process_event(self._make_bind_event('security_socket_bind', '/usr/sbin/httpd'))
+        nginx_val = self._get_counter(
+            rate_analyzer.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/nginx',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        httpd_val = self._get_counter(
+            rate_analyzer.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/httpd',
+            node_name=rate_analyzer.metrics._node_name,
+        )
+        assert nginx_val == 1.0
+        assert httpd_val == 1.0
+
+    def test_counters_disabled_by_default(self, analyzer):
+        """No counter increment when event_rate_metrics_enabled=False (the default)."""
+        assert not analyzer._event_rate_metrics_enabled
+        event = self._make_bind_event('security_socket_bind', '/usr/sbin/nginx')
+        analyzer.process_event(event)
+        samples = list(analyzer.metrics.tls_socket_bind_events_total.collect()[0].samples)
+        assert not any(s.labels.get('process') == '/usr/sbin/nginx' for s in samples)
+
+    def test_counting_independent_of_bind_probe(self):
+        """Event rate is counted even when bind_probe_enabled=False."""
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+        a = CertificateAnalyzer(
+            tetragon_address='unix:///dev/null',
+            event_rate_metrics_enabled=True,
+            bind_probe_enabled=False,
+        )
+        a.process_event(self._make_bind_event('security_socket_bind', '/usr/sbin/nginx'))
+        val = self._get_counter(
+            a.metrics.tls_socket_bind_events_total,
+            process='/usr/sbin/nginx',
+            node_name=a.metrics._node_name,
+        )
+        assert val == 1.0
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+
+    def test_counting_independent_of_connect_probe(self):
+        """Event rate is counted even when connect_probe_enabled=False."""
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+        a = CertificateAnalyzer(
+            tetragon_address='unix:///dev/null',
+            event_rate_metrics_enabled=True,
+            connect_probe_enabled=False,
+        )
+        a.process_event(self._make_connect_event('/usr/bin/curl'))
+        val = self._get_counter(
+            a.metrics.tls_tcp_connect_events_total,
+            process='/usr/bin/curl',
+            node_name=a.metrics._node_name,
+        )
+        assert val == 1.0
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for c in collectors:
+            try:
+                REGISTRY.unregister(c)
+            except Exception:
+                pass
+
+    def test_bind_event_does_not_fall_through_to_cert_extraction(self, rate_analyzer):
+        """Bind events return immediately even when event_rate_metrics_enabled=True."""
+        from unittest.mock import patch
+        event = self._make_bind_event('security_socket_bind')
+        with patch.object(rate_analyzer, 'extract_cert_path_from_event') as mock_extract:
+            rate_analyzer.process_event(event)
+        mock_extract.assert_not_called()
+
+    def test_connect_event_does_not_fall_through_to_cert_extraction(self, rate_analyzer):
+        """tcp_connect events return immediately even when event_rate_metrics_enabled=True."""
+        from unittest.mock import patch
+        event = self._make_connect_event()
+        with patch.object(rate_analyzer, 'extract_cert_path_from_event') as mock_extract:
+            rate_analyzer.process_event(event)
+        mock_extract.assert_not_called()


### PR DESCRIPTION
Adds two Prometheus counters — tls_tcp_connect_events_total and tls_socket_bind_events_total — labelled by process and node_name, to help identify which application is driving probe load spikes. Disabled by default (event_rate_metrics_enabled / EVENT_RATE_METRICS_ENABLED) to avoid high cardinality in environments with many distinct process names.

Also fixes a latent issue in process_event where bind/connect events fell through to cert extraction when probing was disabled; they never carry cert paths so the return is now unconditional for those function names.

Grafana dashboard gains a collapsed "Network Event Rates" row with two timeseries panels (bind/connect rate per process) and a top-processes table.
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/09289dfc-eef2-4d7a-ae86-5c2f66f52a76" />
