### PR TITLE
Bound background threads and cut redundant work on hot cert-processin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ sudo systemctl enable --now cert-analyzer
 | `demo_mode` | `false` | Log certificate details (subject, issuer, serial, validity, SANs) at INFO level instead of DEBUG — for demos only, leave false in production |
 | `large_file_cert_threshold` | `20` | Files with more PEM certs than this (e.g. a system CA bundle) are parsed on a background thread instead of the Tetragon event-consumer thread |
 | `large_file_metrics_cap` | `300` | Caps how many certs in a single bundle file get full Prometheus metrics/logging, independent of `large_file_cert_threshold` above. Certs beyond the cap are still cached internally and still published to Kafka if enabled, just not tracked as individual Prometheus series. Default comfortably covers a real system CA trust bundle (~130-150 certs) |
+| `max_concurrent_background_threads` | `20` | Caps how many TLS-probe / large-file-parse background threads can run at once, so a burst of events (e.g. many pods reconnecting to dependencies after a restart) can't spawn unbounded OS threads. Events beyond the cap are dropped and retried on a later qualifying event rather than queued |
+| `max_processes_per_cert` | `20` | Caps how many distinct `(process, parent_process)` pairs get their own `tls_certificate_process_info` series per certificate. Without this, a file opened by many unrelated binaries over the life of the process (e.g. the system CA trust bundle touched by curl, dnf, git, python, docker, ...) accumulates one permanent series per distinct process, forever, regardless of cache size. The certificate's own expiry/FIPS/self-signed metrics and Kafka discovery event are unaffected — only this per-process attribution axis is capped |
 
 **[passwords]**
 

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -190,7 +190,12 @@ class CertificateAnalyzer:
             self._known_paths.setdefault(path, set()).add(key)
 
     def _deindex_known_cert(self, key: str, value) -> None:
-        """known_certs on_evict callback — the inverse of _index_known_cert."""
+        """
+        known_certs on_evict callback — the inverse of _index_known_cert, plus
+        removing the evicted cert's Prometheus series so metric memory tracks
+        cache occupancy instead of growing for the life of the process (see
+        PrometheusMetrics.remove_certificate_metrics).
+        """
         path = getattr(value, 'path', None)
         if path is None:
             return
@@ -200,6 +205,14 @@ class CertificateAnalyzer:
                 keys_for_path.discard(key)
                 if not keys_for_path:
                     del self._known_paths[path]
+        try:
+            self.metrics.remove_certificate_metrics(value)
+        except Exception as e:
+            # value may be a bare/partial object in tests that seed known_certs
+            # directly — degrade to a leaked series rather than crashing the
+            # thread that's mutating the cache (event consumer, periodic scan,
+            # or a background parse worker).
+            logger.debug(f"Could not remove Prometheus metrics for evicted cert {key}: {e}")
 
     def _update_cache_metrics(self) -> None:
         """Update Prometheus gauges reflecting current LRU cache occupancy."""

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -89,7 +89,8 @@ class CertificateAnalyzer:
                  tls_outbound_ports: Optional[frozenset] = None,
                  large_file_cert_threshold: int = 20,
                  large_file_metrics_cap: int = 300,
-                 max_concurrent_background_threads: int = 20):
+                 max_concurrent_background_threads: int = 20,
+                 max_processes_per_cert: int = 20):
         self.tetragon_address = tetragon_address
         self.alert_threshold_days = alert_threshold_days
         self.filter_self_events = filter_self_events
@@ -115,6 +116,14 @@ class CertificateAnalyzer:
         # finally block, so it can never over-release.
         self._max_concurrent_background_threads = max_concurrent_background_threads
         self._background_thread_semaphore = threading.Semaphore(max_concurrent_background_threads)
+        # Bounds the number of distinct (process, parent_process) pairs
+        # tracked in tls_certificate_process_info per cert. Without this, a
+        # file opened by many unrelated binaries over the life of the process
+        # (e.g. the system CA trust bundle touched by curl, dnf, git, python,
+        # docker, ...) accumulates one permanent series per distinct process,
+        # forever — unbounded regardless of known_certs cache size, since the
+        # cert entry itself may never be evicted. See _record_cert_process_access.
+        self._max_processes_per_cert = max_processes_per_cert
         self.metrics = PrometheusMetrics(node_name=_NODE_NAME)
         # cert_path -> set of known_certs keys for that path. Lets process_event's
         # "already known" check do an O(1) dict lookup instead of scanning every
@@ -220,6 +229,38 @@ class CertificateAnalyzer:
         self.metrics.cache_processed_paths_size.labels(node_name=self.metrics._node_name).set(len(self.processed_paths))
         self.metrics.cache_password_failed_size.labels(node_name=self.metrics._node_name).set(len(self.password_failed_paths))
         self.metrics.update_process_metrics()
