### PR TITLE
Cap per-file/per-event metric fan-out for large cert bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ sudo systemctl enable --now cert-analyzer
 | `host_prefix` | _(empty)_ | Path prefix prepended to certificate paths from Tetragon events — leave empty for bare metal, set to `/host` for Kubernetes |
 | `demo_mode` | `false` | Log certificate details (subject, issuer, serial, validity, SANs) at INFO level instead of DEBUG — for demos only, leave false in production |
 | `large_file_cert_threshold` | `20` | Files with more PEM certs than this (e.g. a system CA bundle) are parsed on a background thread instead of the Tetragon event-consumer thread |
+| `large_file_metrics_cap` | `300` | Caps how many certs in a single bundle file get full Prometheus metrics/logging, independent of `large_file_cert_threshold` above. Certs beyond the cap are still cached internally and still published to Kafka if enabled, just not tracked as individual Prometheus series. Default comfortably covers a real system CA trust bundle (~130-150 certs) |
 
 **[passwords]**
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -151,6 +151,18 @@ class CertificateAnalyzer:
         # letting two workers get spawned for one file. Needs its own lock.
         self._large_file_in_flight: Set[str] = set()
         self._large_file_in_flight_lock = threading.Lock()
+        # Paths below _large_file_cert_threshold (so parsed synchronously rather
+        # than via _process_certificate_file_async) that are currently being
+        # analyzed for the first time. process_event() runs on a single thread
+        # so it can't race against itself, but periodic_scan() runs on its own
+        # thread and re-walks scan_paths independently — without this guard, a
+        # file first seen at almost the same moment by both a Tetragon event and
+        # a periodic scan tick (most likely right after agent startup) would get
+        # parsed and _finish_new_certificate_file'd twice, double-publishing it
+        # to Kafka as two separate "new discovery" events. Same check-then-add
+        # race shape as _probe_in_flight/_large_file_in_flight above.
+        self._new_file_in_flight: Set[str] = set()
+        self._new_file_in_flight_lock = threading.Lock()
         self.last_event_time: float = 0.0
 
     def _index_known_cert(self, key: str, value) -> None:
@@ -1713,15 +1725,27 @@ class CertificateAnalyzer:
             )
             return
 
-        # Analyze new certificate file (may contain multiple certs)
-        cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
-        if not cert_infos:
-            return
+        # Analyze new certificate file (may contain multiple certs). Guarded by
+        # _new_file_in_flight so a periodic_scan tick landing on this same
+        # never-before-seen path at the same moment doesn't double-parse and
+        # double-publish it — see the comment on _new_file_in_flight in __init__.
+        with self._new_file_in_flight_lock:
+            if cert_path in self._new_file_in_flight:
+                logger.debug(f"New-file parse for {cert_path} already in flight, skipping duplicate")
+                return
+            self._new_file_in_flight.add(cert_path)
+        try:
+            cert_infos = self.analyze_certificate(cert_path, process_name, pid, namespace)
+            if not cert_infos:
+                return
 
-        logger.info(f"Found {len(cert_infos)} certificate(s) in {cert_path}")
-        self._finish_new_certificate_file(
-            cert_infos, tetragon_pod, parent_process, parent_pid, event.node_name
-        )
+            logger.info(f"Found {len(cert_infos)} certificate(s) in {cert_path}")
+            self._finish_new_certificate_file(
+                cert_infos, tetragon_pod, parent_process, parent_pid, event.node_name
+            )
+        finally:
+            with self._new_file_in_flight_lock:
+                self._new_file_in_flight.discard(cert_path)
 
     def get_runtime_tetragon_version(self, stub) -> str:
         """
@@ -2056,14 +2080,25 @@ class CertificateAnalyzer:
                         )
                         continue
 
-                    cert_infos = self.analyze_certificate(cert_path, "periodic_scan", 0)
-                    if not cert_infos:
-                        continue
-                    self._finish_new_certificate_file(
-                        cert_infos, tetragon_pod=None, parent_process="",
-                        parent_pid=0, node_name="",
-                    )
-                    cert_count += len(cert_infos)
+                    # Guarded by _new_file_in_flight so a Tetragon event landing on
+                    # this same never-before-seen path at the same moment doesn't
+                    # double-parse and double-publish it — see the comment on
+                    # _new_file_in_flight in __init__.
+                    with self._new_file_in_flight_lock:
+                        if cert_path in self._new_file_in_flight:
+                            continue
+                        self._new_file_in_flight.add(cert_path)
+                    try:
+                        cert_infos = self.analyze_certificate(cert_path, "periodic_scan", 0)
+                        if cert_infos:
+                            self._finish_new_certificate_file(
+                                cert_infos, tetragon_pod=None, parent_process="",
+                                parent_pid=0, node_name="",
+                            )
+                            cert_count += len(cert_infos)
+                    finally:
+                        with self._new_file_in_flight_lock:
+                            self._new_file_in_flight.discard(cert_path)
 
                 logger.info(f"Scanned {cert_count} new certificate(s) in {base_path}")
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -137,8 +137,14 @@ class CertificateAnalyzer:
         # Paths whose large multi-cert file (see _count_pem_certs) is currently
         # being parsed on a background thread — de-dupes repeat Tetragon events
         # for the same path that arrive before the worker populates known_certs.
-        # GIL-atomic set ops, same reasoning as _probe_in_flight above.
+        # Individual set ops (in/add/discard) are GIL-atomic, but the check-then-add
+        # in _process_certificate_file_async is a *pair* of ops, and its discard()
+        # runs on a different thread (the background worker) than its check+add
+        # (the main event-consumer thread) — the GIL can switch between the check
+        # and the add, racing against a same-path discard() completing in between,
+        # letting two workers get spawned for one file. Needs its own lock.
         self._large_file_in_flight: Set[str] = set()
+        self._large_file_in_flight_lock = threading.Lock()
         self.last_event_time: float = 0.0
 
     def _index_known_cert(self, key: str, value) -> None:
@@ -760,13 +766,14 @@ class CertificateAnalyzer:
         de-dupes repeat Tetragon events for the same path that arrive before the
         worker finishes and populates known_certs.
         """
-        if cert_path in self._large_file_in_flight:
-            logger.debug(
-                f"Large certificate file {cert_path} already being processed "
-                f"in the background — skipping duplicate event"
-            )
-            return
-        self._large_file_in_flight.add(cert_path)
+        with self._large_file_in_flight_lock:
+            if cert_path in self._large_file_in_flight:
+                logger.debug(
+                    f"Large certificate file {cert_path} already being processed "
+                    f"in the background — skipping duplicate event"
+                )
+                return
+            self._large_file_in_flight.add(cert_path)
 
         def _worker():
             try:
@@ -790,7 +797,8 @@ class CertificateAnalyzer:
                         event_type='processing', status='error'
                     ).inc()
             finally:
-                self._large_file_in_flight.discard(cert_path)
+                with self._large_file_in_flight_lock:
+                    self._large_file_in_flight.discard(cert_path)
 
         threading.Thread(
             target=_worker, daemon=True, name=f'cert-parse-{Path(cert_path).name}'

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -87,7 +87,8 @@ class CertificateAnalyzer:
                  port_probe_timeout: float = 5.0,
                  port_probe_connect_delay: float = 2.0,
                  tls_outbound_ports: Optional[frozenset] = None,
-                 large_file_cert_threshold: int = 20):
+                 large_file_cert_threshold: int = 20,
+                 large_file_metrics_cap: int = 300):
         self.tetragon_address = tetragon_address
         self.alert_threshold_days = alert_threshold_days
         self.filter_self_events = filter_self_events
@@ -103,6 +104,7 @@ class CertificateAnalyzer:
         self._port_probe_connect_delay = port_probe_connect_delay
         self._tls_outbound_ports = tls_outbound_ports if tls_outbound_ports is not None else self.TLS_OUTBOUND_PORTS
         self._large_file_cert_threshold = large_file_cert_threshold
+        self._large_file_metrics_cap = large_file_metrics_cap
         self.metrics = PrometheusMetrics(node_name=_NODE_NAME)
         # cert_path -> set of known_certs keys for that path. Lets process_event's
         # "already known" check do an O(1) dict lookup instead of scanning every
@@ -681,12 +683,15 @@ class CertificateAnalyzer:
         # certs, so tracking every one individually turns a single file event
         # into thousands of new series in one burst — this is what drove
         # cert-analyzer's cardinality/memory spike and hang on 2026-07-03.
