### PR TITLE
Parse large multi-cert files on a background thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ sudo systemctl enable --now cert-analyzer
 | `filter_self_events` | `true` | Ignore certificate accesses made by the analyzer itself |
 | `host_prefix` | _(empty)_ | Path prefix prepended to certificate paths from Tetragon events — leave empty for bare metal, set to `/host` for Kubernetes |
 | `demo_mode` | `false` | Log certificate details (subject, issuer, serial, validity, SANs) at INFO level instead of DEBUG — for demos only, leave false in production |
+| `large_file_cert_threshold` | `20` | Files with more PEM certs than this (e.g. a system CA bundle) are parsed on a background thread instead of the Tetragon event-consumer thread |
 
 **[passwords]**
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -86,7 +86,8 @@ class CertificateAnalyzer:
                  connect_probe_enabled: bool = False,
                  port_probe_timeout: float = 5.0,
                  port_probe_connect_delay: float = 2.0,
-                 tls_outbound_ports: Optional[frozenset] = None):
+                 tls_outbound_ports: Optional[frozenset] = None,
+                 large_file_cert_threshold: int = 20):
         self.tetragon_address = tetragon_address
         self.alert_threshold_days = alert_threshold_days
         self.filter_self_events = filter_self_events
@@ -101,6 +102,7 @@ class CertificateAnalyzer:
         self._port_probe_timeout = port_probe_timeout
         self._port_probe_connect_delay = port_probe_connect_delay
         self._tls_outbound_ports = tls_outbound_ports if tls_outbound_ports is not None else self.TLS_OUTBOUND_PORTS
+        self._large_file_cert_threshold = large_file_cert_threshold
         self.metrics = PrometheusMetrics(node_name=_NODE_NAME)
         self.known_certs: LRUCache = LRUCache()
         self.processed_paths: LRUCache = LRUCache()
@@ -120,6 +122,11 @@ class CertificateAnalyzer:
         # CPython set operations (in / add / discard) are GIL-atomic; no lock needed.
         self._probed_endpoints: LRUCache = LRUCache()
         self._probe_in_flight: Set[str] = set()
+        # Paths whose large multi-cert file (see _count_pem_certs) is currently
+        # being parsed on a background thread — de-dupes repeat Tetragon events
+        # for the same path that arrive before the worker populates known_certs.
+        # GIL-atomic set ops, same reasoning as _probe_in_flight above.
+        self._large_file_in_flight: Set[str] = set()
         self.last_event_time: float = 0.0
 
     def _update_cache_metrics(self) -> None:
@@ -562,6 +569,27 @@ class CertificateAnalyzer:
             is_self_signed=is_self_signed,
         )
 