+
+    def _record_cert_process_access(self, cert_info: CertificateInfo, process: str, parent_process: str) -> None:
+        """
+        Record that `process` has accessed an already-known cert, capped at
+        max_processes_per_cert distinct (process, parent_process) pairs per
+        cert.
+
+        Without this cap, a file opened by many unrelated binaries over the
+        life of the process (e.g. the system CA trust bundle touched by curl,
+        dnf, git, python, docker, ...) accumulates one permanent
+        tls_certificate_process_info series per distinct process, forever —
+        unlike the cert's own expiry/FIPS/self-signed metrics, this fan-out
+        isn't bounded by known_certs' LRU size, since the cert entry itself
+        may never get evicted while still being actively re-accessed.
+
+        Only ever called from process_event, which runs on the single
+        gRPC event-consumer thread, so cert_info._seen_processes needs no
+        lock — nothing else mutates it after the initial seed in
+        PrometheusMetrics.update_certificate_metrics.
+        """
+        pair = (process, parent_process)
+        if pair not in cert_info._seen_processes:
+            if len(cert_info._seen_processes) >= self._max_processes_per_cert:
+                logger.debug(
+                    f"cert_process_info fan-out cap ({self._max_processes_per_cert}) "
+                    f"reached for {cert_info.path} — not tracking additional "
+                    f"process {process!r}"
+                )
+                self.metrics.cert_analysis_errors.labels(error_type='process_fanout_cap_reached').inc()
+                return
+            cert_info._seen_processes.add(pair)
+        self.metrics.record_cert_process_access(cert_info, process, parent_process)
 
     def is_cert_path(self, path: str) -> bool:
         """Check if a path looks like a certificate or keystore file"""
@@ -1784,7 +1825,7 @@ class CertificateAnalyzer:
                 # in this file.
                 self.log_certificate_status(cert_info, summary_only=True)
                 self.metrics.update_last_accessed(cert_info)
-                self.metrics.record_cert_process_access(cert_info, process_name, parent_process)
+                self._record_cert_process_access(cert_info, process_name, parent_process)
 
             if is_bundle:
                 logger.info(

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -88,7 +88,8 @@ class CertificateAnalyzer:
                  port_probe_connect_delay: float = 2.0,
                  tls_outbound_ports: Optional[frozenset] = None,
                  large_file_cert_threshold: int = 20,
-                 large_file_metrics_cap: int = 300):
+                 large_file_metrics_cap: int = 300,
+                 max_concurrent_background_threads: int = 20):
         self.tetragon_address = tetragon_address
         self.alert_threshold_days = alert_threshold_days
         self.filter_self_events = filter_self_events
@@ -105,6 +106,15 @@ class CertificateAnalyzer:
         self._tls_outbound_ports = tls_outbound_ports if tls_outbound_ports is not None else self.TLS_OUTBOUND_PORTS
         self._large_file_cert_threshold = large_file_cert_threshold
         self._large_file_metrics_cap = large_file_metrics_cap
+        # Bounds how many TLS-probe / large-file-parse threads can run at once.
+        # Without this, a burst of events (e.g. every pod on a node reconnecting
+        # to its dependencies after a restart, each opening a distinct host:port
+        # tls_outbound_port) spawns one raw OS thread per event with no limit.
+        # A plain (non-bounded) Semaphore is fine here: every acquire() this
+        # class makes is matched by exactly one release() in the worker's
+        # finally block, so it can never over-release.
+        self._max_concurrent_background_threads = max_concurrent_background_threads
+        self._background_thread_semaphore = threading.Semaphore(max_concurrent_background_threads)
         self.metrics = PrometheusMetrics(node_name=_NODE_NAME)
         # cert_path -> set of known_certs keys for that path. Lets process_event's
         # "already known" check do an O(1) dict lookup instead of scanning every
@@ -764,6 +774,34 @@ class CertificateAnalyzer:
 
         self._update_cache_metrics()
 