-        # Beyond the large-file threshold (same one that routes parsing to a
-        # background thread), only the first `metrics_cap` certs get full
+        # Beyond large_file_metrics_cap (deliberately separate from
+        # _large_file_cert_threshold, which only controls background-thread
+        # parsing — conflating the two would mean raising the metrics cap to
+        # cover a realistic bundle also disables the background-thread path
+        # for that same bundle), only the first `metrics_cap` certs get full
         # per-cert metrics/logging; the rest are still cached — so known-file
         # lookups and cache size stay accurate — but summarized in one log
         # line instead of fanning out more series.
-        metrics_cap = self._large_file_cert_threshold
+        metrics_cap = self._large_file_metrics_cap
         is_bundle = len(cert_infos) > metrics_cap
         skipped_self_signed = 0
         skipped_fips_noncompliant = 0
@@ -1648,8 +1653,8 @@ class CertificateAnalyzer:
             # an M-cert bundle is O(N*M) series, which is what actually drove
             # the 2026-07-03 incident (more so than the initial-parse fan-out
             # capped in _finish_new_certificate_file). Cap per-event tracking
-            # to metrics_cap certs, same threshold as the initial-parse cap.
-            metrics_cap = self._large_file_cert_threshold
+            # to large_file_metrics_cap certs, same cap as the initial-parse cap.
+            metrics_cap = self._large_file_metrics_cap
             is_bundle = len(matching_keys) > metrics_cap
             for i, key in enumerate(matching_keys):
                 cert_info = self.known_certs.get(key)

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -2035,21 +2035,37 @@ class CertificateAnalyzer:
 
                 cert_count = 0
                 for cert_file in path_obj.rglob('*'):
-                    if cert_file.is_file() and self.is_cert_path(str(cert_file)):
-                        cert_infos = self.analyze_certificate(
-                            str(cert_file),
-                            "periodic_scan",
-                            0
-                        )
-                        for cert_info in cert_infos:
-                            self.metrics.update_certificate_metrics(cert_info)
-                            self.log_certificate_status(cert_info)
-                            self.known_certs[cert_info.unique_key] = cert_info
-                            if self.kafka_publisher is not None:
-                                self.kafka_publisher.publish(cert_info)
-                            cert_count += 1
+                    if not cert_file.is_file() or not self.is_cert_path(str(cert_file)):
+                        continue
 
-                logger.info(f"Scanned {cert_count} certificates in {base_path}")
+                    cert_path = str(cert_file)
+                    # Skip files already parsed via a Tetragon event (or an earlier
+                    # scan) — re-parsing every known file on every scan_interval
+                    # is wasted crypto work, and re-running _finish_new_certificate_file
+                    # would re-publish "new discovery" Kafka messages for certs that
+                    # aren't new. Genuinely new files fall through to the same
+                    # threshold-routed / metrics-capped path Tetragon events use.
+                    with self._known_paths_lock:
+                        if cert_path in self._known_paths:
+                            continue
+
+                    if self._count_pem_certs(cert_path) > self._large_file_cert_threshold:
+                        self._process_certificate_file_async(
+                            cert_path, "periodic_scan", 0, "",
+                            None, "", 0, "",
+                        )
+                        continue
+
+                    cert_infos = self.analyze_certificate(cert_path, "periodic_scan", 0)
+                    if not cert_infos:
+                        continue
+                    self._finish_new_certificate_file(
+                        cert_infos, tetragon_pod=None, parent_process="",
+                        parent_pid=0, node_name="",
+                    )
+                    cert_count += len(cert_infos)
+
+                logger.info(f"Scanned {cert_count} new certificate(s) in {base_path}")
 
             except Exception as e:
                 logger.error(f"Error scanning {base_path}: {e}")

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -131,9 +131,15 @@ class CertificateAnalyzer:
         # _probe_in_flight: "host:port" strings currently being probed — prevents
         #   duplicate concurrent probes when several events for a new endpoint
         #   arrive before the first probe completes (e.g. connection pooling).
-        # CPython set operations (in / add / discard) are GIL-atomic; no lock needed.
+        # Individual set ops (in/add/discard) are GIL-atomic, but the check-then-add
+        # at each call site is a *pair* of ops, and its discard() runs on a different
+        # thread (the probe worker) than its check+add (the event-consumer thread) —
+        # the GIL can switch between the check and the add, racing against a same-key
+        # discard() completing in between, letting two probes get spawned for one
+        # endpoint. Needs its own lock.
         self._probed_endpoints: LRUCache = LRUCache()
         self._probe_in_flight: Set[str] = set()
+        self._probe_in_flight_lock = threading.Lock()
         # Paths whose large multi-cert file (see _count_pem_certs) is currently
         # being parsed on a background thread — de-dupes repeat Tetragon events
         # for the same path that arrive before the worker populates known_certs.
@@ -1506,10 +1512,11 @@ class CertificateAnalyzer:
         self.metrics.last_event_timestamp.labels(node_name=self.metrics._node_name).set(self.last_event_time)
 
         endpoint_key = f'{host}:{port}'
-        if endpoint_key in self._probed_endpoints or endpoint_key in self._probe_in_flight:
-            logger.debug(f"TLS bind probe: {endpoint_key} already probed or in flight, skipping")
-            return
-        self._probe_in_flight.add(endpoint_key)
+        with self._probe_in_flight_lock:
+            if endpoint_key in self._probed_endpoints or endpoint_key in self._probe_in_flight:
+                logger.debug(f"TLS bind probe: {endpoint_key} already probed or in flight, skipping")
+                return
+            self._probe_in_flight.add(endpoint_key)
 
         def _probe():
             if delay:
@@ -1519,7 +1526,8 @@ class CertificateAnalyzer:
             except Exception as e:
                 logger.debug(f"TLS probe thread error {host}:{port}: {e}")
             finally:
-                self._probe_in_flight.discard(endpoint_key)
+                with self._probe_in_flight_lock:
+                    self._probe_in_flight.discard(endpoint_key)
                 self._probed_endpoints.add(endpoint_key)
 
         t = threading.Thread(target=_probe, daemon=True, name=f'tls-probe-{host}-{port}')
@@ -1560,10 +1568,11 @@ class CertificateAnalyzer:
         self.metrics.last_event_timestamp.labels(node_name=self.metrics._node_name).set(self.last_event_time)
 
         endpoint_key = f'{daddr}:{dport}'
-        if endpoint_key in self._probed_endpoints or endpoint_key in self._probe_in_flight:
-            logger.debug(f"TLS connect probe: {endpoint_key} already probed or in flight, skipping")
-            return
-        self._probe_in_flight.add(endpoint_key)
+        with self._probe_in_flight_lock:
+            if endpoint_key in self._probed_endpoints or endpoint_key in self._probe_in_flight:
+                logger.debug(f"TLS connect probe: {endpoint_key} already probed or in flight, skipping")
+                return
+            self._probe_in_flight.add(endpoint_key)
 
         def _probe():
             try:
@@ -1571,7 +1580,8 @@ class CertificateAnalyzer:
             except Exception as e:
                 logger.debug(f"TLS outbound probe thread error {daddr}:{dport}: {e}")
             finally:
-                self._probe_in_flight.discard(endpoint_key)
+                with self._probe_in_flight_lock:
+                    self._probe_in_flight.discard(endpoint_key)
                 self._probed_endpoints.add(endpoint_key)
 
         t = threading.Thread(target=_probe, daemon=True, name=f'tls-probe-out-{daddr}-{dport}')

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -2043,6 +2043,14 @@ class CertificateAnalyzer:
             logger.info("Shutting down...")
             self.metrics.analyzer_healthy.labels(node_name=self.metrics._node_name).set(0)
             self.metrics.tetragon_connected.labels(node_name=self.metrics._node_name).set(0)
+            # Re-raise so callers (agent.config.main()) get a chance to run their
+            # own shutdown handling -- flushing/closing the Kafka producer and
+            # stopping the health server. Swallowing it here previously made
+            # main()'s except KeyboardInterrupt block dead code: this method
+            # returned normally, so main() fell off the end of its try block
+            # without ever closing the Kafka producer, risking loss of
+            # unflushed in-flight messages on a graceful shutdown signal.
+            raise
         finally:
             channel.close()
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -676,15 +676,37 @@ class CertificateAnalyzer:
         node_name: str,
     ) -> None:
         """Apply pod/event context, update metrics, log, cache, and publish for a freshly-parsed file."""
