### PR TITLE
Surface key_usage/extended_key_usage as Prometheus labels

### DIFF
--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -18,13 +18,22 @@ class PrometheusMetrics:
         # process/parent_process are intentionally absent: these are cert properties,
         # not per-accessor properties.  Use tls_certificate_process_info to map certs
         # to the processes that have loaded them.
+        #
+        # key_usage/extended_key_usage are comma-joined (same pattern as
+        # san_dns_names/san_ip_addresses below) so key-usage-abuse queries
+        # (e.g. a serverAuth-only cert observed somewhere clientAuth is
+        # expected) are filterable/alertable from Prometheus instead of only
+        # visible in the detail log or the optional Kafka event stream. Real
+        # KU/EKU combinations cluster into a handful of common patterns, so
+        # this doesn't add meaningful cardinality risk.
         self.cert_expiry_days = Gauge(
             'tls_certificate_expiry_days',
             'Days until TLS certificate expiry',
             ['cert_path', 'subject', 'issuer', 'serial', 'common_name',
              'san_dns_names', 'san_ip_addresses',
              'cert_index', 'pod_name', 'namespace', 'workload_kind', 'workload_name',
-             'node_name', 'app_label', 'container_name', 'checksum']
+             'node_name', 'app_label', 'container_name', 'checksum',
+             'key_usage', 'extended_key_usage']
         )
 
         self.cert_expiry_timestamp = Gauge(
@@ -33,7 +42,8 @@ class PrometheusMetrics:
             ['cert_path', 'subject', 'issuer', 'serial', 'common_name',
              'san_dns_names', 'san_ip_addresses',
              'cert_index', 'pod_name', 'namespace', 'workload_kind', 'workload_name',
-             'node_name', 'app_label', 'container_name', 'checksum']
+             'node_name', 'app_label', 'container_name', 'checksum',
+             'key_usage', 'extended_key_usage']
         )
 
         self.cert_valid_from = Gauge(
@@ -42,7 +52,8 @@ class PrometheusMetrics:
             ['cert_path', 'subject', 'issuer', 'serial', 'common_name',
              'san_dns_names', 'san_ip_addresses',
              'cert_index', 'pod_name', 'namespace', 'workload_kind', 'workload_name',
-             'node_name', 'app_label', 'container_name', 'checksum']
+             'node_name', 'app_label', 'container_name', 'checksum',
+             'key_usage', 'extended_key_usage']
         )
 
         self.cert_last_accessed = Gauge(
@@ -51,7 +62,8 @@ class PrometheusMetrics:
             ['cert_path', 'subject', 'issuer', 'serial', 'common_name',
              'san_dns_names', 'san_ip_addresses',
              'cert_index', 'pod_name', 'namespace', 'workload_kind', 'workload_name',
-             'node_name', 'app_label', 'container_name', 'checksum']
+             'node_name', 'app_label', 'container_name', 'checksum',
+             'key_usage', 'extended_key_usage']
         )
 
         self.cert_process_info = Gauge(
@@ -253,6 +265,8 @@ class PrometheusMetrics:
             'app_label':        info.app_label,
             'container_name':   info.container_name,
             'checksum':         info.checksum,
+            'key_usage':          ','.join(info.key_usage) if info.key_usage else '',
+            'extended_key_usage': ','.join(info.extended_key_usage) if info.extended_key_usage else '',
         }
 
         self.cert_process_info.labels(
@@ -355,6 +369,8 @@ class PrometheusMetrics:
             app_label=info.app_label,
             container_name=info.container_name,
             checksum=info.checksum,
+            key_usage=','.join(info.key_usage) if info.key_usage else '',
+            extended_key_usage=','.join(info.extended_key_usage) if info.extended_key_usage else '',
         ).set(datetime.utcnow().timestamp())
 
     def record_cert_process_access(self, info: CertificateInfo, process: str, parent_process: str) -> None:

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -31,7 +31,6 @@ All share the same label set:
 | `subject` | X.509 | RFC 4514 string, truncated to 100 chars |
 | `issuer` | X.509 | RFC 4514 string, truncated to 100 chars |
 | `serial` | X.509 | Decimal serial number as string |