+    def _start_background_thread(self, target, name: str) -> bool:
+        """
+        Start a daemon thread for probe/large-file work, bounded by
+        _background_thread_semaphore so a burst of events (many simultaneous
+        TLS binds/connects, or several large CA bundles at once) can't spawn
+        unbounded concurrent OS threads.
+
+        Returns False without starting a thread if the concurrency cap is
+        already reached. Callers already de-dupe via their own in-flight
+        tracking before calling this, so a dropped attempt just means the
+        same work is retried on a later event rather than queuing here.
+        """
+        if not self._background_thread_semaphore.acquire(blocking=False):
+            logger.warning(
+                f"Background thread cap ({self._max_concurrent_background_threads}) "
+                f"reached, skipping {name}"
+            )
+            return False
+
+        def _run():
+            try:
+                target()
+            finally:
+                self._background_thread_semaphore.release()
+
+        threading.Thread(target=_run, daemon=True, name=name).start()
+        return True
+
     def _process_certificate_file_async(
         self,
         cert_path: str,
@@ -818,9 +856,13 @@ class CertificateAnalyzer:
                 with self._large_file_in_flight_lock:
                     self._large_file_in_flight.discard(cert_path)
 
-        threading.Thread(
-            target=_worker, daemon=True, name=f'cert-parse-{Path(cert_path).name}'
-        ).start()
+        started = self._start_background_thread(_worker, name=f'cert-parse-{Path(cert_path).name}')
+        if not started:
+            # _worker's finally never ran, so undo the in-flight marker here —
+            # the file will be retried on its next qualifying event.
+            with self._large_file_in_flight_lock:
+                self._large_file_in_flight.discard(cert_path)
+            self.metrics.cert_analysis_errors.labels(error_type='background_thread_cap_reached').inc()
 
     def _apply_pod_context(self, cert_info: CertificateInfo, tetragon_pod):
         """Populate all Tetragon Pod proto fields onto cert_info."""
@@ -1204,7 +1246,9 @@ class CertificateAnalyzer:
             f"by {process_name} (PID: {pid})"
         )
 
-        if any(k.startswith(synthetic_path + ":") for k in self.known_certs):
+        with self._known_paths_lock:
+            already_known = synthetic_path in self._known_paths
+        if already_known:
             logger.info(f"Re-detected known Java FIPS certificate: {synthetic_path}")
             return True
 
@@ -1333,7 +1377,9 @@ class CertificateAnalyzer:
         self.metrics.last_event_timestamp.labels(node_name=self.metrics._node_name).set(self.last_event_time)
         logger.info(f"🔍 Detected in-memory certificate: {synthetic_path} by {process_name} (PID: {pid})")
 
-        if any(k.startswith(synthetic_path + ":") for k in self.known_certs):
+        with self._known_paths_lock:
+            already_known = synthetic_path in self._known_paths
+        if already_known:
             logger.info(f"Re-detected known in-memory certificate: {synthetic_path}")
             return True
 
@@ -1551,8 +1597,14 @@ class CertificateAnalyzer:
                     self._probe_in_flight.discard(endpoint_key)
                 self._probed_endpoints.add(endpoint_key)
 
-        t = threading.Thread(target=_probe, daemon=True, name=f'tls-probe-{host}-{port}')
-        t.start()
+        started = self._start_background_thread(_probe, name=f'tls-probe-{host}-{port}')
+        if not started:
+            # _probe's finally never ran, so undo the in-flight marker here —
+            # this endpoint will be retried on its next qualifying event.
+            with self._probe_in_flight_lock:
+                self._probe_in_flight.discard(endpoint_key)
+            self.metrics.tls_port_probes_total.labels(status='skipped').inc()
+            return
         logger.debug(f"Scheduled TLS probe {host}:{port} delay={delay}s pid={pid} process={process_name}")
 
     def _handle_tls_connect_event(self, event) -> None:
@@ -1605,8 +1657,14 @@ class CertificateAnalyzer:
                     self._probe_in_flight.discard(endpoint_key)
                 self._probed_endpoints.add(endpoint_key)
 
-        t = threading.Thread(target=_probe, daemon=True, name=f'tls-probe-out-{daddr}-{dport}')
-        t.start()
+        started = self._start_background_thread(_probe, name=f'tls-probe-out-{daddr}-{dport}')
+        if not started:
+            # _probe's finally never ran, so undo the in-flight marker here —
+            # this endpoint will be retried on its next qualifying event.
+            with self._probe_in_flight_lock:
+                self._probe_in_flight.discard(endpoint_key)
+            self.metrics.tls_port_probes_total.labels(status='skipped').inc()
+            return
         logger.debug(
             f"Scheduled TLS outbound probe {daddr}:{dport} pid={pid} process={process_name}"
         )

--- a/agent/config.py
+++ b/agent/config.py
@@ -114,6 +114,10 @@ def main():
     # Conflating them meant raising the metrics cap to cover a realistic CA
     # bundle (~130-150 certs) also disabled background-thread parsing for it.
     large_file_metrics_cap = int(cfg(cp, 'certificates', 'large_file_metrics_cap', 'LARGE_FILE_METRICS_CAP', '300'))
+    # Caps concurrent TLS-probe / large-file-parse threads so a burst of events
+    # (e.g. many pods reconnecting to dependencies at once) can't spawn
+    # unbounded OS threads.
+    max_concurrent_background_threads = int(cfg(cp, 'certificates', 'max_concurrent_background_threads', 'MAX_CONCURRENT_BACKGROUND_THREADS', '20'))
 
     event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
 
