### PR TITLE
Add expired-cert option to fresh-test-cert use case

### DIFF
--- a/extras/test-server/server.py
+++ b/extras/test-server/server.py
@@ -168,7 +168,15 @@ def make_handler(broadcaster: EventBroadcaster):
                     "description": uc.description,
                     "pipeline": uc.pipeline or [],
                     "params": [
-                        {"name": p.name, "label": p.label, "options": p.options, "default": p.default}
+                        {
+                            "name": p.name,
+                            "label": p.label,
+                            "type": p.type,
+                            "options": p.options,
+                            "default": p.default,
+                            "min": p.min,
+                            "max": p.max,
+                        }
                         for p in (uc.params or [])
                     ],
                 }

--- a/extras/test-server/static/app.css
+++ b/extras/test-server/static/app.css
@@ -66,13 +66,24 @@ h2 {
   color: #777;
 }
 
-.use-case-params select {
+.use-case-params select,
+.use-case-params input[type="number"] {
   font: inherit;
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   border: 1px solid var(--border);
   background: transparent;
   color: inherit;
+}
+
+.use-case-params input[type="number"] {
+  width: 4.5rem;
+}
+
+.use-case-params label:has(input[type="checkbox"]) {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 #use-case-list button {

--- a/extras/test-server/static/app.js
+++ b/extras/test-server/static/app.js
@@ -50,16 +50,29 @@ async function loadUseCases() {
       for (const param of uc.params) {
         const label = document.createElement('label');
         label.textContent = param.label;
-        const select = document.createElement('select');
-        select.dataset.paramName = param.name;
-        for (const option of param.options) {
-          const opt = document.createElement('option');
-          opt.value = option;
-          opt.textContent = option;
-          if (option === param.default) opt.selected = true;
-          select.appendChild(opt);
+        let control;
+        if (param.type === 'checkbox') {
+          control = document.createElement('input');
+          control.type = 'checkbox';
+          control.checked = param.default === 'true';
+        } else if (param.type === 'number') {
+          control = document.createElement('input');
+          control.type = 'number';
+          control.value = param.default;
+          if (param.min != null) control.min = param.min;
+          if (param.max != null) control.max = param.max;
+        } else {
+          control = document.createElement('select');
+          for (const option of param.options) {
+            const opt = document.createElement('option');
+            opt.value = option;
+            opt.textContent = option;
+            if (option === param.default) opt.selected = true;
+            control.appendChild(opt);
+          }
         }
-        label.appendChild(select);
+        control.dataset.paramName = param.name;
+        label.appendChild(control);
         paramsDiv.appendChild(label);
       }
       li.appendChild(paramsDiv);
@@ -97,8 +110,8 @@ async function runUseCase(id, button, li) {
   status.className = '';
   status.textContent = `Running '${id}'...`;
   const params = {};
-  for (const select of li.querySelectorAll('select[data-param-name]')) {
-    params[select.dataset.paramName] = select.value;
+  for (const el of li.querySelectorAll('[data-param-name]')) {
+    params[el.dataset.paramName] = el.type === 'checkbox' ? String(el.checked) : el.value;
   }
   try {
     const res = await fetch(`/api/run/${encodeURIComponent(id)}`, {

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -35,10 +35,13 @@ class UseCaseResult:
 
 @dataclass
 class UseCaseParam:
-    name: str                # key in the JSON body POSTed to /api/run/<id>
-    label: str                # shown next to the <select> in the UI
-    options: List[str]        # values shown and sent as-is; run() is responsible for validating
+    name: str                 # key in the JSON body POSTed to /api/run/<id>
+    label: str                 # shown next to the control in the UI
     default: str
+    type: str = "select"       # "select" | "checkbox" | "number" -- which control the UI renders
+    options: List[str] = None  # values shown/sent as-is for type="select"; run() is responsible for validating
+    min: str = None            # type="number": HTML min hint only, run() still validates server-side
+    max: str = None            # type="number": HTML max hint only, run() still validates server-side
 
 
 @dataclass
@@ -79,20 +82,35 @@ _GENERATED_CERT_DIR = Path("/dev/shm/certsight-test-server")
 _ALLOWED_KEY_SIZES = ["1024", "2048", "3072", "4096"]
 _DEFAULT_KEY_SIZE = "2048"
 
+_DEFAULT_EXPIRED = "false"
+_DEFAULT_EXPIRED_DAYS = "30"
+# Bounds an unauthenticated, client-supplied integer (same rationale as
+# _ALLOWED_KEY_SIZES above) -- 10 years is more than enough range for testing
+# either a barely-expired or a long-expired cert.
+_MIN_EXPIRED_DAYS = 1
+_MAX_EXPIRED_DAYS = 3650
 
-def _generate_self_signed_cert(cn: str, key_size: int) -> Tuple[bytes, bytes]:
-    """Returns (cert_pem, key_pem) for a fresh self-signed cert, 1yr validity, SAN=cn."""
+
+def _generate_self_signed_cert(cn: str, key_size: int, expired_days: int = 0) -> Tuple[bytes, bytes]:
+    """Returns (cert_pem, key_pem) for a self-signed cert, SAN=cn.
+
+    With expired_days=0 (default), the cert is valid for 1yr starting now, as
+    before. With expired_days=N>0, the cert instead covers the 1yr window
+    ending N days ago, so it's already expired.
+    """
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
     subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
     now = datetime.now(timezone.utc)
+    not_valid_after = now - timedelta(days=expired_days) if expired_days else now + timedelta(days=365)
+    not_valid_before = not_valid_after - timedelta(days=365)
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
         .issuer_name(issuer)
         .public_key(private_key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(now)
-        .not_valid_after(now + timedelta(days=365))
+        .not_valid_before(not_valid_before)
+        .not_valid_after(not_valid_after)
         .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
         .sign(private_key, hashes.SHA256())
     )
@@ -114,6 +132,19 @@ def _generate_and_read_fresh_cert(params: dict) -> UseCaseResult:
         )
     key_size = int(key_size_str)
 
+    expired_days = 0
+    if params.get("expired", _DEFAULT_EXPIRED) == "true":
+        expired_days_str = params.get("expired_days", _DEFAULT_EXPIRED_DAYS)
+        try:
+            expired_days = int(expired_days_str)
+        except (TypeError, ValueError):
+            return UseCaseResult(ok=False, detail=f"invalid expired_days '{expired_days_str}' -- must be an integer")
+        if not (_MIN_EXPIRED_DAYS <= expired_days <= _MAX_EXPIRED_DAYS):
+            return UseCaseResult(
+                ok=False,
+                detail=f"expired_days must be between {_MIN_EXPIRED_DAYS} and {_MAX_EXPIRED_DAYS}",
+            )
+
     token = uuid.uuid4().hex[:12]
     cn = f"certsight-test-{token}.local"
     path = _GENERATED_CERT_DIR / f"generated-{token}.crt"
@@ -124,7 +155,7 @@ def _generate_and_read_fresh_cert(params: dict) -> UseCaseResult:
     # a legitimate, informative outcome for a FIPS-focused test tool, not a
     # bug, so surface it as a normal use-case failure rather than a 500.
     try:
-        cert_pem, _key_pem = _generate_self_signed_cert(cn, key_size)
+        cert_pem, _key_pem = _generate_self_signed_cert(cn, key_size, expired_days)
     except Exception as e:
         return UseCaseResult(
             ok=False,
@@ -158,11 +189,16 @@ def _generate_and_read_fresh_cert(params: dict) -> UseCaseResult:
         if key_size < 2048
         else ""
     )
+    expiry_note = (
+        f" -- expired {expired_days}d ago, expect CertSight to flag this in the Kafka event"
+        if expired_days
+        else ""
+    )
     return UseCaseResult(
         ok=True,
         detail=(
             f"generated a fresh self-signed cert (CN={cn}, {key_size}-bit RSA) at "
-            f"{path} and cat'd it{fips_note} -- unique path and serial number "
+            f"{path} and cat'd it{fips_note}{expiry_note} -- unique path and serial number "
             "guarantee CertSight treats this as a first-time discovery, so a new "
             "Kafka event should always appear"
         ),
@@ -475,15 +511,32 @@ USE_CASES: List[UseCase] = [
             "Generates a new self-signed certificate at a unique path under "
             "/dev/shm and cat's it. Guaranteed to be a first-time discovery "
             "every click, so a new Kafka event always appears. Pick a key size "
-            "below 2048 bits to trigger a FIPS non-compliance finding."
+            "below 2048 bits to trigger a FIPS non-compliance finding, or check "
+            "'expired' to generate a cert that's already past its validity "
+            "window and verify CertSight flags that in the Kafka event."
         ),
         run=_generate_and_read_fresh_cert,
         params=[
             UseCaseParam(
                 name="key_size",
                 label="RSA key size",
+                type="select",
                 options=_ALLOWED_KEY_SIZES,
                 default=_DEFAULT_KEY_SIZE,
+            ),
+            UseCaseParam(
+                name="expired",
+                label="expired",
+                type="checkbox",
+                default=_DEFAULT_EXPIRED,
+            ),
+            UseCaseParam(
+                name="expired_days",
+                label="days ago",
+                type="number",
+                default=_DEFAULT_EXPIRED_DAYS,
+                min=str(_MIN_EXPIRED_DAYS),
+                max=str(_MAX_EXPIRED_DAYS),
             ),
         ],
         pipeline=[


### PR DESCRIPTION
Lets a user check a box (with a configurable days-ago field) to generate an already-expired self-signed cert instead of a valid one, so the resulting Kafka event can be checked for CertSight's expiry detection. Extends UseCaseParam to support checkbox/number controls in addition to the existing select dropdown.