### PR TITLE
Add cert chain length listing and missing-intermediate detection

### DIFF
--- a/extras/kafka/KAFKA-README.md
+++ b/extras/kafka/KAFKA-README.md
@@ -125,6 +125,40 @@ python3 extras/kafka/view_kafka_messages.py --host localhost --port 9092 --topic
 It reads whatever's already on the topic and exits after 5s of no new
 messages (or Ctrl-C to stop early).
 
+### Certificate chain lengths
+
+`list_cert_chains.py` groups discovery events by `path` and reports how
+many certificates were found at each path (leaf, intermediates, root),
+ordered by `cert_index`:
+
+```bash
+python3 extras/kafka/list_cert_chains.py --host localhost --port 9092 --topic cert-analyzer-events
+```
+
+Since Kafka only receives *first-time* discoveries, a chain whose
+intermediates were already known before Kafka was enabled will show up as
+incomplete — the script flags this with a gap note rather than guessing.
+
+Separately, the script also flags a real chain-of-trust problem: any
+non-root cert in a bundle whose issuer doesn't match any other cert's
+subject in that same bundle, i.e. the file itself — not just the Kafka
+topic — is missing an intermediate. This is the "server forgot to include
+its intermediate CA" misconfiguration, and shows up per-path as a `⚠
+missing intermediate` line plus a summary at the end.
+
+To generate a test case for it:
+
+```bash
+python3 extras/test_analyzer.py   # also (re)generates broken-chain-missing-intermediate.crt
+sudo cp test-certs/broken-chain-missing-intermediate.crt /etc/pki/tls/certs/
+cat /etc/pki/tls/certs/broken-chain-missing-intermediate.crt > /dev/null  # trigger detection
+```
+
+`generate_broken_chain()` in `test_analyzer.py` builds a real root ->
+intermediate -> leaf chain, signs the leaf with the intermediate, then
+writes out only the leaf and root — discarding the intermediate — so the
+bundle looks like a server that forgot to ship it.
+
 ---
 
 ## View the data in a browser (Kafdrop)

--- a/extras/kafka/list_cert_chains.py
+++ b/extras/kafka/list_cert_chains.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Groups cert-analyzer's Kafka discovery events by certificate path and
+reports the chain length (leaf + intermediates + root) found at each path.
+
+cert-analyzer publishes one `certificate_discovered` event per certificate
+in a bundle, with `cert_index` numbering position within that file/bundle
+(0 = leaf). This script reads whatever's on the topic, groups by `path`,
+and prints each chain ordered by `cert_index` with subject/issuer so you
+can see how deep a given trust chain is.
+
+Note: Kafka only receives *first-time* discoveries (see KAFKA-README.md),
+so a chain whose intermediates were already known before Kafka was enabled
+will show up here as incomplete (a gap in cert_index) -- this script flags
+that rather than guessing at the missing entries.
+
+Separately, this also flags a real chain-of-trust problem: any non-root
+cert in a bundle whose issuer doesn't match any other cert's subject in
+that same bundle -- i.e. the file itself is missing an intermediate,
+regardless of what Kafka has or hasn't seen before. This is the "server
+forgot to include its intermediate CA" misconfiguration.
+
+Usage: python3 list_cert_chains.py [--host HOST] [--port PORT] [--topic TOPIC]
+"""
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+try:
+    from kafka import KafkaConsumer
+    from kafka.errors import KafkaError
+except ImportError:
+    print("ERROR: kafka-python is not installed. Install it with:", file=sys.stderr)
+    print("       pip install kafka-python", file=sys.stderr)
+    sys.exit(1)
+
+IDLE_TIMEOUT_MS = 5000
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost", help="Kafka broker IP/hostname (default: localhost)")
+    parser.add_argument("--port", type=int, default=9092, help="Kafka broker port (default: 9092)")
+    parser.add_argument("--topic", default="cert-analyzer-events", help="Topic to consume (default: cert-analyzer-events)")
+    return parser.parse_args()
+
+
+def describe(entry: dict) -> str:
+    cn = entry.get("common_name") or entry.get("subject") or "(no subject)"
+    if entry.get("is_self_signed"):
+        role = "root (self-signed)"
+    elif entry.get("is_ca"):
+        role = "intermediate CA"
+    else:
+        role = "leaf"
+    return f"{cn}  [{role}, issuer={entry.get('issuer') or '(none)'}]"
+
+
+def find_missing_intermediates(by_index: dict) -> list:
+    """
+    Returns [(cert_index, entry, missing_issuer_subject), ...] for every
+    non-self-signed cert in this bundle whose issuer doesn't match any
+    other cert's subject in the same bundle -- i.e. its issuing CA cert
+    is absent from the file.
+
+    Only meaningful for bundles that already contain more than one cert --
+    a lone leaf cert (a single TLS probe capture, a standalone entitlement
+    cert, etc.) never embeds its own issuer by design, so checking those
+    would just flag every single-cert file in existence.
+    """
+    if len(by_index) <= 1:
+        return []
+    subjects = {entry.get("subject") for entry in by_index.values()}
+    missing = []
+    for idx in sorted(by_index):
+        entry = by_index[idx]
+        if entry.get("is_self_signed"):
+            continue
+        issuer = entry.get("issuer")
+        if issuer and issuer not in subjects:
+            missing.append((idx, entry, issuer))
+    return missing
+
+
+def main() -> None:
+    args = parse_args()
+    bootstrap_servers = f"{args.host}:{args.port}"
+
+    print(f"Connecting to {bootstrap_servers}, topic '{args.topic}'...")
+    print(f"Reading available messages (stops after {IDLE_TIMEOUT_MS // 1000}s of no new ones, or Ctrl-C).\n")
+
+    try:
+        consumer = KafkaConsumer(
+            args.topic,
+            bootstrap_servers=bootstrap_servers,
+            auto_offset_reset='earliest',
+            enable_auto_commit=False,
+            consumer_timeout_ms=IDLE_TIMEOUT_MS,
+        )
+    except KafkaError as e:
+        print(f"ERROR: could not connect to {bootstrap_servers}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    chains = defaultdict(dict)  # path -> {cert_index: event}
+    count = 0
+    try:
+        for message in consumer:
+            count += 1
+            try:
+                payload = json.loads(message.value.decode('utf-8'))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            path = payload.get("path")
+            if not path:
+                continue
+            chains[path][payload.get("cert_index", 0)] = payload
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    finally:
+        consumer.close()
+
+    print(f"{count} message(s) read, {len(chains)} distinct path(s).\n")
+
+    if not chains:
+        return
+
+    paths_with_missing_intermediates = []
+
+    for path in sorted(chains):
+        by_index = chains[path]
+        indices = sorted(by_index)
+        chain_len = indices[-1] + 1
+        seen_len = len(indices)
+        gap_note = ""
+        if seen_len != chain_len:
+            gap_note = f"  (only {seen_len} of {chain_len} positions seen on topic -- some certs were already known before discovery)"
+
+        missing_intermediates = find_missing_intermediates(by_index)
+        if missing_intermediates:
+            paths_with_missing_intermediates.append(path)
+
+        print(f"── {path} ──")
+        print(f"chain length: {chain_len}{gap_note}")
+        for idx in indices:
+            print(f"  [{idx}] {describe(by_index[idx])}")
+        for idx, entry, issuer in missing_intermediates:
+            cn = entry.get("common_name") or entry.get("subject") or "(no subject)"
+            print(f"  ⚠ missing intermediate: cert [{idx}] '{cn}' is issued by '{issuer}', which is not present in this bundle")
+        print()
+
+    if paths_with_missing_intermediates:
+        print(f"── Summary: {len(paths_with_missing_intermediates)} path(s) with a missing intermediate ──")
+        for path in paths_with_missing_intermediates:
+            print(f"  {path}")
+        print()
+
+
+if __name__ == '__main__':
+    main()

--- a/extras/test_analyzer.py
+++ b/extras/test_analyzer.py
@@ -208,6 +208,80 @@ def generate_test_pkcs12(days_valid: int, output_path: str, cn: str = None, pass
     print(f"           Password: {password}")
 
 
+def generate_broken_chain(output_path: str, cn: str = None, root_cn: str = None, intermediate_cn: str = None):
+    """
+    Builds a 3-tier chain (root CA -> intermediate CA -> leaf) but writes only
+    the leaf and root certificates to output_path -- the intermediate signs
+    the leaf and is then discarded rather than written out. Simulates a
+    server misconfigured to serve an incomplete chain, for testing
+    cert-analyzer's/list_cert_chains.py's missing-intermediate detection.
+    """
+    if cn is None:
+        cn = "broken-chain.example.com"
+    if root_cn is None:
+        root_cn = "Test Root CA"
+    if intermediate_cn is None:
+        intermediate_cn = "Test Intermediate CA"
+
+    root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    root_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, root_cn)])
+    root_cert = (
+        x509.CertificateBuilder()
+        .subject_name(root_subject).issuer_name(root_subject)
+        .public_key(root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(root_key, hashes.SHA256())
+    )
+
+    intermediate_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    intermediate_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, intermediate_cn)])
+    intermediate_cert = (
+        x509.CertificateBuilder()
+        .subject_name(intermediate_subject).issuer_name(root_subject)
+        .public_key(intermediate_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=1825))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(root_key, hashes.SHA256())
+    )
+
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_subject).issuer_name(intermediate_subject)  # signed by the omitted intermediate
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
+        .sign(intermediate_key, hashes.SHA256())
+    )
+
+    # Intentionally omit the intermediate cert from the bundle -- that's the
+    # scenario under test. Order matches how a real misconfigured server
+    # would present it: leaf first, then whatever's left of the chain.
+    with open(output_path, "wb") as f:
+        f.write(leaf_cert.public_bytes(serialization.Encoding.PEM))
+        f.write(root_cert.public_bytes(serialization.Encoding.PEM))
+
+    key_path = output_path.replace('.crt', '.key')
+    with open(key_path, "wb") as f:
+        f.write(leaf_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
+
+    print(f"Generated: {output_path}")
+    print(f"           Leaf CN={cn}, issuer='{intermediate_cn}' (omitted), root='{root_cn}' (included)")
+    print(f"           Intermediate '{intermediate_cn}' deliberately left out of the bundle")
+
+
 if __name__ == '__main__':
     # Create test-certs directory in current repo
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -264,6 +338,12 @@ if __name__ == '__main__':
     for filename, days, cn in pkcs12_cases:
         generate_test_pkcs12(days, os.path.join(test_dir, filename), cn)
         print()
+
+    print("="*60)
+    print("Generating a chain with a missing intermediate...")
+    print("="*60)
+    generate_broken_chain(os.path.join(test_dir, "broken-chain-missing-intermediate.crt"))
+    print()
 
     print("="*60)
     print("\nTo test the analyzer:")


### PR DESCRIPTION
list_cert_chains.py groups cert-analyzer's Kafka discovery events by path and reports each bundle's chain length and structure. It also flags a real misconfiguration: a non-root cert in a multi-cert bundle whose issuer isn't present anywhere in that bundle (the "server forgot to include its intermediate CA" case), scoped to multi-cert bundles only since a lone leaf cert never embeds its own issuer by design.

test_analyzer.py gains generate_broken_chain() to produce a test fixture for this: a real root -> intermediate -> leaf chain with the intermediate deliberately left out of the written bundle.