@@ -155,6 +159,7 @@ def main():
     logger.info(f"FIPS checking:     {'enabled' if fips_compliance_enabled else 'disabled'}")
     logger.info(f"Large file threshold: >{large_file_cert_threshold} certs parsed in background")
     logger.info(f"Large file metrics cap: {large_file_metrics_cap} certs get full Prometheus tracking per bundle")
+    logger.info(f"Max concurrent background threads: {max_concurrent_background_threads}")
     logger.info(f"Metrics port:      {metrics_port}")
     logger.info(f"Health port:       {health_port}")
     logger.info(f"Alert threshold:   {alert_threshold} days")
@@ -214,7 +219,8 @@ def main():
                                    port_probe_connect_delay=port_probe_connect_delay,
                                    tls_outbound_ports=tls_outbound_ports,
                                    large_file_cert_threshold=large_file_cert_threshold,
-                                   large_file_metrics_cap=large_file_metrics_cap)
+                                   large_file_metrics_cap=large_file_metrics_cap,
+                                   max_concurrent_background_threads=max_concurrent_background_threads)
 
     health = HealthServer(
         analyzer=analyzer,

--- a/agent/config.py
+++ b/agent/config.py
@@ -118,6 +118,12 @@ def main():
     # (e.g. many pods reconnecting to dependencies at once) can't spawn
     # unbounded OS threads.
     max_concurrent_background_threads = int(cfg(cp, 'certificates', 'max_concurrent_background_threads', 'MAX_CONCURRENT_BACKGROUND_THREADS', '20'))
+    # Caps how many distinct (process, parent_process) pairs get their own
+    # tls_certificate_process_info series per cert -- otherwise a file opened
+    # by many unrelated binaries over the process's lifetime (e.g. the system
+    # CA trust bundle) accumulates one permanent series per distinct process,
+    # forever, regardless of known_certs cache size.
+    max_processes_per_cert = int(cfg(cp, 'certificates', 'max_processes_per_cert', 'MAX_PROCESSES_PER_CERT', '20'))
 
     event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
 
@@ -160,6 +166,7 @@ def main():
     logger.info(f"Large file threshold: >{large_file_cert_threshold} certs parsed in background")
     logger.info(f"Large file metrics cap: {large_file_metrics_cap} certs get full Prometheus tracking per bundle")
     logger.info(f"Max concurrent background threads: {max_concurrent_background_threads}")
+    logger.info(f"Max processes tracked per cert: {max_processes_per_cert}")
     logger.info(f"Metrics port:      {metrics_port}")
     logger.info(f"Health port:       {health_port}")
     logger.info(f"Alert threshold:   {alert_threshold} days")
@@ -220,7 +227,8 @@ def main():
                                    tls_outbound_ports=tls_outbound_ports,
                                    large_file_cert_threshold=large_file_cert_threshold,
                                    large_file_metrics_cap=large_file_metrics_cap,
-                                   max_concurrent_background_threads=max_concurrent_background_threads)
+                                   max_concurrent_background_threads=max_concurrent_background_threads,
+                                   max_processes_per_cert=max_processes_per_cert)
 
     health = HealthServer(
         analyzer=analyzer,

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -305,6 +305,11 @@ class PrometheusMetrics:
             node_name=info.node_name,
             checksum=info.checksum,
         ).set(1)
+        # The discovering process is always allowed (an empty seen-set can
+        # never already be at the fan-out cap) — seed it here so a later
+        # cache-hit re-access by this same process isn't mistaken for a new
+        # distinct process by CertificateAnalyzer._record_cert_process_access.
+        info._seen_processes.add((info.process, info.parent_process))
 
         self.cert_expiry_days.labels(**labels).set(days_left)
         self.cert_expiry_timestamp.labels(**labels).set(info.not_after.timestamp())
@@ -391,14 +396,14 @@ class PrometheusMetrics:
         previously removed them on eviction, so every certificate ever seen
         stayed resident in the registry forever.
 