-| `process` | Tetragon event | Binary path of the process that accessed the cert |
 | `common_name` | X.509 | CN from the Subject, empty if absent |
 | `san_dns_names` | X.509 | Comma-joined DNS SANs; empty string if none |
 | `san_ip_addresses` | X.509 | Comma-joined IP SANs; empty string if none |
@@ -44,7 +43,13 @@ All share the same label set:
 | `app_label` | k8s pod labels | Value of `app`, `app.kubernetes.io/name`, or `k8s-app` label; empty if none |
 | `container_name` | Tetragon / k8s | Empty on bare metal |
 | `checksum` | X.509 | SHA-256 hex fingerprint of DER-encoded cert; empty string when `checksum_enabled=false` |
-| `parent_process` | Tetragon event | Binary path of the process that spawned the cert loader; empty when Tetragon's process cache did not have the parent at event time (common at startup) |
+| `key_usage` | X.509 | Comma-joined Key Usage bits (e.g. `digital_signature,key_encipherment`); empty string if the extension is absent |
+| `extended_key_usage` | X.509 | Comma-joined Extended Key Usage OIDs (e.g. `server_auth,client_auth`); empty string if the extension is absent |
+
+Note: `process`/`parent_process` are per-*access*, not per-certificate, so they are
+deliberately not labels on these four gauges — they're tracked instead on the
+`tls_certificate_process_info` gauge, which maps certificates to the processes
+observed loading them.
 
 ### Certificate status flags
 

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -1128,7 +1128,9 @@
               "serial": 14,
               "subject": 15,
               "Value": 16,
-              "checksum": 17
+              "checksum": 17,
+              "key_usage": 18,
+              "extended_key_usage": 19
             },
             "renameByName": {
               "Value": "Days Until Expiry",
@@ -1147,7 +1149,9 @@
               "cert_index": "Cert #",
               "serial": "Serial",
               "subject": "Subject",
-              "checksum": "Checksum"
+              "checksum": "Checksum",
+              "key_usage": "Key Usage",
+              "extended_key_usage": "Extended Key Usage"
             }
           }
         },

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -2328,7 +2328,7 @@ class TestCacheHitReDetection:
             serial='42', common_name='', san_dns_names='', san_ip_addresses='',
             cert_index='0', pod_name='', namespace='', workload_kind='',
             workload_name='', node_name='', app_label='', container_name='',
-            checksum='',
+            checksum='', key_usage='', extended_key_usage='',
         )._value.get()
         assert before == 0.0
 
@@ -2339,7 +2339,7 @@ class TestCacheHitReDetection:
             serial='42', common_name='', san_dns_names='', san_ip_addresses='',
             cert_index='0', pod_name='', namespace='', workload_kind='',
             workload_name='', node_name='', app_label='', container_name='',
-            checksum='',
+            checksum='', key_usage='', extended_key_usage='',
         )._value.get()
         assert after > 0.0
 


### PR DESCRIPTION
Both fields were already extracted and logged, and published to the optional Kafka event stream, but had no Prometheus presence at all -- there was no way to query or alert on key-usage abuse (e.g. a serverAuth-only cert observed somewhere clientAuth is expected) without consuming Kafka (opt-in, event-driven) or grepping text logs.

Adds key_usage/extended_key_usage as comma-joined labels (same pattern already used for san_dns_names/san_ip_addresses) on the four gauges that share the certificate-identity label set: tls_certificate_expiry_days, _expiry_timestamp, _valid_from_timestamp, and _last_accessed_timestamp. Real KU/EKU combinations cluster into a handful of common patterns, so this doesn't add meaningful cardinality risk.

Adds the two fields as columns on the "All Certificates" Grafana panel (the one panel that surfaces cert_expiry_days as an inventory table). Also corrects two stale rows in FIELDS-README.md's label table -- process/parent_process were listed as labels on these four gauges but never have been; they're tracked separately on tls_certificate_process_info.