### PR TITLE
Add schema_version to the Kafka certificate-discovery event

### DIFF
--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -31,6 +31,12 @@ _kafka_delivery_errors = Counter(
     ['node_name'],
 )
 
+# Bumped only when the message schema itself breaks compatibility (a field is
+# renamed, removed, or changes type) -- not on every release. Deliberately
+# separate from CERT_ANALYZER_VERSION, which bumps on every release whether
+# or not the payload shape changed; consumers should gate on this instead.
+KAFKA_SCHEMA_VERSION = 1
+
 
 class KafkaPublisher:
     """
@@ -66,6 +72,7 @@ class KafkaPublisher:
 
     Message schema (all fields present, empty string when not applicable):
     {
+        "schema_version":   1,
         "event_type":       "certificate_discovered",
         "detected_at":      "2026-03-31T10:00:00.000000",   # ISO 8601 UTC
         "path":             "/etc/pki/tls/certs/ca-bundle.crt",
@@ -231,6 +238,7 @@ class KafkaPublisher:
             return
 
         message = {
+            'schema_version':    KAFKA_SCHEMA_VERSION,
             'event_type':        'certificate_discovered',
             'detected_at':       datetime.utcnow().isoformat(),
             'path':              cert_info.path,

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -147,6 +147,7 @@ unique per certificate, and rotated when the cert at a path changes.
 
 ```json
 {
+  "schema_version":    1,
   "event_type":        "certificate_discovered",
   "detected_at":       "2026-06-10T10:00:00.000000",
 
@@ -210,6 +211,7 @@ unique per certificate, and rotated when the cert at a path changes.
 
 | Field | Type | Description |
 |---|---|---|
+| `schema_version` | int | Bumped only on breaking schema changes (renamed/removed field, changed type) — not on every release |
 | `event_type` | string | Always `"certificate_discovered"` |
 | `detected_at` | ISO 8601 | UTC timestamp when the event was processed |
 | `path` | string | Filesystem path of the certificate file |

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -5454,6 +5454,24 @@ class TestKafkaPublisher:
             msg = send_kwargs['value']
             assert msg['event_type'] == 'certificate_discovered'
 
+    def test_publish_sends_schema_version(self, monkeypatch, sample_cert_info):
+        """Published message contains schema_version, currently 1."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            publisher.publish(sample_cert_info)
+
+            _, send_kwargs = mock_producer.send.call_args
+            msg = send_kwargs['value']
+            assert msg['schema_version'] == _ca.KAFKA_SCHEMA_VERSION == 1
+
     def test_publish_message_contains_all_fields(self, monkeypatch, sample_cert_info):
         """Published message contains all expected CertificateInfo fields."""
         import agent.kafka as _ca


### PR DESCRIPTION
The published schema has grown to 40+ fields with no way for a consumer to detect a breaking change. schema_version is deliberately separate from CERT_ANALYZER_VERSION (which bumps every release regardless of payload shape) -- it only increments when the schema itself breaks compatibility, so consumers can gate on it directly.