-        cert_process_info is only partially cleaned up: it fans out to one
-        series per distinct process that has accessed this cert, but only the
-        most recently recorded (process, parent_process) pair is retained on
-        CertificateInfo, so earlier distinct-process series for the same cert
-        can't be reconstructed and removed here. tls_negotiated_protocol
-        (TLS-probe discoveries only) isn't cleaned up at all for the same
-        reason — protocol/cipher aren't persisted on CertificateInfo after the
-        probe completes.
+        cert_process_info fans out to one series per distinct process that
+        has accessed this cert, capped at max_processes_per_cert -- every
+        (process, parent_process) pair that was ever actually given a series
+        is tracked in info._seen_processes, so all of them are removed here,
+        not just the most recent. tls_negotiated_protocol (TLS-probe
+        discoveries only) still isn't cleaned up: protocol/cipher aren't
+        persisted on CertificateInfo after the probe completes, so there's
+        nothing to reconstruct that label tuple from.
         """
         shared_labels = (
             info.path, info.subject[:100], info.issuer[:100], info.serial_number,
@@ -413,10 +418,12 @@ class PrometheusMetrics:
                       self.cert_valid_from, self.cert_last_accessed):
             self._safe_remove(gauge, shared_labels)
 
-        self._safe_remove(self.cert_process_info, (
-            info.path, str(info.cert_index), info.serial_number,
-            info.process, info.parent_process, info.node_name, info.checksum,
-        ))
+        seen_processes = getattr(info, '_seen_processes', None) or {(info.process, info.parent_process)}
+        for process, parent_process in seen_processes:
+            self._safe_remove(self.cert_process_info, (
+                info.path, str(info.cert_index), info.serial_number,
+                process, parent_process, info.node_name, info.checksum,
+            ))
 
         self._safe_remove(self.cert_expired, (
             info.path, str(info.cert_index), info.pod_name, info.namespace,
@@ -482,6 +489,11 @@ class PrometheusMetrics:
         A distinct (process, parent_process) label pair is its own Prometheus series,
         so repeated calls for different processes accumulate into a multi-process view
         of who has loaded this cert, rather than overwriting the original discoverer.
+
+        This method always writes the series unconditionally — capping the
+        number of distinct processes tracked per cert (max_processes_per_cert)
+        is the caller's job: see CertificateAnalyzer._record_cert_process_access,
+        which decides whether to call this at all.
         """
         self.cert_process_info.labels(
             cert_path=info.path,

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -371,6 +371,81 @@ class PrometheusMetrics:
             checksum=info.checksum,
         ).set(1 if info.is_self_signed else 0)
 