-        for cert_info in cert_infos:
+        # update_certificate_metrics() writes ~10 Prometheus series per cert.
+        # A bundle file (e.g. a system CA trust store) can hold hundreds of
+        # certs, so tracking every one individually turns a single file event
+        # into thousands of new series in one burst — this is what drove
+        # cert-analyzer's cardinality/memory spike and hang on 2026-07-03.
+        # Beyond the large-file threshold (same one that routes parsing to a
+        # background thread), only the first `metrics_cap` certs get full
+        # per-cert metrics/logging; the rest are still cached — so known-file
+        # lookups and cache size stay accurate — but summarized in one log
+        # line instead of fanning out more series.
+        metrics_cap = self._large_file_cert_threshold
+        is_bundle = len(cert_infos) > metrics_cap
+        skipped_self_signed = 0
+        skipped_fips_noncompliant = 0
+
+        for i, cert_info in enumerate(cert_infos):
             try:
                 self._apply_pod_context(cert_info, tetragon_pod)
                 cert_info.node_name      = node_name
                 cert_info.parent_process = parent_process
                 cert_info.parent_pid     = parent_pid
 
-                self.metrics.update_certificate_metrics(cert_info)
-                self.log_certificate_status(cert_info)
+                if not is_bundle or i < metrics_cap:
+                    self.metrics.update_certificate_metrics(cert_info)
+                    self.log_certificate_status(cert_info)
+                else:
+                    if cert_info.is_self_signed:
+                        skipped_self_signed += 1
+                    if cert_info.fips_violations:
+                        skipped_fips_noncompliant += 1
+
                 self.known_certs[cert_info.unique_key] = cert_info
 
                 if self.kafka_publisher is not None:
@@ -700,6 +722,16 @@ class CertificateAnalyzer:
                     event_type='processing', status='error'
                 ).inc()
                 self.metrics.cert_analysis_errors.labels(error_type='finish_error').inc()
+
+        if is_bundle:
+            remaining = len(cert_infos) - metrics_cap
+            logger.info(
+                f"{cert_infos[0].path}: bundle of {len(cert_infos)} certs — "
+                f"tracked metrics/logging for the first {metrics_cap}; "
+                f"{remaining} more cached but not individually tracked "
+                f"({skipped_self_signed} self-signed, {skipped_fips_noncompliant} "
+                f"FIPS non-compliant among them, not individually alertable)"
+            )
 
         self._update_cache_metrics()
 
@@ -1609,7 +1641,17 @@ class CertificateAnalyzer:
             matching_keys = list(self._known_paths.get(cert_path, ()))
         if matching_keys:
             logger.info(f"Re-detected known certificate file: {cert_path}")
-            for key in matching_keys:
+            # A bundle file re-accessed by many distinct processes (e.g. the
+            # system CA bundle opened by dozens of unrelated binaries) would
+            # otherwise mint a cert_process_info series per (cached cert,
+            # process) pair on every single event -- N processes re-accessing
+            # an M-cert bundle is O(N*M) series, which is what actually drove
+            # the 2026-07-03 incident (more so than the initial-parse fan-out
+            # capped in _finish_new_certificate_file). Cap per-event tracking
+            # to metrics_cap certs, same threshold as the initial-parse cap.
+            metrics_cap = self._large_file_cert_threshold
+            is_bundle = len(matching_keys) > metrics_cap
+            for i, key in enumerate(matching_keys):
                 cert_info = self.known_certs.get(key)
                 if cert_info is None:  # evicted between snapshot and access
                     continue
@@ -1618,6 +1660,8 @@ class CertificateAnalyzer:
                     self._apply_pod_context(cert_info, tetragon_pod)
                 if event.node_name:
                     cert_info.node_name = event.node_name
+                if is_bundle and i >= metrics_cap:
+                    continue
                 # The cert's own properties (expiry, FIPS status, etc.) haven't
                 # changed since the last full update — only the access recency
                 # and the (possibly new) accessing process need refreshing here,
@@ -1626,6 +1670,14 @@ class CertificateAnalyzer:
                 self.log_certificate_status(cert_info, summary_only=True)
                 self.metrics.update_last_accessed(cert_info)
                 self.metrics.record_cert_process_access(cert_info, process_name, parent_process)
+
+            if is_bundle:
+                logger.info(
+                    f"{cert_path}: re-access by {process_name} covers "
+                    f"{len(matching_keys)} cached certs — tracked process-access "
+                    f"for the first {metrics_cap}; {len(matching_keys) - metrics_cap} "
+                    f"more skipped to bound cert_process_info cardinality"
+                )
             return
 
         # Large multi-cert files (e.g. system CA bundles with hundreds of certs)

--- a/agent/config.py
+++ b/agent/config.py
@@ -108,6 +108,12 @@ def main():
     demo_mode               = cfg(cp, 'certificates', 'demo_mode',               'DEMO_MODE',                    'false').lower() == 'true'
     fips_compliance_enabled = cfg(cp, 'certificates', 'fips_compliance_enabled', 'FIPS_COMPLIANCE_ENABLED',      'true').lower() != 'false'
     large_file_cert_threshold = int(cfg(cp, 'certificates', 'large_file_cert_threshold', 'LARGE_FILE_CERT_THRESHOLD', '20'))
+    # Deliberately separate from large_file_cert_threshold above: that one only
+    # decides whether a file's parsing is deferred to a background thread, this
+    # one caps how many certs in a bundle get full Prometheus metrics/logging.
+    # Conflating them meant raising the metrics cap to cover a realistic CA
+    # bundle (~130-150 certs) also disabled background-thread parsing for it.
+    large_file_metrics_cap = int(cfg(cp, 'certificates', 'large_file_metrics_cap', 'LARGE_FILE_METRICS_CAP', '300'))
 
     event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
 
@@ -148,6 +154,7 @@ def main():
     logger.info(f"Cert checksums:    {'enabled' if checksum_enabled else 'disabled'}")
     logger.info(f"FIPS checking:     {'enabled' if fips_compliance_enabled else 'disabled'}")
     logger.info(f"Large file threshold: >{large_file_cert_threshold} certs parsed in background")
+    logger.info(f"Large file metrics cap: {large_file_metrics_cap} certs get full Prometheus tracking per bundle")
     logger.info(f"Metrics port:      {metrics_port}")
     logger.info(f"Health port:       {health_port}")
     logger.info(f"Alert threshold:   {alert_threshold} days")
@@ -206,7 +213,8 @@ def main():
                                    port_probe_timeout=port_probe_timeout,
                                    port_probe_connect_delay=port_probe_connect_delay,
                                    tls_outbound_ports=tls_outbound_ports,