+    def _count_pem_certs(self, cert_path: str) -> int:
+        """
+        Cheap upper-bound estimate of how many certificates a file contains —
+        used only to decide whether parsing should be deferred to a background
+        thread. Counts PEM 'BEGIN CERTIFICATE' markers without doing any ASN.1
+        parsing, which is orders of magnitude cheaper than parse_certificates()
+        for files with hundreds of certs (e.g. a system CA trust bundle).
+
+        JKS/PKCS12 keystores go through a dedicated decoder either way and
+        aren't pre-counted here — always treated as small enough to process
+        inline, since large multi-cert files in practice are PEM bundles.
+        """
+        suffix = Path(cert_path).suffix.lower()
+        if suffix in self.JKS_EXTENSIONS or suffix in self.PKCS12_EXTENSIONS:
+            return 0
+        try:
+            with open(cert_path, 'rb') as f:
+                return f.read().count(b'-----BEGIN CERTIFICATE-----')
+        except OSError:
+            return 0
+
     def analyze_certificate(
         self,
         cert_path: str,
@@ -602,6 +630,76 @@ class CertificateAnalyzer:
         self.processed_paths.add(cert_path)
         self._update_cache_metrics()
         return cert_infos
+
+    def _finish_new_certificate_file(
+        self,
+        cert_infos: List[CertificateInfo],
+        tetragon_pod,
+        parent_process: str,
+        parent_pid: int,
+        node_name: str,
+    ) -> None:
+        """Apply pod/event context, update metrics, log, cache, and publish for a freshly-parsed file."""
+        for cert_info in cert_infos:
+            self._apply_pod_context(cert_info, tetragon_pod)
+            cert_info.node_name      = node_name
+            cert_info.parent_process = parent_process
+            cert_info.parent_pid     = parent_pid
+
+            self.metrics.update_certificate_metrics(cert_info)
+            self.log_certificate_status(cert_info)
+            self.known_certs[cert_info.unique_key] = cert_info
+
+            if self.kafka_publisher is not None:
+                self.kafka_publisher.publish(cert_info)
+
+        self._update_cache_metrics()
+
+    def _process_certificate_file_async(
+        self,
+        cert_path: str,
+        process_name: str,
+        pid: int,
+        namespace: str,
+        tetragon_pod,
+        parent_process: str,
+        parent_pid: int,
+        node_name: str,
+    ) -> None:
+        """
+        Parse and extract a large multi-cert file on a background thread.
+
+        Keeps the Tetragon event-consumer thread free to keep draining the
+        gRPC stream while hundreds of certs (e.g. a system CA bundle) get
+        parsed, instead of blocking it for the whole burst. _large_file_in_flight
+        de-dupes repeat Tetragon events for the same path that arrive before the
+        worker finishes and populates known_certs.
+        """
+        if cert_path in self._large_file_in_flight:
+            logger.debug(
+                f"Large certificate file {cert_path} already being processed "
+                f"in the background — skipping duplicate event"
+            )
+            return
+        self._large_file_in_flight.add(cert_path)
+
+        def _worker():
+            try:
+                cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
+                if cert_infos:
+                    logger.info(
+                        f"Found {len(cert_infos)} certificate(s) in {cert_path} "
+                        f"(parsed in background — large file)"
+                    )
+                    self._finish_new_certificate_file(
+                        cert_infos, tetragon_pod, parent_process, parent_pid, node_name
+                    )
+            finally:
+                self._large_file_in_flight.discard(cert_path)
+
+        threading.Thread(
+            target=_worker, daemon=True, name=f'cert-parse-{Path(cert_path).name}'
+        ).start()
 
     def _apply_pod_context(self, cert_info: CertificateInfo, tetragon_pod):
         """Populate all Tetragon Pod proto fields onto cert_info."""
@@ -1452,29 +1550,25 @@ class CertificateAnalyzer:
                 self.metrics.update_certificate_metrics(cert_info)
             return
 
+        # Large multi-cert files (e.g. system CA bundles with hundreds of certs)
+        # are parsed on a background thread so one file doesn't block this
+        # thread from consuming the rest of the Tetragon event stream.
+        if self._count_pem_certs(cert_path) > self._large_file_cert_threshold:
+            self._process_certificate_file_async(
+                cert_path, process_name, pid, namespace,
+                tetragon_pod, parent_process, parent_pid, event.node_name,
+            )
+            return
+
         # Analyze new certificate file (may contain multiple certs)
         cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
         if not cert_infos:
             return
 
         logger.info(f"Found {len(cert_infos)} certificate(s) in {cert_path}")
-
-        for cert_info in cert_infos:
-            # Apply pod context: Tetragon event first, k8s API for extras
-            self._apply_pod_context(cert_info, tetragon_pod)
-            cert_info.node_name     = event.node_name
-            cert_info.parent_process = parent_process
-            cert_info.parent_pid     = parent_pid
-
-            self.metrics.update_certificate_metrics(cert_info)
-            self.log_certificate_status(cert_info)
-            self.known_certs[cert_info.unique_key] = cert_info
-
-            # Publish new certificate discovery to Kafka if enabled
-            if self.kafka_publisher is not None:
-                self.kafka_publisher.publish(cert_info)
-
-        self._update_cache_metrics()
+        self._finish_new_certificate_file(
+            cert_infos, tetragon_pod, parent_process, parent_pid, event.node_name
+        )
 
     def get_runtime_tetragon_version(self, stub) -> str:
         """

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -641,17 +641,29 @@ class CertificateAnalyzer:
     ) -> None:
         """Apply pod/event context, update metrics, log, cache, and publish for a freshly-parsed file."""
         for cert_info in cert_infos:
-            self._apply_pod_context(cert_info, tetragon_pod)
-            cert_info.node_name      = node_name
-            cert_info.parent_process = parent_process
-            cert_info.parent_pid     = parent_pid
+            try:
+                self._apply_pod_context(cert_info, tetragon_pod)
+                cert_info.node_name      = node_name
+                cert_info.parent_process = parent_process
+                cert_info.parent_pid     = parent_pid
 
-            self.metrics.update_certificate_metrics(cert_info)
-            self.log_certificate_status(cert_info)
-            self.known_certs[cert_info.unique_key] = cert_info
+                self.metrics.update_certificate_metrics(cert_info)
+                self.log_certificate_status(cert_info)
+                self.known_certs[cert_info.unique_key] = cert_info
 
-            if self.kafka_publisher is not None:
-                self.kafka_publisher.publish(cert_info)
+                if self.kafka_publisher is not None:
+                    self.kafka_publisher.publish(cert_info)
+            except Exception as e:
+                # One bad cert (e.g. an unexpected label value) must not abort
+                # the rest of the file — each cert is otherwise independent.
+                logger.error(
+                    f"Error finishing certificate {cert_info.cert_index} in "
+                    f"{cert_info.path}: {e}", exc_info=True
+                )
+                self.metrics.cert_events_total.labels(
+                    event_type='processing', status='error'
+                ).inc()
+                self.metrics.cert_analysis_errors.labels(error_type='finish_error').inc()
 
         self._update_cache_metrics()
 
@@ -685,15 +697,25 @@ class CertificateAnalyzer:
 
         def _worker():
             try:
-                cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
-                if cert_infos:
-                    logger.info(
-                        f"Found {len(cert_infos)} certificate(s) in {cert_path} "
-                        f"(parsed in background — large file)"
-                    )
-                    self._finish_new_certificate_file(
-                        cert_infos, tetragon_pod, parent_process, parent_pid, node_name
-                    )
+                try:
+                    cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
+                    if cert_infos:
+                        logger.info(
+                            f"Found {len(cert_infos)} certificate(s) in {cert_path} "
+                            f"(parsed in background — large file)"
+                        )
+                        self._finish_new_certificate_file(
+                            cert_infos, tetragon_pod, parent_process, parent_pid, node_name
+                        )
+                except Exception as e:
+                    # Mirror the error handling start()'s event loop gives every
+                    # synchronous event — this runs on its own thread, so nothing
+                    # else will catch, log, or count an exception raised here.
+                    logger.error(f"Error processing large certificate file {cert_path}: {e}",
+                                 exc_info=True)
+                    self.metrics.cert_events_total.labels(
+                        event_type='processing', status='error'
+                    ).inc()
             finally:
                 self._large_file_in_flight.discard(cert_path)
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -107,6 +107,7 @@ def main():
     checksum_enabled        = cfg(cp, 'certificates', 'checksum_enabled',        'CERT_CHECKSUM_ENABLED',        'false').lower() == 'true'
     demo_mode               = cfg(cp, 'certificates', 'demo_mode',               'DEMO_MODE',                    'false').lower() == 'true'
     fips_compliance_enabled = cfg(cp, 'certificates', 'fips_compliance_enabled', 'FIPS_COMPLIANCE_ENABLED',      'true').lower() != 'false'
+    large_file_cert_threshold = int(cfg(cp, 'certificates', 'large_file_cert_threshold', 'LARGE_FILE_CERT_THRESHOLD', '20'))
 
     event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
 
@@ -146,6 +147,7 @@ def main():
     logger.info(f"Cache max size:    {CACHE_MAX_SIZE}")
     logger.info(f"Cert checksums:    {'enabled' if checksum_enabled else 'disabled'}")
     logger.info(f"FIPS checking:     {'enabled' if fips_compliance_enabled else 'disabled'}")
+    logger.info(f"Large file threshold: >{large_file_cert_threshold} certs parsed in background")
     logger.info(f"Metrics port:      {metrics_port}")
     logger.info(f"Health port:       {health_port}")
     logger.info(f"Alert threshold:   {alert_threshold} days")
@@ -203,7 +205,8 @@ def main():
                                    connect_probe_enabled=connect_probe_enabled,
                                    port_probe_timeout=port_probe_timeout,
                                    port_probe_connect_delay=port_probe_connect_delay,
-                                   tls_outbound_ports=tls_outbound_ports)
+                                   tls_outbound_ports=tls_outbound_ports,
+                                   large_file_cert_threshold=large_file_cert_threshold)
 
     health = HealthServer(
         analyzer=analyzer,

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 from datetime import datetime
 from typing import Optional
@@ -43,6 +44,14 @@ class KafkaPublisher:
     The publisher is a no-op when Kafka is disabled or unavailable. All
     errors are logged as warnings and never propagate — a broker outage must
     never prevent the analyzer from continuing to work with Prometheus only.
+
+    Thread-safety: publish() may be called concurrently from the main Tetragon
+    event-consumer thread, the periodic_scan thread, and any number of
+    large-file background parsing threads. An RLock guards every read/write of
+    self._producer and self._last_connect_attempt (including the async
+    _on_error errback, which kafka-python invokes from its own I/O thread) so
+    reconnects can't race and a producer can't be closed out from under a
+    concurrent send().
 
     Message schema (all fields present, empty string when not applicable):
     {
@@ -98,6 +107,7 @@ class KafkaPublisher:
         self._producer_kwargs: dict = {}
         self._last_connect_attempt: float = 0.0
         self._reconnect_cooldown: float = 30.0  # seconds between reconnect attempts
+        self._lock = threading.RLock()
 
         if not KAFKA_AVAILABLE:
             logger.warning(
@@ -123,12 +133,16 @@ class KafkaPublisher:
             self._producer_kwargs['sasl_plain_username']    = sasl_username
             self._producer_kwargs['sasl_plain_password']    = sasl_password
 
-        self._connect(bootstrap_servers, topic)
+        with self._lock:
+            self._connect(bootstrap_servers, topic)
 
     def _connect(self, bootstrap_servers: str = '', topic: str = '') -> bool:
         """
         Attempt to create a KafkaProducer. Returns True on success.
         Respects a cooldown period to avoid hammering a down broker.
+
+        Caller must hold self._lock — this reads and writes self._producer
+        and self._last_connect_attempt without its own locking.
         """
         now = time.time()
         if now - self._last_connect_attempt < self._reconnect_cooldown:
@@ -170,11 +184,6 @@ class KafkaPublisher:
         """
         if not KAFKA_AVAILABLE:
             return
-
-        # Attempt reconnection if producer is absent
-        if self._producer is None:
-            if not self._connect():
-                return
 
         message = {
             'event_type':        'certificate_discovered',
@@ -228,31 +237,42 @@ class KafkaPublisher:
         # Use unique_key (path:cert_index:serial) as the partition key.
         key = cert_info.unique_key
 
-        try:
-            self._producer.send(
-                self._topic,
-                key=key,
-                value=message,
-            ).add_errback(self._on_error)
-        except Exception as e:
-            logger.warning(f"Kafka publish failed for {cert_info.path}: {e}")
-            # Nullify the producer so the next publish attempt triggers reconnect
-            self._producer = None
+        with self._lock:
+            # Attempt reconnection if producer is absent
+            if self._producer is None:
+                if not self._connect():
+                    return
+
+            try:
+                self._producer.send(
+                    self._topic,
+                    key=key,
+                    value=message,
+                ).add_errback(self._on_error)
+            except Exception as e:
+                logger.warning(f"Kafka publish failed for {cert_info.path}: {e}")
+                # Nullify the producer so the next publish attempt triggers reconnect
+                self._producer = None
 
     def _on_error(self, exc: Exception) -> None:
+        # kafka-python invokes errbacks from its own internal I/O thread, so
+        # this can run concurrently with publish()/close() on other threads.
         logger.warning(f"Kafka delivery error: {exc}")
         _kafka_delivery_errors.labels(node_name=_NODE_NAME).inc()
         # Nullify the producer so the next publish attempt triggers reconnect.
         # Without this, a broker that drops messages in-flight (broker down,
         # auth failure, topic deleted) would leave the producer in a state where
         # send() appears to succeed but nothing is ever delivered.
-        self._producer = None
+        with self._lock:
+            self._producer = None
 
     def close(self) -> None:
         """Flush pending messages and close the producer cleanly."""
-        if self._producer is not None:
-            try:
-                self._producer.flush(timeout=5)
-                self._producer.close()
-            except Exception as e:
-                logger.warning(f"Error closing Kafka producer: {e}")
+        with self._lock:
+            if self._producer is not None:
+                try:
+                    self._producer.flush(timeout=5)
+                    self._producer.close()
+                except Exception as e:
+                    logger.warning(f"Error closing Kafka producer: {e}")
+                self._producer = None

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -91,6 +91,12 @@ demo_mode = false
 # and per-certificate checking adds unwanted overhead.
 fips_compliance_enabled = true
 
+# Files containing more PEM certificates than this (e.g. a system CA trust
+# bundle) are parsed on a background thread instead of the Tetragon
+# event-consumer thread, so one large bundle can't delay processing of
+# other events.
+large_file_cert_threshold = 20
+
 
 [passwords]
 # Passwords for encrypted keystores. These are tried before the

--- a/probe_tests/README.md
+++ b/probe_tests/README.md
@@ -387,3 +387,62 @@ reactively when it sees the bind event.  The outbound probe test must also make
 the client-side connect itself, because the kprobe trigger is the connect, not
 the bind.  Both tests use the same `_probe_tls_endpoint` path inside cert_analyzer;
 the difference is which Tetragon event starts the chain.
+
+---
+
+### test_large_cert_bundle (Python)
+
+Exercises the large-file background-parsing path added to `cert_analyzer`
+(`_count_pem_certs` / `_process_certificate_file_async` in `agent/analyzer.py`):
+files with more PEM certs than `large_file_cert_threshold` (default 20, e.g. a
+system CA trust bundle) are parsed on a background thread instead of the
+Tetragon event-consumer thread, so one large file can't delay processing of
+other events.
+
+**Step 1 — Load the policy:**
+
+```bash
+sudo tetra tracingpolicy add tetragon-policies/certificate-file-access.yaml
+```
+
+**Step 2 — Run the probe test:**
+
+```bash
+# Writes to /etc/pki/tls/certs by default — same ReadOnlyPaths location used
+# by the other file-based probe tests; typically requires sudo to write.
+sudo python3 probe_tests/test_large_cert_bundle.py
+
+# Custom cert count / output directory:
+sudo python3 probe_tests/test_large_cert_bundle.py --count 50
+python3 probe_tests/test_large_cert_bundle.py --out-dir /some/writable/readonly/path
+
+# Keep the generated files instead of printing an rm command:
+sudo python3 probe_tests/test_large_cert_bundle.py --keep
+```
+
+The script generates an N-cert PEM bundle plus a single-cert "canary" file,
+opens the bundle first (firing `fd_install` for a large file), then
+immediately opens the canary (firing `fd_install` for a one-cert file).
+
+**Step 3 — Verify cert_analyzer output:**
+
+```bash
+journalctl -u cert-analyzer --since "-1 min" | grep -E "bundle-test|canary"
+```
+
+The canary's `🔍 Detected certificate access` / `✅ OK` lines should appear
+within a second or two of being triggered, even though they were opened
+*after* the bundle — proof the bundle's parsing (which logs `Found N
+certificate(s) in ... (parsed in background — large file)`) didn't block the
+event-consumer thread from handling the canary's event first.
+
+**Step 4 — Remove the policy:**
+
+```bash
+sudo tetra tracingpolicy delete certificate-file-access
+```
+
+**What this doesn't cover:** the script only checks canary event *latency*,
+not `cert_fips_compliant`/`tls_certificate_expiry_days` correctness for the
+bundle's certs — that's already covered by
+`TestLargeFileBackgroundProcessing` in `test_cert_analyzer.py`.

--- a/probe_tests/test_large_cert_bundle.py
+++ b/probe_tests/test_large_cert_bundle.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+test_large_cert_bundle.py
+
+Exercises the large-file background-parsing path in cert_analyzer
+(agent/analyzer.py: _count_pem_certs / _process_certificate_file_async):
+
+  1. Generates a PEM bundle with more certificates than the configured
+     large_file_cert_threshold (default 20) and opens it, firing the
+     fd_install kprobe in certificate-file-access.yaml.
+  2. Immediately opens a single-cert "canary" file, firing a second
+     fd_install event for a small file.
+  3. Because the bundle is parsed on a background thread, cert_analyzer's
+     Tetragon event-consumer loop should keep draining events and process
+     the canary promptly — its log line should not be delayed behind the
+     hundreds-of-certs bundle.
+
+Usage:
+  python3 test_large_cert_bundle.py                  # default: 30 certs
+  python3 test_large_cert_bundle.py --count 50
+  python3 test_large_cert_bundle.py --out-dir /etc/pki/tls/certs
+  python3 test_large_cert_bundle.py --keep            # don't delete generated files
+
+Requires:
+  - Tetragon running with tetragon-policies/certificate-file-access.yaml loaded
+  - cert_analyzer running
+  - --out-dir must be a path cert_analyzer can read. cert_analyzer runs with
+    ProtectHome=true and PrivateTmp=true, so /home and /tmp are not visible to
+    it — /etc/pki/tls/certs/ is in the service's ReadOnlyPaths and is the
+    default here. Writing there typically requires sudo.
+"""
+
+import argparse
+import configparser
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_OUT_DIR = '/etc/pki/tls/certs'
+DEFAULT_COUNT = 30
+CONFIG_FILE_PATH = '/etc/cert-analyzer/cert-analyzer.conf'
+_SETTLE_WAIT = 3  # seconds to let cert_analyzer log the canary before we exit
+
+
+def _effective_threshold() -> int:
+    """Best-effort read of the configured large_file_cert_threshold, for the reminder printed below."""
+    default = int(os.getenv('LARGE_FILE_CERT_THRESHOLD', '20'))
+    cp = configparser.ConfigParser()
+    try:
+        if os.access(CONFIG_FILE_PATH, os.R_OK):
+            cp.read(CONFIG_FILE_PATH)
+            if cp.has_option('certificates', 'large_file_cert_threshold'):
+                return int(cp.get('certificates', 'large_file_cert_threshold'))
+    except (OSError, configparser.Error, ValueError):
+        pass
+    return default
+
+
+def _make_self_signed_cert(common_name: str) -> bytes:
+    """Generate a throwaway EC self-signed cert (fast — avoids RSA keygen cost for bulk generation)."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(encoding=serialization.Encoding.PEM)
+
+
+def _write_file(path: str, data: bytes) -> None:
+    try:
+        with open(path, 'wb') as f:
+            f.write(data)
+        os.chmod(path, 0o644)
+    except PermissionError:
+        print(f'ERROR: permission denied writing {path}', file=sys.stderr)
+        print('Re-run with sudo, or pass --out-dir pointing to a location', file=sys.stderr)
+        print('cert_analyzer can read (see probe_tests/README.md).', file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Large multi-cert bundle background-parsing test for cert_analyzer',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--count', type=int, default=DEFAULT_COUNT,
+                        help=f'number of certs in the bundle (default: {DEFAULT_COUNT})')
+    parser.add_argument('--out-dir', default=DEFAULT_OUT_DIR,
+                        help=f'directory to write test files to (default: {DEFAULT_OUT_DIR})')
+    parser.add_argument('--keep', action='store_true',
+                        help='keep the generated bundle/canary files instead of printing an rm command')
+    args = parser.parse_args()
+
+    threshold = _effective_threshold()
+    if args.count <= threshold:
+        print(f'WARNING: --count {args.count} does not exceed the configured '
+              f'large_file_cert_threshold ({threshold}) — the bundle will be '
+              f'processed synchronously, not on a background thread.', file=sys.stderr)
+        print('Increase --count or lower large_file_cert_threshold in cert-analyzer.conf.\n',
+              file=sys.stderr)
+
+    bundle_path = os.path.join(args.out_dir, 'cert-analyzer-large-bundle-test.pem')
+    canary_path = os.path.join(args.out_dir, 'cert-analyzer-canary-test.pem')
+
+    print(f'=== large-cert-bundle background-parsing test ({args.count} certs) ===')
+    print()
+    print('Prerequisites:')
+    print('  Tetragon running with certificate-file-access.yaml policy loaded:')
+    print('    sudo tetra tracingpolicy add tetragon-policies/certificate-file-access.yaml')
+    print()
+    print(f'Configured large_file_cert_threshold: {threshold}')
+    print()
+
+    print(f'[test] Generating {args.count} self-signed certs -> {bundle_path}')
+    bundle_data = b''.join(
+        _make_self_signed_cert(f'bundle-test-{i}.example.com') for i in range(args.count)
+    )
+    _write_file(bundle_path, bundle_data)
+
+    print(f'[test] Generating 1 canary cert -> {canary_path}')
+    _write_file(canary_path, _make_self_signed_cert('canary.example.com'))
+    print()
+
+    print('[test] Opening the bundle — this fires fd_install and should be picked up')
+    print('       by cert_analyzer as a large file and handed to a background thread.')
+    t0 = time.time()
+    with open(bundle_path, 'rb') as f:
+        f.read()
+    print(f'[test]   bundle opened at t=+{time.time() - t0:.3f}s')
+
+    print('[test] Immediately opening the canary — proves the event-consumer thread')
+    print('       is still free to process new events while the bundle parses.')
+    with open(canary_path, 'rb') as f:
+        f.read()
+    print(f'[test]   canary opened at t=+{time.time() - t0:.3f}s')
+    print()
+
+    print(f'[test] Waiting {_SETTLE_WAIT}s for cert_analyzer to log both...')
+    time.sleep(_SETTLE_WAIT)
+    print()
+
+    print('=== Verify ===')
+    print()
+    print('journalctl -u cert-analyzer --since "-1 min" | grep -E "bundle-test|canary"')
+    print()
+    print('Expected (canary lines should NOT be delayed behind the bundle):')
+    print(f'  🔍 Detected certificate access: {bundle_path} ...')
+    print(f'  🔍 Detected certificate access: {canary_path} ...')
+    print(f'  ✅ OK: {canary_path} [cert #1] ... CN=canary.example.com ...')
+    print(f'  Found {args.count} certificate(s) in {bundle_path} (parsed in background — large file)')
+    print()
+    print('If the canary\'s "Detected certificate access" / "OK" lines appear within')
+    print('a second or two of being triggered — even though the bundle line above may')
+    print('land later — the background thread is doing its job and the event loop was')
+    print('not blocked by the large file.')
+    print()
+    print(f'curl -s http://localhost:9090/metrics | grep -c \'CN="bundle-test\'')
+    print(f'# Expect {args.count} once the background parse finishes')
+    print()
+
+    if not args.keep:
+        rm_prefix = 'sudo ' if not os.access(args.out_dir, os.W_OK) else ''
+        print('=== Cleanup ===')
+        print(f'{rm_prefix}rm {bundle_path} {canary_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/probe_tests/test_large_cert_bundle.py
+++ b/probe_tests/test_large_cert_bundle.py
@@ -115,8 +115,13 @@ def main() -> None:
         print('Increase --count or lower large_file_cert_threshold in cert-analyzer.conf.\n',
               file=sys.stderr)
 
-    bundle_path = os.path.join(args.out_dir, 'cert-analyzer-large-bundle-test.pem')
-    canary_path = os.path.join(args.out_dir, 'cert-analyzer-canary-test.pem')
+    # A unique suffix per run is required: cert_analyzer's known_certs cache is
+    # keyed by path only (agent/analyzer.py process_event's "already known" check
+    # is `key.startswith(cert_path + ":")`), so re-using the same path across runs
+    # would hit that fast path and skip re-analysis of the new file content.
+    run_id = f'{os.getpid()}-{int(time.time())}'
+    bundle_path = os.path.join(args.out_dir, f'cert-analyzer-large-bundle-test-{run_id}.pem')
+    canary_path = os.path.join(args.out_dir, f'cert-analyzer-canary-test-{run_id}.pem')
 
     print(f'=== large-cert-bundle background-parsing test ({args.count} certs) ===')
     print()

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -312,6 +312,65 @@ class TestLargeFileBackgroundProcessing:
         assert mock_publisher.publish.call_count == 0
         assert bundle_path not in analyzer.known_certs
 
+    def test_bad_cert_in_finish_loop_does_not_abort_remaining_certs(self, analyzer, temp_dir):
+        """One cert raising in _finish_new_certificate_file must not drop the rest of the file."""
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "flaky_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        real_update = analyzer.metrics.update_certificate_metrics
+
+        def flaky_update(cert_info):
+            if cert_info.cert_index == 2:
+                raise ValueError("simulated bad label value")
+            return real_update(cert_info)
+
+        analyzer.metrics.update_certificate_metrics = flaky_update
+
+        errors_before = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='finish_error'
+        )._value.get()
+
+        analyzer.process_event(self._make_event(bundle_path))
+
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        # certs 0,1,3,4 must have landed in the cache; only cert 2 was lost.
+        assert len(matching) == 4
+
+        errors_after = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='finish_error'
+        )._value.get()
+        assert errors_after == errors_before + 1
+
+    def test_large_file_worker_exception_is_logged_and_counted(self, analyzer, temp_dir, caplog):
+        """An exception inside the background worker must hit the same error-logging/metrics path as a synchronous event."""
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "exploding_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated parse failure")
+
+        analyzer.analyze_certificate = boom
+
+        errors_before = analyzer.metrics.cert_events_total.labels(
+            event_type='processing', status='error'
+        )._value.get()
+
+        with caplog.at_level(logging.ERROR, logger="agent.analyzer"):
+            analyzer.process_event(self._make_event(bundle_path))
+            self._wait_for_background_processing(analyzer, bundle_path)
+
+        errors_after = analyzer.metrics.cert_events_total.labels(
+            event_type='processing', status='error'
+        )._value.get()
+        assert errors_after == errors_before + 1
+        assert any("Error processing large certificate file" in r.message
+                   for r in caplog.records)
+
 
 class TestCertificateAnalysis:
     """Test certificate analysis and information extraction"""
@@ -3803,7 +3862,57 @@ class TestKafkaPublisher:
         publisher = KafkaPublisher.__new__(KafkaPublisher)
         publisher._producer = None
         publisher._topic = 't'
+        publisher._lock = threading.RLock()
         publisher.close()   # must not raise
+
+    # ── thread-safety ────────────────────────────────────────────────────────
+
+    def test_concurrent_publish_connects_producer_once(self, monkeypatch, sample_cert_info):
+        """
+        Many threads calling publish() while the producer is absent must only
+        construct one KafkaProducer — the self._lock around _connect()/publish()
+        serializes the check-then-connect so concurrent callers (main thread,
+        periodic_scan thread, and any number of large-file background workers)
+        can't race into creating/discarding multiple producers.
+        """
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        connect_count = {'n': 0}
+
+        class SlowFakeProducer:
+            def __init__(self, **kwargs):
+                # Widen the race window — releases the GIL, giving other
+                # threads a chance to interleave if the lock isn't held.
+                time.sleep(0.02)
+                connect_count['n'] += 1
+
+            def send(self, *args, **kwargs):
+                future = MagicMock()
+                future.add_errback = lambda cb: None
+                return future
+
+            def close(self, timeout=None):
+                pass
+
+        with patch('agent.kafka.KafkaProducer', SlowFakeProducer):
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            connect_count['n'] = 0  # ignore the constructor's own initial connect
+            publisher._producer = None  # force every thread to see "needs reconnect"
+            publisher._reconnect_cooldown = 0
+
+            threads = [
+                threading.Thread(target=publisher.publish, args=(sample_cert_info,))
+                for _ in range(20)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+            assert connect_count['n'] == 1
 
     # ── integration with CertificateAnalyzer ─────────────────────────────────
 

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -221,8 +221,96 @@ class TestMultiCertificateParsing:
             f.write("")
         
         certs = analyzer.parse_certificates(bundle_path)
-        
+
         assert len(certs) == 0
+
+
+class TestLargeFileBackgroundProcessing:
+    """Files with more PEM certs than large_file_cert_threshold are parsed off-thread"""
+
+    @staticmethod
+    def _make_event(path):
+        from unittest.mock import MagicMock
+        mock_event = MagicMock()
+        mock_event.HasField.side_effect = lambda f: f == 'process_kprobe'
+        mock_kprobe = MagicMock()
+        mock_kprobe.process.binary = '/usr/bin/cat'
+        mock_kprobe.process.pid.value = 4242
+        mock_kprobe.process.HasField.return_value = False
+        mock_kprobe.HasField.return_value = False
+        mock_arg = MagicMock()
+        mock_arg.HasField.side_effect = lambda f: f == 'file_arg'
+        mock_arg.file_arg.path = path
+        mock_kprobe.args = [mock_arg]
+        mock_event.process_kprobe = mock_kprobe
+        mock_event.node_name = ''
+        return mock_event
+
+    def _wait_for_background_processing(self, analyzer, path, timeout=5.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if path not in analyzer._large_file_in_flight:
+                return
+            time.sleep(0.01)
+        pytest.fail("background certificate parsing did not finish in time")
+
+    def test_count_pem_certs(self, analyzer, temp_dir):
+        """_count_pem_certs counts BEGIN markers without parsing"""
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        assert analyzer._count_pem_certs(bundle_path) == 5
+
+    def test_small_file_processed_synchronously(self, analyzer, temp_dir):
+        """A file at or below the threshold is processed inline, no background thread"""
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(3)]
+        bundle_path = os.path.join(temp_dir, "small_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        analyzer.process_event(self._make_event(bundle_path))
+
+        # No wait needed — must already be populated when process_event returns
+        assert bundle_path not in analyzer._large_file_in_flight
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        assert len(matching) == 3
+
+    def test_large_file_processed_in_background(self, analyzer, temp_dir):
+        """A file over the threshold is handed to a worker thread and still lands in known_certs"""
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "large_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        analyzer.process_event(self._make_event(bundle_path))
+
+        self._wait_for_background_processing(analyzer, bundle_path)
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        assert len(matching) == 5
+
+    def test_duplicate_events_for_large_file_in_flight_are_deduped(self, analyzer, temp_dir):
+        """A second event for the same large file while the first is still parsing is skipped"""
+        from unittest.mock import MagicMock
+        analyzer._large_file_cert_threshold = 3
+        mock_publisher = MagicMock()
+        analyzer.kafka_publisher = mock_publisher
+
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "dup_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        # Simulate the in-flight worker already having claimed this path.
+        analyzer._large_file_in_flight.add(bundle_path)
+        analyzer.process_event(self._make_event(bundle_path))
+
+        # Nothing should have been published — the event was skipped, not processed.
+        assert mock_publisher.publish.call_count == 0
+        assert bundle_path not in analyzer.known_certs
 
 
 class TestCertificateAnalysis:


### PR DESCRIPTION
A system CA trust bundle (100+ certs) parsed synchronously blocks the single thread consuming the Tetragon event stream for the whole burst. Files with more PEM certs than large_file_cert_threshold (default 20) are now handed to a background worker so other events keep flowing; _large_file_in_flight de-dupes repeat events for the same in-progress file. Verified live against Tetragon + cert-analyzer with a new probe test (probe_tests/test_large_cert_bundle.py): a canary cert opened just after a 30-cert bundle finishes processing before the bundle does.