+    @staticmethod
+    def _safe_remove(metric, labelvalues: tuple) -> None:
+        """Remove a label-set if present; a missing series (never set, or
+        already removed) is not an error here."""
+        try:
+            metric.remove(*labelvalues)
+        except KeyError:
+            pass
+
+    def remove_certificate_metrics(self, info: CertificateInfo) -> None:
+        """
+        Remove the per-cert Gauge series written by update_certificate_metrics.
+
+        Called from LRUCache's on_evict callback when a cert falls out of
+        known_certs, so Prometheus's own memory tracks cache occupancy instead
+        of growing for the entire life of the process — update_certificate_metrics
+        creates ~10 new label-sets per newly-discovered cert and nothing
+        previously removed them on eviction, so every certificate ever seen
+        stayed resident in the registry forever.
+
+        cert_process_info is only partially cleaned up: it fans out to one
+        series per distinct process that has accessed this cert, but only the
+        most recently recorded (process, parent_process) pair is retained on
+        CertificateInfo, so earlier distinct-process series for the same cert
+        can't be reconstructed and removed here. tls_negotiated_protocol
+        (TLS-probe discoveries only) isn't cleaned up at all for the same
+        reason — protocol/cipher aren't persisted on CertificateInfo after the
+        probe completes.
+        """
+        shared_labels = (
+            info.path, info.subject[:100], info.issuer[:100], info.serial_number,
+            info.common_name, ','.join(info.san_dns_names), ','.join(info.san_ip_addresses),
+            str(info.cert_index), info.pod_name, info.namespace, info.workload_kind,
+            info.workload_name, info.node_name, info.app_label, info.container_name,
+            info.checksum,
+            ','.join(info.key_usage) if info.key_usage else '',
+            ','.join(info.extended_key_usage) if info.extended_key_usage else '',
+        )
+        for gauge in (self.cert_expiry_days, self.cert_expiry_timestamp,
+                      self.cert_valid_from, self.cert_last_accessed):
+            self._safe_remove(gauge, shared_labels)
+
+        self._safe_remove(self.cert_process_info, (
+            info.path, str(info.cert_index), info.serial_number,
+            info.process, info.parent_process, info.node_name, info.checksum,
+        ))
+
+        self._safe_remove(self.cert_expired, (
+            info.path, str(info.cert_index), info.pod_name, info.namespace,
+            info.workload_kind, info.workload_name, info.node_name,
+            info.issuer[:100], info.serial_number, info.checksum,
+        ))
+
+        for threshold in (7, 30, 90):
+            self._safe_remove(self.cert_expiring_soon, (
+                info.path, str(threshold), str(info.cert_index), info.pod_name,
+                info.namespace, info.workload_kind, info.workload_name,
+                info.node_name, info.issuer[:100], info.serial_number, info.checksum,
+            ))
+
+        if info.key_algorithm:
+            self._safe_remove(self.cert_fips_compliant, (
+                info.path, str(info.cert_index), info.pod_name, info.namespace,
+                info.workload_kind, info.workload_name, info.node_name,
+                info.key_algorithm, info.signature_hash, str(info.key_size),
+                info.curve_name, info.issuer[:100], info.serial_number, info.checksum,
+            ))
+
+        is_ca_label = 'true' if info.is_ca else ('false' if info.is_ca is False else 'unknown')
+        self._safe_remove(self.cert_self_signed, (
+            info.path, str(info.cert_index), info.pod_name, info.namespace,
+            info.workload_kind, info.workload_name, info.node_name,
+            is_ca_label, info.issuer[:100], info.serial_number, info.checksum,
+        ))
+
     def update_last_accessed(self, info: CertificateInfo) -> None:
         """
         Refresh only the last-accessed timestamp for an already-known certificate.

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -269,6 +269,12 @@ class PrometheusMetrics:
 
     def update_certificate_metrics(self, info: CertificateInfo):
         """Update Prometheus metrics for a certificate"""
+        # Computed once and reused below instead of re-evaluating the
+        # days_until_expiry property (each call does its own datetime.utcnow())
+        # once per Gauge that needs it -- cheap for a single cert, but this runs
+        # per-cert across a whole bundle (up to large_file_metrics_cap certs).
+        now = datetime.utcnow()
+        days_left = info.days_until_expiry
         labels = {
             'cert_path':        info.path,
             'subject':          info.subject[:100],
@@ -300,10 +306,10 @@ class PrometheusMetrics:
             checksum=info.checksum,
         ).set(1)
 
-        self.cert_expiry_days.labels(**labels).set(info.days_until_expiry)
+        self.cert_expiry_days.labels(**labels).set(days_left)
         self.cert_expiry_timestamp.labels(**labels).set(info.not_after.timestamp())
         self.cert_valid_from.labels(**labels).set(info.not_before.timestamp())
-        self.cert_last_accessed.labels(**labels).set(datetime.utcnow().timestamp())
+        self.cert_last_accessed.labels(**labels).set(now.timestamp())
 
         self.cert_expired.labels(
             cert_path=info.path,
@@ -331,7 +337,7 @@ class PrometheusMetrics:
                 issuer=info.issuer[:100],
                 serial=info.serial_number,
                 checksum=info.checksum,
-            ).set(1 if 0 < info.days_until_expiry < threshold else 0)
+            ).set(1 if 0 < days_left < threshold else 0)
 
         if info.key_algorithm:
             self.cert_fips_compliant.labels(

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from dataclasses import dataclass, field
-from typing import Optional, List
+from typing import Optional, List, Set, Tuple
 
 
 @dataclass
@@ -60,6 +60,14 @@ class CertificateInfo:
     # verifies against its own public key). Root CA certificates are legitimately
     # self-signed; self-signed leaf certificates are typically a configuration risk.
     is_self_signed: bool = False
+    # Distinct (process, parent_process) pairs already given their own
+    # tls_certificate_process_info series for this cert, capped at
+    # max_processes_per_cert (see CertificateAnalyzer._record_cert_process_access).
+    # Internal bookkeeping only — not cert data, not published to Kafka, and
+    # excluded from repr/equality so it doesn't affect anything that compares
+    # or prints a CertificateInfo. Dies naturally when the cert is LRU-evicted
+    # from known_certs, so it needs no separate cleanup of its own.
+    _seen_processes: Set[Tuple[str, str]] = field(default_factory=set, repr=False, compare=False)
 
     @property
     def days_until_expiry(self) -> float:

--- a/cert-analyzer.service
+++ b/cert-analyzer.service
@@ -47,7 +47,15 @@ ReadWritePaths=/var/log/cert-analyzer
 
 # Resource limits
 LimitNOFILE=65536
-MemoryMax=256M
+# Raised from 256M as a stopgap: Prometheus metric memory grows with every
+# distinct cert this process discovers and previously was never reclaimed on
+# LRU eviction (see PrometheusMetrics.remove_certificate_metrics, wired up in
+# CertificateAnalyzer._deindex_known_cert). A single first-time scan of the
+# system CA trust bundle alone added ~32M in one burst; 256M had already been
+# touched (systemd reported peak == max) before that eviction-cleanup fix
+# existed. Revisit this number after that fix has had time to bound growth
+# for real, rather than treating 384M as the new steady-state ceiling.
+MemoryMax=384M
 CPUQuota=200%
 
 [Install]

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -2233,6 +2233,96 @@ class TestKnownCertsIndex:
         assert len(analyzer._known_paths) == 0
 
 
+class TestMetricsCleanupOnEviction:
+    """
+    Tests for PrometheusMetrics.remove_certificate_metrics, wired into
+    CertificateAnalyzer._deindex_known_cert (known_certs' on_evict callback).
+
+    Before this, evicting a cert from known_certs only cleaned up the
+    _known_paths index -- the ~10 per-cert Prometheus Gauge series created by
+    update_certificate_metrics were never removed, so Prometheus registry
+    memory grew for the entire life of the process regardless of cache size.
+    A single first-time scan of the system CA trust bundle (146 certs, all
+    under large_file_metrics_cap) added ~32MB in one burst in production.
+    """
+
+    @staticmethod
+    def _samples_for(gauge, cert_path):
+        return [
+            s for metric in gauge.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == cert_path
+        ]
+
+    def test_per_cert_series_removed_on_lru_eviction(self, analyzer, temp_dir):
+        """
+        Evicting a cert from known_certs must remove its cert_expiry_days,
+        cert_expired, cert_process_info, and cert_self_signed series --
+        otherwise Prometheus keeps every cert ever discovered in memory
+        forever, independent of whether the LRU cache actually evicted it.
+        """
+        import cert_analyzer as _ca
+
+        cert, _ = TestCertificateGeneration.generate_certificate("evict-me.example.com", 365)
+        path = os.path.join(temp_dir, "evict-me.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        cert_infos = analyzer.analyze_certificate(path, "test-proc", 111)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+        target_key = cert_infos[0].unique_key
+
+        gauges = (
+            analyzer.metrics.cert_expiry_days,
+            analyzer.metrics.cert_expired,
+            analyzer.metrics.cert_process_info,
+            analyzer.metrics.cert_self_signed,
+        )
+
+        assert target_key in analyzer.known_certs
+        for gauge in gauges:
+            assert self._samples_for(gauge, path), \
+                f"{gauge._name} should have a series before eviction"
+
+        # Fill the rest of the cache directly (cheap — bypasses callbacks,
+        # same approach as TestKnownCertsIndex.test_index_cleaned_up_on_lru_eviction)
+        # so the next real insert pushes `target_key` out as the LRU-oldest entry.
+        for i in range(_ca.CACHE_MAX_SIZE - 1):
+            analyzer.known_certs._store[f"filler:{i}:serial"] = None
+        filler = CertificateInfo(
+            path="/tmp/new-entry.pem", subject='CN=y', issuer='CN=ca',
+            serial_number='2',
+            not_before=datetime.utcnow() - timedelta(days=1),
+            not_after=datetime.utcnow() + timedelta(days=365),
+            process='test', pid=1,
+        )
+        analyzer.known_certs[filler.unique_key] = filler
+
+        assert target_key not in analyzer.known_certs
+        for gauge in gauges:
+            assert not self._samples_for(gauge, path), \
+                f"{gauge._name} series must be removed when its cert is evicted"
+
+    def test_metrics_removal_ignores_entries_missing_fields(self, analyzer):
+        """
+        An evicted entry with a .path but missing other CertificateInfo
+        fields (e.g. a minimal stub, mirroring how
+        test_index_ignores_entries_without_a_path covers a bare None value)
+        must not crash metric removal -- it should degrade to a debug log,
+        same as the _known_paths index already does.
+        """
+        import types
+
+        stub = types.SimpleNamespace(path="/tmp/stub-only-path.pem")
+        analyzer.known_certs["stub:0:serial"] = stub
+        assert "/tmp/stub-only-path.pem" in analyzer._known_paths
+
+        # Must not raise, even though remove_certificate_metrics will hit an
+        # AttributeError reading stub.subject/issuer/etc.
+        analyzer.known_certs.discard("stub:0:serial")
+
+        assert "/tmp/stub-only-path.pem" not in analyzer._known_paths
+
+
 class TestCacheHitReDetection:
     """
     Tests for the "already known certificate file" branch in process_event

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -2322,6 +2322,136 @@ class TestMetricsCleanupOnEviction:
 
         assert "/tmp/stub-only-path.pem" not in analyzer._known_paths
 
+    def test_all_tracked_process_series_removed_on_eviction(self, analyzer, temp_dir):
+        """
+        remove_certificate_metrics must clean up every distinct process
+        series tracked in cert_process_info for an evicted cert, not just
+        the most recently recorded one -- possible now that CertificateInfo
+        tracks its full _seen_processes set (added for the fan-out cap),
+        closing the "only partially cleaned up" gap this class's docstring
+        used to note.
+        """
+        import cert_analyzer as _ca
+
+        cert, _ = TestCertificateGeneration.generate_certificate("multi-proc.example.com", 365)
+        path = os.path.join(temp_dir, "multi-proc.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        cert_infos = analyzer.analyze_certificate(path, "discoverer-proc", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+        target = cert_infos[0]
+        target_key = target.unique_key
+
+        for i in range(3):
+            analyzer._record_cert_process_access(target, f"/usr/bin/proc{i}", "")
+
+        samples_before = self._samples_for(analyzer.metrics.cert_process_info, path)
+        assert len(samples_before) == 4, "discoverer + 3 distinct re-accessing processes"
+
+        # Fill the rest of the cache and evict `target` as the LRU-oldest entry
+        # (same approach as test_per_cert_series_removed_on_lru_eviction above).
+        for i in range(_ca.CACHE_MAX_SIZE - 1):
+            analyzer.known_certs._store[f"filler:{i}:serial"] = None
+        filler = CertificateInfo(
+            path="/tmp/new-entry.pem", subject='CN=y', issuer='CN=ca',
+            serial_number='2',
+            not_before=datetime.utcnow() - timedelta(days=1),
+            not_after=datetime.utcnow() + timedelta(days=365),
+            process='test', pid=1,
+        )
+        analyzer.known_certs[filler.unique_key] = filler
+
+        assert target_key not in analyzer.known_certs
+        assert self._samples_for(analyzer.metrics.cert_process_info, path) == [], \
+            "all 4 process series must be removed, not just the most recent one"
+
+
+class TestCertProcessInfoFanoutCap:
+    """
+    Tests for CertificateAnalyzer._record_cert_process_access's cap on
+    distinct (process, parent_process) pairs tracked per cert
+    (max_processes_per_cert).
+
+    TestMetricsCleanupOnEviction closes the leak for certs that actually get
+    LRU-evicted, but a file re-accessed by many distinct processes (e.g. the
+    system CA trust bundle touched by curl, dnf, git, python, docker, ...)
+    may never be evicted while still actively in use -- without this cap,
+    cert_process_info would keep growing by one series per new distinct
+    process, forever, regardless of known_certs cache size.
+    """
+
+    @staticmethod
+    def _samples_for(gauge, cert_path):
+        return [
+            s for metric in gauge.collect()
+            for s in metric.samples
+            if s.labels.get('cert_path') == cert_path
+        ]
+
+    def test_distinct_processes_capped_at_max_processes_per_cert(self, analyzer, temp_dir):
+        """Only the first max_processes_per_cert distinct processes (including
+        the discoverer) ever get their own cert_process_info series."""
+        analyzer._max_processes_per_cert = 3
+        cert, _ = TestCertificateGeneration.generate_certificate("fanout.example.com", 365)
+        path = os.path.join(temp_dir, "fanout.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        cert_infos = analyzer.analyze_certificate(path, "discoverer-proc", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+        cert_info = cert_infos[0]
+
+        for i in range(10):
+            analyzer._record_cert_process_access(cert_info, f"/usr/bin/proc{i}", "")
+
+        samples = self._samples_for(analyzer.metrics.cert_process_info, path)
+        assert len(samples) == 3, \
+            f"expected exactly max_processes_per_cert (3) series, got {len(samples)}"
+
+    def test_repeat_access_by_already_tracked_process_is_not_capped(self, analyzer, temp_dir):
+        """
+        Re-access by a process that already has a series must keep refreshing
+        it rather than being mistaken for a new distinct process competing
+        for the (already-exhausted) cap.
+        """
+        analyzer._max_processes_per_cert = 1
+        cert, _ = TestCertificateGeneration.generate_certificate("repeat.example.com", 365)
+        path = os.path.join(temp_dir, "repeat.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        cert_infos = analyzer.analyze_certificate(path, "discoverer-proc", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+        cert_info = cert_infos[0]
+
+        # Cap (1) is already exhausted by the discoverer alone.
+        analyzer._record_cert_process_access(cert_info, "discoverer-proc", "")
+        analyzer._record_cert_process_access(cert_info, "discoverer-proc", "")
+
+        samples = self._samples_for(analyzer.metrics.cert_process_info, path)
+        assert len(samples) == 1
+        assert samples[0].labels.get('process') == 'discoverer-proc'
+
+    def test_process_dropped_by_cap_increments_error_metric(self, analyzer, temp_dir):
+        """A process rejected by the cap must be observable, not silent."""
+        analyzer._max_processes_per_cert = 1
+        cert, _ = TestCertificateGeneration.generate_certificate("capmetric.example.com", 365)
+        path = os.path.join(temp_dir, "capmetric.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        cert_infos = analyzer.analyze_certificate(path, "discoverer-proc", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+        cert_info = cert_infos[0]
+
+        before = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='process_fanout_cap_reached'
+        )._value.get()
+
+        analyzer._record_cert_process_access(cert_info, "/usr/bin/other", "")
+
+        after = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='process_fanout_cap_reached'
+        )._value.get()
+        assert after == before + 1
+
 
 class TestCacheHitReDetection:
     """


### PR DESCRIPTION
…g paths

Caps concurrent TLS-probe/large-file-parse threads via a semaphore instead of spawning an unbounded OS thread per event, replaces an O(cache-size) scan with the existing O(1) known-paths index for Java-FIPS/in-memory cert re-detection, and computes days_until_expiry/utcnow once per metrics update instead of 5 times.