-                                   large_file_cert_threshold=large_file_cert_threshold)
+                                   large_file_cert_threshold=large_file_cert_threshold,
+                                   large_file_metrics_cap=large_file_metrics_cap)
 
     health = HealthServer(
         analyzer=analyzer,

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -51,7 +51,9 @@ class KafkaPublisher:
     self._producer and self._last_connect_attempt (including the async
     _on_error errback, which kafka-python invokes from its own I/O thread) so
     reconnects can't race and a producer can't be closed out from under a
-    concurrent send().
+    concurrent send(). _on_error also carries the specific producer instance
+    its send() was issued from, so a delayed errback for a producer that's
+    since been superseded by a reconnect can't nullify the new one.
 
     Message schema (all fields present, empty string when not applicable):
     {
@@ -242,21 +244,30 @@ class KafkaPublisher:
             if self._producer is None:
                 if not self._connect():
                     return
+            producer = self._producer
 
             try:
-                self._producer.send(
+                producer.send(
                     self._topic,
                     key=key,
                     value=message,
-                ).add_errback(self._on_error)
+                ).add_errback(lambda exc, _producer=producer: self._on_error(_producer, exc))
             except Exception as e:
                 logger.warning(f"Kafka publish failed for {cert_info.path}: {e}")
                 # Nullify the producer so the next publish attempt triggers reconnect
-                self._producer = None
+                if self._producer is producer:
+                    self._producer = None
 
-    def _on_error(self, exc: Exception) -> None:
-        # kafka-python invokes errbacks from its own internal I/O thread, so
-        # this can run concurrently with publish()/close() on other threads.
+    def _on_error(self, producer, exc: Exception) -> None:
+        # kafka-python invokes errbacks from its own internal I/O thread, so this
+        # can run concurrently with publish()/close() on other threads, and can
+        # fire long after the send() call that registered it -- kafka-python
+        # retries internally before giving up, so the callback for an old send()
+        # can land well after a later reconnect has already installed a new,
+        # healthy producer. `producer` is the specific instance this failure
+        # came from (captured at send() time); only nullify self._producer if
+        # it's still that same instance, so a stale error from an
+        # already-superseded producer can't tear down a newer one.
         logger.warning(f"Kafka delivery error: {exc}")
         _kafka_delivery_errors.labels(node_name=_NODE_NAME).inc()
         # Nullify the producer so the next publish attempt triggers reconnect.
@@ -264,7 +275,8 @@ class KafkaPublisher:
         # auth failure, topic deleted) would leave the producer in a state where
         # send() appears to succeed but nothing is ever delivered.
         with self._lock:
-            self._producer = None
+            if self._producer is producer:
+                self._producer = None
 
     def close(self) -> None:
         """Flush pending messages and close the producer cleanly."""

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -97,6 +97,17 @@ fips_compliance_enabled = true
 # other events.
 large_file_cert_threshold = 20
 
+# Caps how many certs in a single bundle file get full Prometheus metrics
+# and per-cert logging. Independent of large_file_cert_threshold above —
+# that one only controls background-thread parsing; this one bounds
+# Prometheus cardinality/memory. Certs beyond the cap are still cached
+# internally (known-file lookups stay correct) and still published to
+# Kafka if enabled, just not individually tracked in Prometheus. Default
+# of 300 comfortably covers a real system CA trust bundle (~130-150
+# certs) without truncation. Raise with care: each additional cert here
+# costs ~10 Prometheus series.
+large_file_metrics_cap = 300
+
 
 [passwords]
 # Passwords for encrypted keystores. These are tried before the

--- a/cert-analyzer.spec
+++ b/cert-analyzer.spec
@@ -250,6 +250,38 @@ if [ -f "$_CONF" ] && grep -q '^\[port_probe\]' "$_CONF" 2>/dev/null \
     && printf '#tls_outbound_ports = 443,636,5671,5672,6380,8443,8883,9093,9094\n' >> "$_CONF" \
     || echo "WARNING: failed to append tls_outbound_ports to $_CONF" >&2
 fi
+# Hosts upgraded from a release predating large_file_metrics_cap: insert it
+# into the existing [certificates] section, right after
+# large_file_cert_threshold (which every prior release has). Unlike the
+# [port_probe] cases above this can't be a plain end-of-file append -- that
+# would land the key after whatever section happens to be last in the
+# operator's file instead of under [certificates], where the loader expects
+# it (configparser reads options by section, not by file position).
+if [ -f "$_CONF" ] && grep -q '^large_file_cert_threshold[ \t]*=' "$_CONF" 2>/dev/null \
+        && ! grep -q '^large_file_metrics_cap[ \t]*=' "$_CONF" 2>/dev/null; then
+    awk '
+    /^large_file_cert_threshold[ \t]*=/ {
+        print
+        print ""
+        print "# Caps how many certs in a single bundle file get full Prometheus metrics"
+        print "# and per-cert logging. Independent of large_file_cert_threshold above —"
+        print "# that one only controls background-thread parsing; this one bounds"
+        print "# Prometheus cardinality/memory. Certs beyond the cap are still cached"
+        print "# internally (known-file lookups stay correct) and still published to"
+        print "# Kafka if enabled, just not individually tracked in Prometheus. Default"
+        print "# of 300 comfortably covers a real system CA trust bundle (~130-150"
+        print "# certs) without truncation. Raise with care: each additional cert here"
+        print "# costs ~10 Prometheus series."
+        print "large_file_metrics_cap = 300"
+        next
+    }
+    { print }
+    ' "$_CONF" > "$_CONF.new" \
+    && mv "$_CONF.new" "$_CONF" \
+    && chown root:%{ana_group} "$_CONF" \
+    && chmod 0640 "$_CONF" \
+    || echo "WARNING: failed to insert large_file_metrics_cap into $_CONF" >&2
+fi
 unset _CONF
 
 # Reload systemd to pick up the Tetragon drop-in

--- a/extras/DASHBOARDS.md
+++ b/extras/DASHBOARDS.md
@@ -145,9 +145,11 @@ Dashboards → Import → Upload `extras/examples/grafana-dashboard.json` → se
 | Section | Panels |
 |---|---|
 | **Overview** | Analyzer health, total certificates, expired, expiring ≤7/30 days, FIPS non-compliant, self-signed, last event age |
-| **Certificate Inventory** | Filterable/sortable table of all certificates with colour-coded expiry; expiry distribution donut; soonest-expiring bar gauge |
+| **Certificate Inventory** | Filterable/sortable table of all *tracked* certificates with colour-coded expiry; expiry distribution donut; soonest-expiring bar gauge |
 | **FIPS Compliance** | Compliant vs non-compliant donut; key algorithm distribution; table of non-compliant certificates with algorithm and hash details |
 | **Security** | Self-signed certificate table; Tetragon build/runtime version match; Kafka delivery error rate; self-signed breakdown by namespace |
 | **Operational Health** | Event processing rate; analysis error rate by type; cache occupancy time series (vs configured cap); per-cache utilisation % bar gauge |
 
 Template variables at the top of the dashboard filter all panels by **Namespace** and **Node** simultaneously. Both default to "All", which also covers bare-metal deployments where namespace is empty.
+
+**"Tracked" vs "all":** a bundle file with more certs than `large_file_metrics_cap` (default 300 — see the main [README](../README.md#configuration)) only gets Prometheus series for the first `large_file_metrics_cap` certs; the rest are cached internally and still published to Kafka if enabled, but won't appear as rows in this dashboard. This is a separate cap from the cache occupancy panel above, which tracks LRU eviction of the whole `known_certs` cache (`CACHE_MAX_SIZE`, default 10,000) — the two can both cause "why isn't cert X showing up," but for different reasons, so check both if a cert is missing.

--- a/probe_tests/README.md
+++ b/probe_tests/README.md
@@ -418,11 +418,23 @@ python3 probe_tests/test_large_cert_bundle.py --out-dir /some/writable/readonly/
 
 # Keep the generated files instead of printing an rm command:
 sudo python3 probe_tests/test_large_cert_bundle.py --keep
+
+# Also verify the re-access cardinality cap: once the bundle is cached, N
+# distinct processes each independently re-open it (simulating a shared
+# system CA bundle read by many unrelated binaries). Confirms
+# tls_certificate_process_info stays bounded per re-access event instead of
+# growing as N * cert-count — see agent/analyzer.py process_event's
+# cache-hit branch.
+sudo python3 probe_tests/test_large_cert_bundle.py --parallel-processes 25
 ```
 
 The script generates an N-cert PEM bundle plus a single-cert "canary" file,
 opens the bundle first (firing `fd_install` for a large file), then
-immediately opens the canary (firing `fd_install` for a one-cert file).
+immediately opens the canary (firing `fd_install` for a one-cert file). With
+`--parallel-processes M`, after the bundle finishes its background parse the
+script additionally spawns `M` concurrently-running processes — each a
+uniquely-named copy of `/bin/cat`, so Tetragon reports a distinct
+`process.binary` per copy — that each re-open the already-cached bundle.
 
 **Step 3 — Verify cert_analyzer output:**
 
@@ -435,6 +447,11 @@ within a second or two of being triggered, even though they were opened
 *after* the bundle — proof the bundle's parsing (which logs `Found N
 certificate(s) in ... (parsed in background — large file)`) didn't block the
 event-consumer thread from handling the canary's event first.
+
+If run with `--parallel-processes`, the script also prints a `curl`/`grep`
+command comparing the observed `tls_certificate_process_info` series count
+for the bundle against the pre-fix (`N * cert-count`) and post-fix
+(`N * large_file_cert_threshold`) expectations.
 
 **Step 4 — Remove the policy:**
 

--- a/probe_tests/README.md
+++ b/probe_tests/README.md
@@ -451,7 +451,7 @@ event-consumer thread from handling the canary's event first.
 If run with `--parallel-processes`, the script also prints a `curl`/`grep`
 command comparing the observed `tls_certificate_process_info` series count
 for the bundle against the pre-fix (`N * cert-count`) and post-fix
-(`N * large_file_cert_threshold`) expectations.
+(`N * large_file_metrics_cap`) expectations.
 
 **Step 4 — Remove the policy:**
 

--- a/probe_tests/test_large_cert_bundle.py
+++ b/probe_tests/test_large_cert_bundle.py
@@ -26,7 +26,7 @@ Usage:
   # bundle is cached, spawn N distinct processes that each independently open
   # it, simulating e.g. a shared system CA bundle being read by many unrelated
   # binaries. Prometheus's tls_certificate_process_info series for the bundle
-  # should stay bounded (~large_file_cert_threshold per process), not grow as
+  # should stay bounded (~large_file_metrics_cap per process), not grow as
   # N * cert-count.
   python3 test_large_cert_bundle.py --parallel-processes 25
 
@@ -61,18 +61,38 @@ CONFIG_FILE_PATH = '/etc/cert-analyzer/cert-analyzer.conf'
 _SETTLE_WAIT = 3  # seconds to let cert_analyzer log the canary before we exit
 
 
-def _effective_threshold() -> int:
-    """Best-effort read of the configured large_file_cert_threshold, for the reminder printed below."""
-    default = int(os.getenv('LARGE_FILE_CERT_THRESHOLD', '20'))
+def _effective_config_int(option: str, env_var: str, default: str) -> int:
+    """Best-effort read of an integer [certificates] option, for the reminders printed below."""
+    fallback = int(os.getenv(env_var, default))
     cp = configparser.ConfigParser()
     try:
         if os.access(CONFIG_FILE_PATH, os.R_OK):
             cp.read(CONFIG_FILE_PATH)
-            if cp.has_option('certificates', 'large_file_cert_threshold'):
-                return int(cp.get('certificates', 'large_file_cert_threshold'))
+            if cp.has_option('certificates', option):
+                return int(cp.get('certificates', option))
     except (OSError, configparser.Error, ValueError):
         pass
-    return default
+    return fallback
+
+
+def _effective_threshold() -> int:
+    """Effective large_file_cert_threshold -- controls background-thread parsing routing."""
+    return _effective_config_int('large_file_cert_threshold', 'LARGE_FILE_CERT_THRESHOLD', '20')
+
+
+def _effective_metrics_cap() -> int:
+    """
+    Effective large_file_metrics_cap -- caps per-bundle Prometheus fan-out.
+
+    Deliberately separate from _effective_threshold() above: that one only
+    reflects when a file is parsed on a background thread, this one reflects
+    the actual cap process_event()'s cache-hit branch and
+    _finish_new_certificate_file() enforce on Prometheus series. An earlier
+    version of this script used _effective_threshold()'s value for both,
+    which silently printed the wrong (15x too small) expected series count
+    once the two knobs were split apart in agent/analyzer.py.
+    """
+    return _effective_config_int('large_file_metrics_cap', 'LARGE_FILE_METRICS_CAP', '300')
 
 
 def _make_self_signed_cert(common_name: str) -> bytes:
@@ -181,6 +201,7 @@ def main() -> None:
     args = parser.parse_args()
 
     threshold = _effective_threshold()
+    metrics_cap = _effective_metrics_cap()
     if args.count <= threshold:
         print(f'WARNING: --count {args.count} does not exceed the configured '
               f'large_file_cert_threshold ({threshold}) — the bundle will be '
@@ -203,6 +224,7 @@ def main() -> None:
     print('    sudo tetra tracingpolicy add tetragon-policies/certificate-file-access.yaml')
     print()
     print(f'Configured large_file_cert_threshold: {threshold}')
+    print(f'Configured large_file_metrics_cap:    {metrics_cap}')
     print()
 
     print(f'[test] Generating {args.count} self-signed certs -> {bundle_path}')
@@ -263,11 +285,11 @@ def main() -> None:
     print()
 
     if args.parallel_processes > 0:
-        cap = threshold
+        cap = metrics_cap
         print('--- Re-access cardinality cap ---')
         print()
         print(f'{args.parallel_processes} distinct processes each re-opened the already-cached')
-        print(f'bundle. Each re-access is capped to large_file_cert_threshold '
+        print(f'bundle. Each re-access is capped to large_file_metrics_cap '
               f'({cap}) tracked certs (agent/analyzer.py process_event, cache-hit branch),')
         print(f'instead of one tls_certificate_process_info series per (cached cert, process) pair:')
         print()
@@ -276,7 +298,7 @@ def main() -> None:
         print(f'# Before the fix: up to {args.parallel_processes + 1} * {args.count} = '
               f'{(args.parallel_processes + 1) * args.count} series (N processes x every cached cert)')
         print(f'# After the fix:  at most {args.parallel_processes + 1} * {cap} = '
-              f'{(args.parallel_processes + 1) * cap} series (capped per event to large_file_cert_threshold)')
+              f'{(args.parallel_processes + 1) * cap} series (capped per event to large_file_metrics_cap)')
         print()
 
     if not args.keep:

--- a/probe_tests/test_large_cert_bundle.py
+++ b/probe_tests/test_large_cert_bundle.py
@@ -21,6 +21,15 @@ Usage:
   python3 test_large_cert_bundle.py --out-dir /etc/pki/tls/certs
   python3 test_large_cert_bundle.py --keep            # don't delete generated files
 
+  # Also verify the re-access cardinality cap (agent/analyzer.py process_event's
+  # cache-hit branch, agent/metrics.py record_cert_process_access): once the
+  # bundle is cached, spawn N distinct processes that each independently open
+  # it, simulating e.g. a shared system CA bundle being read by many unrelated
+  # binaries. Prometheus's tls_certificate_process_info series for the bundle
+  # should stay bounded (~large_file_cert_threshold per process), not grow as
+  # N * cert-count.
+  python3 test_large_cert_bundle.py --parallel-processes 25
+
 Requires:
   - Tetragon running with tetragon-policies/certificate-file-access.yaml loaded
   - cert_analyzer running
@@ -33,7 +42,10 @@ Requires:
 import argparse
 import configparser
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timedelta
 
@@ -93,6 +105,63 @@ def _write_file(path: str, data: bytes) -> None:
         sys.exit(1)
 
 
+_REACCESS_STAGGER_SECONDS = 0.05
+
+
+def _reaccess_from_parallel_processes(target_path: str, count: int, run_id: str) -> None:
+    """
+    Open `target_path` from `count` distinct processes, launched a few
+    milliseconds apart rather than all at once.
+
+    Each accessor is its own copy of /bin/cat under a unique name, so Tetragon
+    (which identifies the accessing process by its resolved binary path)
+    reports a distinct process.binary per copy — same as N unrelated real
+    binaries (pingsender, curl, some init script, ...) independently opening a
+    shared file like a system CA bundle. A single re-used binary would collapse
+    back to one process identity and defeat the point of the test.
+
+    The opener temp dir must NOT have "cert-analyzer" or "cert_analyzer"
+    anywhere in its path: process_event()'s filter_self_events check skips any
+    event whose process path contains those substrings (meant to stop
+    cert-analyzer from tracing its own file accesses). An earlier version of
+    this helper used prefix='cert-analyzer-probe-openers-', which silently
+    self-filtered every single re-access event — Tetragon captured and
+    delivered them correctly, cert-analyzer just discarded them all by design.
+    Confirmed via DEBUG-level logging: "Skipping self-generated event from
+    /tmp/cert-analyzer-probe-openers-.../bundle-opener-...".
+
+    The small stagger between launches is a smaller, separate precaution —
+    launching all N via back-to-back subprocess.Popen() with no delay at all
+    means many execs/opens/exits within a handful of milliseconds, which is
+    unrepresentative of the real-world scenario (many distinct binaries
+    reading a shared bundle over seconds, not milliseconds) even if Tetragon
+    handles the burst fine.
+    """
+    opener_dir = tempfile.mkdtemp(prefix='cert-bundle-reaccess-probe-')
+    opener_paths = []
+    try:
+        for i in range(count):
+            opener_path = os.path.join(opener_dir, f'bundle-opener-{run_id}-{i}')
+            shutil.copy('/bin/cat', opener_path)
+            os.chmod(opener_path, 0o755)
+            opener_paths.append(opener_path)
+
+        print(f'[test] Launching {count} processes to re-access the bundle '
+              f'({_REACCESS_STAGGER_SECONDS * 1000:.0f}ms apart)...')
+        t0 = time.time()
+        procs = []
+        for opener_path in opener_paths:
+            procs.append(
+                subprocess.Popen([opener_path, target_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            )
+            time.sleep(_REACCESS_STAGGER_SECONDS)
+        for p in procs:
+            p.wait()
+        print(f'[test]   {count} processes finished at t=+{time.time() - t0:.3f}s')
+    finally:
+        shutil.rmtree(opener_dir, ignore_errors=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description='Large multi-cert bundle background-parsing test for cert_analyzer',
@@ -105,6 +174,10 @@ def main() -> None:
                         help=f'directory to write test files to (default: {DEFAULT_OUT_DIR})')
     parser.add_argument('--keep', action='store_true',
                         help='keep the generated bundle/canary files instead of printing an rm command')
+    parser.add_argument('--parallel-processes', type=int, default=0,
+                        help='after the bundle is cached, re-access it from this many distinct, '
+                             'concurrently-running processes to verify the cert_process_info '
+                             're-access cardinality cap (default: 0 = skip this check)')
     args = parser.parse_args()
 
     threshold = _effective_threshold()
@@ -160,6 +233,16 @@ def main() -> None:
     time.sleep(_SETTLE_WAIT)
     print()
 
+    if args.parallel_processes > 0:
+        # Only meaningful once the bundle is actually cached — re-accessing it
+        # while the background parse is still in flight would just pile onto
+        # the initial-parse path (already capped in _finish_new_certificate_file)
+        # instead of exercising process_event's cache-hit re-access cap.
+        _reaccess_from_parallel_processes(bundle_path, args.parallel_processes, run_id)
+        print(f'[test] Waiting {_SETTLE_WAIT}s for cert_analyzer to process the re-accesses...')
+        time.sleep(_SETTLE_WAIT)
+        print()
+
     print('=== Verify ===')
     print()
     print('journalctl -u cert-analyzer --since "-1 min" | grep -E "bundle-test|canary"')
@@ -178,6 +261,23 @@ def main() -> None:
     print(f'curl -s http://localhost:9090/metrics | grep -c \'CN="bundle-test\'')
     print(f'# Expect {args.count} once the background parse finishes')
     print()
+
+    if args.parallel_processes > 0:
+        cap = threshold
+        print('--- Re-access cardinality cap ---')
+        print()
+        print(f'{args.parallel_processes} distinct processes each re-opened the already-cached')
+        print(f'bundle. Each re-access is capped to large_file_cert_threshold '
+              f'({cap}) tracked certs (agent/analyzer.py process_event, cache-hit branch),')
+        print(f'instead of one tls_certificate_process_info series per (cached cert, process) pair:')
+        print()
+        print(f'curl -s http://localhost:9090/metrics | grep \'^tls_certificate_process_info\' '
+              f'| grep -cF \'cert_path="{bundle_path}"\'')
+        print(f'# Before the fix: up to {args.parallel_processes + 1} * {args.count} = '
+              f'{(args.parallel_processes + 1) * args.count} series (N processes x every cached cert)')
+        print(f'# After the fix:  at most {args.parallel_processes + 1} * {cap} = '
+              f'{(args.parallel_processes + 1) * cap} series (capped per event to large_file_cert_threshold)')
+        print()
 
     if not args.keep:
         rm_prefix = 'sudo ' if not os.access(args.out_dir, os.W_OK) else ''

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -229,13 +229,13 @@ class TestLargeFileBackgroundProcessing:
     """Files with more PEM certs than large_file_cert_threshold are parsed off-thread"""
 
     @staticmethod
-    def _make_event(path):
+    def _make_event(path, process='/usr/bin/cat', pid=4242):
         from unittest.mock import MagicMock
         mock_event = MagicMock()
         mock_event.HasField.side_effect = lambda f: f == 'process_kprobe'
         mock_kprobe = MagicMock()
-        mock_kprobe.process.binary = '/usr/bin/cat'
-        mock_kprobe.process.pid.value = 4242
+        mock_kprobe.process.binary = process
+        mock_kprobe.process.pid.value = pid
         mock_kprobe.process.HasField.return_value = False
         mock_kprobe.HasField.return_value = False
         mock_arg = MagicMock()
@@ -291,6 +291,87 @@ class TestLargeFileBackgroundProcessing:
         self._wait_for_background_processing(analyzer, bundle_path)
         matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
         assert len(matching) == 5
+
+    def test_bundle_beyond_threshold_caps_metrics_fanout(self, analyzer, temp_dir):
+        """
+        A bundle file (e.g. a system CA trust store) with far more certs than
+        the large-file threshold must only get full per-cert Prometheus series
+        for the first `metrics_cap` certs -- otherwise one bundle file turns
+        into thousands of new series in a single burst, which is what drove
+        cert-analyzer's cardinality/memory spike and hang on 2026-07-03.
+        All certs must still land in known_certs (so known-file lookups and
+        cache-size accounting stay correct) even though metrics are capped.
+        """
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(10)]
+        bundle_path = os.path.join(temp_dir, "ca_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        analyzer.process_event(self._make_event(bundle_path))
+        self._wait_for_background_processing(analyzer, bundle_path)
+
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        assert len(matching) == 10, "every cert must still be cached, even beyond the metrics cap"
+
+        samples = [
+            s for metric in analyzer.metrics.cert_expiry_days.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == bundle_path
+        ]
+        assert len(samples) == 3, "only the first metrics_cap certs should get full per-cert series"
+
+    @pytest.mark.parametrize("n_processes", [5, 25, 100])
+    def test_many_processes_reaccessing_cached_bundle(self, analyzer, temp_dir, n_processes):
+        """
+        Reproduces the dominant cardinality driver behind the 2026-07-03
+        incident: once a bundle is cached, every *subsequent* access from a
+        distinct process (e.g. the system CA bundle being opened by dozens of
+        unrelated binaries) re-walks every cached cert for that path and
+        records a process-access sample per (cert, process) pair via
+        record_cert_process_access(). Uncapped, N processes re-accessing an
+        M-cert bundle mints N*M series. process_event() now caps how many of
+        the cached certs get a process-access sample per re-access event to
+        metrics_cap, so growth is O(N*metrics_cap) instead of O(N*M) -- still
+        linear in N, but with a small constant slope instead of the full
+        (much larger) bundle size.
+        """
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(10)]
+        bundle_path = os.path.join(temp_dir, "ca_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        # First access parses and caches the bundle (metrics fan-out already
+        # capped by the fix above).
+        analyzer.process_event(self._make_event(bundle_path))
+        self._wait_for_background_processing(analyzer, bundle_path)
+
+        # N independent processes each re-access the now-cached bundle.
+        for i in range(n_processes):
+            analyzer.process_event(
+                self._make_event(bundle_path, process=f"/usr/bin/proc{i}", pid=5000 + i)
+            )
+
+        samples = [
+            s for metric in analyzer.metrics.cert_process_info.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == bundle_path
+        ]
+        metrics_cap = analyzer._large_file_cert_threshold
+        # +1 covers the initial parsing event (process=/usr/bin/cat), which
+        # also contributes up to metrics_cap series of its own.
+        max_expected = metrics_cap * (n_processes + 1)
+        assert len(samples) <= max_expected, (
+            f"process-access fan-out should be capped at ~metrics_cap per event, "
+            f"got {len(samples)} cert_process_info series for {n_processes} "
+            f"processes re-accessing a {len(certs)}-cert bundle (expected <= {max_expected})"
+        )
+        # Confirm the cap is actually doing something, not just a loose bound:
+        # uncapped behavior would be up to n_processes * len(certs) series.
+        assert len(samples) < n_processes * len(certs), (
+            "fan-out should be well below the old uncapped N*M behavior"
+        )
 
     def test_duplicate_events_for_large_file_in_flight_are_deduped(self, analyzer, temp_dir):
         """A second event for the same large file while the first is still parsing is skipped"""

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -593,6 +593,99 @@ class TestPeriodicScan:
         """A configured scan path that doesn't exist on disk is skipped without raising."""
         analyzer.periodic_scan(["/nonexistent/scan/path"])
 
+    @staticmethod
+    def _make_event(path, process='/usr/bin/cat', pid=4242):
+        from unittest.mock import MagicMock
+        mock_event = MagicMock()
+        mock_event.HasField.side_effect = lambda f: f == 'process_kprobe'
+        mock_kprobe = MagicMock()
+        mock_kprobe.process.binary = process
+        mock_kprobe.process.pid.value = pid
+        mock_kprobe.process.HasField.return_value = False
+        mock_kprobe.HasField.return_value = False
+        mock_arg = MagicMock()
+        mock_arg.HasField.side_effect = lambda f: f == 'file_arg'
+        mock_arg.file_arg.path = path
+        mock_kprobe.args = [mock_arg]
+        mock_event.process_kprobe = mock_kprobe
+        mock_event.node_name = ''
+        return mock_event
+
+    def test_new_file_in_flight_prevents_periodic_scan_reparsing_file_claimed_by_event_path(
+        self, analyzer, temp_dir
+    ):
+        """
+        If a Tetragon event for a brand-new small file is mid-parse (has claimed
+        the path in _new_file_in_flight) right as periodic_scan's directory walk
+        reaches the same path, periodic_scan must not also parse/publish it.
+        """
+        from unittest.mock import Mock
+
+        cert, _ = TestCertificateGeneration.generate_certificate("racy.example.com", 365)
+        cert_path = os.path.join(temp_dir, "racy.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        analyzer.kafka_publisher = Mock()
+        analyzer._new_file_in_flight.add(cert_path)  # simulate process_event already claiming it
+        real_analyze = analyzer.analyze_certificate
+        analyze_calls = []
+
+        def spy(path, *args, **kwargs):
+            analyze_calls.append(path)
+            return real_analyze(path, *args, **kwargs)
+
+        analyzer.analyze_certificate = spy
+        analyzer.periodic_scan([temp_dir])
+
+        assert analyze_calls == [], "a path already claimed by another thread must not be re-parsed"
+        analyzer.kafka_publisher.publish.assert_not_called()
+        assert cert_path not in analyzer.known_certs.keys()
+
+    def test_new_file_in_flight_prevents_event_path_reparsing_file_claimed_by_periodic_scan(
+        self, analyzer, temp_dir
+    ):
+        """Same race, mirrored: process_event must not re-parse/publish a path periodic_scan has already claimed."""
+        from unittest.mock import Mock
+
+        cert, _ = TestCertificateGeneration.generate_certificate("racy2.example.com", 365)
+        cert_path = os.path.join(temp_dir, "racy2.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        analyzer.kafka_publisher = Mock()
+        analyzer._new_file_in_flight.add(cert_path)  # simulate periodic_scan already claiming it
+        real_analyze = analyzer.analyze_certificate
+        analyze_calls = []
+
+        def spy(path, *args, **kwargs):
+            analyze_calls.append(path)
+            return real_analyze(path, *args, **kwargs)
+
+        analyzer.analyze_certificate = spy
+        analyzer.process_event(self._make_event(cert_path))
+
+        assert analyze_calls == [], "a path already claimed by another thread must not be re-parsed"
+        analyzer.kafka_publisher.publish.assert_not_called()
+
+    def test_new_file_in_flight_cleared_after_periodic_scan_completes(self, analyzer, temp_dir):
+        """_new_file_in_flight must not leak an entry once periodic_scan finishes with a path."""
+        cert, _ = TestCertificateGeneration.generate_certificate("cleanup.example.com", 365)
+        cert_path = os.path.join(temp_dir, "cleanup.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        analyzer.periodic_scan([temp_dir])
+
+        assert cert_path not in analyzer._new_file_in_flight
+
+    def test_new_file_in_flight_cleared_after_process_event_completes(self, analyzer, temp_dir):
+        """_new_file_in_flight must not leak an entry once process_event finishes with a path."""
+        cert, _ = TestCertificateGeneration.generate_certificate("cleanup2.example.com", 365)
+        cert_path = os.path.join(temp_dir, "cleanup2.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        analyzer.process_event(self._make_event(cert_path))
+
+        assert cert_path not in analyzer._new_file_in_flight
+
 
 class TestCertificateAnalysis:
     """Test certificate analysis and information extraction"""

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -489,6 +489,111 @@ class TestLargeFileBackgroundProcessing:
                    for r in caplog.records)
 
 
+class TestPeriodicScan:
+    """
+    periodic_scan() used to reimplement its own inline
+    metrics/logging/cache/publish loop instead of reusing analyze_certificate()
+    + _finish_new_certificate_file() — so it never got the large_file_metrics_cap
+    fan-out cap (reproducing the 2026-07-03 cardinality incident for any bundle
+    under a scan_paths directory) and always re-published already-known certs to
+    Kafka on every scan_interval. periodic_scan now shares the same threshold
+    routing / cap / known-file-skip logic as the Tetragon event path.
+    """
+
+    def test_bundle_beyond_threshold_caps_metrics_fanout(self, analyzer, temp_dir):
+        """A bundle discovered via periodic_scan gets the same fan-out cap as one discovered via a Tetragon event."""
+        analyzer._large_file_cert_threshold = 3
+        analyzer._large_file_metrics_cap = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(10)]
+        bundle_path = os.path.join(temp_dir, "ca_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        analyzer.periodic_scan([temp_dir])
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and bundle_path in analyzer._large_file_in_flight:
+            time.sleep(0.01)
+
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        assert len(matching) == 10, "every cert must still be cached, even beyond the metrics cap"
+
+        samples = [
+            s for metric in analyzer.metrics.cert_expiry_days.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == bundle_path
+        ]
+        assert len(samples) == 3, "only the first metrics_cap certs should get full per-cert series"
+
+    def test_large_bundle_routed_to_background_worker(self, analyzer, temp_dir):
+        """A bundle over the threshold is hop-scotched through the same async worker path as a Tetragon event, not parsed inline."""
+        analyzer._large_file_cert_threshold = 3
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "large_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        real_async = analyzer._process_certificate_file_async
+        calls = []
+
+        def spy(cert_path, *args, **kwargs):
+            calls.append(cert_path)
+            return real_async(cert_path, *args, **kwargs)
+
+        analyzer._process_certificate_file_async = spy
+        analyzer.periodic_scan([temp_dir])
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and bundle_path in analyzer._large_file_in_flight:
+            time.sleep(0.01)
+
+        assert calls == [bundle_path]
+
+    def test_already_known_file_is_not_reparsed_or_republished(self, analyzer, temp_dir):
+        """A file already present in known_certs must be skipped entirely — no re-parse, no duplicate Kafka publish."""
+        from unittest.mock import Mock
+
+        cert, _ = TestCertificateGeneration.generate_certificate("known.example.com", 365)
+        cert_path = os.path.join(temp_dir, "known.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        cert_infos = analyzer.analyze_certificate(cert_path, "test_process", 1234)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+
+        analyzer.kafka_publisher = Mock()
+        real_analyze = analyzer.analyze_certificate
+        analyze_calls = []
+
+        def spy(path, *args, **kwargs):
+            analyze_calls.append(path)
+            return real_analyze(path, *args, **kwargs)
+
+        analyzer.analyze_certificate = spy
+        analyzer.periodic_scan([temp_dir])
+
+        assert analyze_calls == [], "already-known files must not be re-parsed"
+        analyzer.kafka_publisher.publish.assert_not_called()
+
+    def test_new_file_is_parsed_cached_and_published(self, analyzer, temp_dir):
+        """A file periodic_scan has never seen before is parsed, cached, and published exactly once."""
+        from unittest.mock import Mock
+
+        cert, _ = TestCertificateGeneration.generate_certificate("new.example.com", 365)
+        cert_path = os.path.join(temp_dir, "new.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, cert_path)
+
+        analyzer.kafka_publisher = Mock()
+        analyzer.periodic_scan([temp_dir])
+
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(cert_path + ":")]
+        assert len(matching) == 1
+        analyzer.kafka_publisher.publish.assert_called_once()
+
+    def test_nonexistent_scan_path_is_skipped(self, analyzer):
+        """A configured scan path that doesn't exist on disk is skipped without raising."""
+        analyzer.periodic_scan(["/nonexistent/scan/path"])
+
+
 class TestCertificateAnalysis:
     """Test certificate analysis and information extraction"""
     

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -3593,6 +3593,39 @@ class TestReconnection:
         assert second_call.wait(timeout=3.0), "GetEvents was not called a second time"
         assert call_count[0] >= 2
 
+    def test_keyboard_interrupt_propagates_after_cleanup(self, analyzer, monkeypatch):
+        """
+        start() must re-raise KeyboardInterrupt after its own cleanup (metrics,
+        channel.close()) instead of swallowing it. agent.config.main() wraps
+        start() in its own try/except KeyboardInterrupt specifically to flush
+        the Kafka producer and stop the health server on a graceful shutdown
+        signal -- if start() swallows the interrupt, that handler never runs
+        and unflushed in-flight Kafka messages can be lost.
+        """
+        class _InterruptingStub:
+            def GetEvents(self_, request, **kwargs):
+                raise KeyboardInterrupt()
+
+            def GetVersion(self_, request, timeout=None):
+                return _MockGetVersionResponse('v1.1.0')
+
+        class _FakeChannel:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        fake_channel = _FakeChannel()
+        monkeypatch.setattr(grpc, 'insecure_channel', lambda *a, **kw: fake_channel)
+        monkeypatch.setattr(sensors_pb2_grpc, 'FineGuidanceSensorsStub',
+                            lambda ch: _InterruptingStub())
+
+        with pytest.raises(KeyboardInterrupt):
+            analyzer.start()
+
+        assert fake_channel.closed, "channel.close() must still run via finally"
+
 
 class TestVersionMonitor:
     """Tests for _start_version_monitor background thread."""

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -4472,10 +4472,99 @@ class TestKafkaPublisher:
             publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
 
             with caplog.at_level(logging.WARNING):
-                publisher._on_error(Exception('delivery failed'))
+                publisher._on_error(publisher._producer, Exception('delivery failed'))
 
             assert any('delivery' in r.message.lower() or 'kafka' in r.message.lower()
                        for r in caplog.records)
+
+    def test_on_error_nullifies_matching_current_producer(self, monkeypatch):
+        """_on_error() nullifies self._producer when it's still the producer the failed send came from."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            current_producer = publisher._producer
+
+            publisher._on_error(current_producer, Exception('delivery failed'))
+
+            assert publisher._producer is None
+
+    def test_stale_on_error_does_not_nullify_a_superseded_producer(self, monkeypatch):
+        """
+        kafka-python invokes errbacks from its own internal I/O thread, and can
+        do so long after the send() call that registered it (after internal
+        retries/timeouts) -- possibly after a reconnect has already replaced
+        self._producer with a new, healthy one. A stale errback for the OLD
+        producer must not tear down the new one.
+        """
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            old_producer = publisher._producer
+
+            # Simulate a reconnect installing a new, healthy producer.
+            new_producer = MagicMock()
+            publisher._producer = new_producer
+
+            # The old producer's delayed errback finally fires.
+            publisher._on_error(old_producer, Exception('stale delivery failure'))
+
+            assert publisher._producer is new_producer, \
+                "a stale error from a superseded producer must not nullify the current one"
+
+    def test_publish_errback_captures_producer_instance_at_send_time(self, monkeypatch, sample_cert_info):
+        """
+        publish() must bind the errback to the specific producer instance send()
+        was issued from (not to whatever self._producer happens to be when the
+        errback eventually fires) -- otherwise a delayed error from an old send
+        could nullify a producer installed by a later reconnect.
+        """
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+
+        class FakeProducer:
+            def __init__(self, **kwargs):
+                self.errback = None
+
+            def send(self, *args, **kwargs):
+                future = MagicMock()
+                future.add_errback = lambda cb: setattr(self, 'errback', cb)
+                return future
+
+            def close(self, timeout=None):
+                pass
+
+        with patch('agent.kafka.KafkaProducer', FakeProducer):
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            publisher._reconnect_cooldown = 0
+
+            old_producer = publisher._producer
+            publisher.publish(sample_cert_info)
+            assert old_producer.errback is not None
+
+            # Reconnect: old producer is replaced by a new one.
+            publisher._producer = None
+            publisher.publish(sample_cert_info)
+            new_producer = publisher._producer
+            assert new_producer is not old_producer
+
+            # The OLD producer's stale errback fires after the reconnect.
+            old_producer.errback(Exception('old delivery failed'))
+
+            assert publisher._producer is new_producer, \
+                "a stale error bound to the old producer must not nullify the new one"
 
     # ── close ─────────────────────────────────────────────────────────────────
 

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -292,6 +292,40 @@ class TestLargeFileBackgroundProcessing:
         matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
         assert len(matching) == 5
 
+    def test_background_threading_and_metrics_cap_are_independent(self, analyzer, temp_dir):
+        """
+        _large_file_cert_threshold (background-thread routing) and
+        _large_file_metrics_cap (Prometheus fan-out cap) are separate knobs.
+        A bundle over the (low) threshold but under the (higher) metrics cap
+        must still be parsed on a background thread AND get full per-cert
+        metrics for every cert -- raising the metrics cap to cover a realistic
+        bundle must not also disable background-thread parsing for it.
+        """
+        analyzer._large_file_cert_threshold = 3
+        analyzer._large_file_metrics_cap = 10
+        certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
+                 for i in range(5)]
+        bundle_path = os.path.join(temp_dir, "midsize_bundle.pem")
+        TestCertificateGeneration.save_multi_certificate_pem(certs, bundle_path)
+
+        analyzer.process_event(self._make_event(bundle_path))
+
+        # Over the cert threshold (5 > 3) -> routed to the background-thread
+        # path (same routing logic covered by test_count_pem_certs and
+        # test_large_file_processed_in_background).
+        self._wait_for_background_processing(analyzer, bundle_path)
+
+        matching = [k for k in analyzer.known_certs.keys() if k.startswith(bundle_path + ":")]
+        assert len(matching) == 5
+
+        # Under the metrics cap (5 <= 10) -> every cert gets full metrics, none skipped.
+        samples = [
+            s for metric in analyzer.metrics.cert_expiry_days.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == bundle_path
+        ]
+        assert len(samples) == 5, "certs under the metrics cap must all get full per-cert series"
+
     def test_bundle_beyond_threshold_caps_metrics_fanout(self, analyzer, temp_dir):
         """
         A bundle file (e.g. a system CA trust store) with far more certs than
@@ -303,6 +337,7 @@ class TestLargeFileBackgroundProcessing:
         cache-size accounting stay correct) even though metrics are capped.
         """
         analyzer._large_file_cert_threshold = 3
+        analyzer._large_file_metrics_cap = 3
         certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
                  for i in range(10)]
         bundle_path = os.path.join(temp_dir, "ca_bundle.pem")
@@ -337,6 +372,7 @@ class TestLargeFileBackgroundProcessing:
         (much larger) bundle size.
         """
         analyzer._large_file_cert_threshold = 3
+        analyzer._large_file_metrics_cap = 3
         certs = [TestCertificateGeneration.generate_certificate(f"c{i}.example.com", 365)[0]
                  for i in range(10)]
         bundle_path = os.path.join(temp_dir, "ca_bundle.pem")
@@ -358,7 +394,7 @@ class TestLargeFileBackgroundProcessing:
             for s in metric.samples
             if s.labels.get('cert_path') == bundle_path
         ]
-        metrics_cap = analyzer._large_file_cert_threshold
+        metrics_cap = analyzer._large_file_metrics_cap
         # +1 covers the initial parsing event (process=/usr/bin/cat), which
         # also contributes up to metrics_cap series of its own.
         max_expected = metrics_cap * (n_processes + 1)


### PR DESCRIPTION
A system CA trust bundle parsed or repeatedly re-accessed by many distinct processes was minting Prometheus series unbounded by both cert count and accessing-process count, which drove a real cardinality/memory spike and hang on 2026-07-03 (256MB cgroup ceiling hit, /metrics scrape timeouts, stuck HTTP handler threads).

Cap both fan-out points at large_file_cert_threshold: the initial parse in _finish_new_certificate_file() now only tracks metrics/logs for the first N certs of a bundle, and process_event()'s cache-hit branch now only records process-access for the first N cached certs per re-access event instead of every cached cert. Verified against a live RPM deployment with real Tetragon events: 50-cert bundle capped to 20 series, 26 distinct re-accessing processes capped to 520 series (26 x 20) instead of the uncapped 1,300+.

Extends probe_tests/test_large_cert_bundle.py with --parallel-processes to reproduce the re-access scenario with real distinct processes.