### PR TITLE
Add blast-radius and chain-explorer links to the test console

### DIFF
--- a/extras/cert_blast_radius.py
+++ b/extras/cert_blast_radius.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+cert_blast_radius.py -- Generate a single self-contained, interactive HTML
+page: every certificate cert-analyzer has discovered, colored by expiry
+urgency. Click any certificate to reveal its blast radius -- every distinct
+(process, pod, namespace, node) Tetragon has observed loading it -- straight
+from cert-analyzer's own `tls_certificate_expiry_days` /
+`tls_certificate_process_info` Prometheus metrics, no separate inventory to
+keep in sync.
+
+Usage:
+    python3 cert_blast_radius.py -o blast_radius.html
+    python3 cert_blast_radius.py --prometheus-url http://prom.example:9090 -o out.html
+
+Queries Prometheus once at generation time; the output HTML is fully static
+and works offline after that (open it in any browser, no server needed).
+Stdlib only -- no third-party packages required.
+"""
+import argparse
+import json
+import math
+import sys
+import urllib.parse
+import urllib.request
+
+CATEGORICAL_SLOTS = 8
+# Matches the thresholds cert-analyzer's own tls_certificate_expiring_soon
+# metric buckets on (see extras/examples/grafana-dashboard.json).
+EXPIRY_THRESHOLDS = (0, 7, 30)  # expired / <7d critical / <30d warning / else good
+
+# Palette values (dataviz skill reference/palette.md), wired as CSS custom
+# properties in PAGE_CSS below so the page follows the OS/browser light-dark
+# preference automatically -- SVG marks reference them via fill="var(--...)"
+# rather than baking in one theme's hex values.
+PAGE_CSS = """
+:root {
+  color-scheme: light;
+  --surface: #fcfcfb; --page: #f9f9f7;
+  --primary: #0b0b0b; --secondary: #52514e; --muted: #898781;
+  --spoke: #c3c2b7; --border: rgba(11,11,11,0.10);
+  --good: #0ca30c; --warning: #fab219; --serious: #ec835a; --critical: #d03b3b;
+  --cat-1: #2a78d6; --cat-2: #008300; --cat-3: #e87ba4; --cat-4: #eda100;
+  --cat-5: #1baf7a; --cat-6: #eb6834; --cat-7: #4a3aa7; --cat-8: #e34948;
+  --other: #898781;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --surface: #1a1a19; --page: #0d0d0d;
+    --primary: #ffffff; --secondary: #c3c2b7; --muted: #898781;
+    --spoke: #383835; --border: rgba(255,255,255,0.10);
+    --good: #0ca30c; --warning: #fab219; --serious: #ec835a; --critical: #d03b3b;
+    --cat-1: #3987e5; --cat-2: #008300; --cat-3: #d55181; --cat-4: #c98500;
+    --cat-5: #199e70; --cat-6: #d95926; --cat-7: #9085e9; --cat-8: #e66767;
+    --other: #898781;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem; background: var(--page); color: var(--primary);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+.subtitle { color: var(--secondary); font-size: 0.9rem; margin: 0 0 1.5rem; }
+#overview {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px; max-width: 1100px;
+}
+.cert-card {
+  display: flex; align-items: center; gap: 10px; padding: 12px 14px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  cursor: pointer;
+}
+.cert-card:hover { border-color: var(--muted); }
+.cert-dot { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.cert-name { font-weight: 600; font-size: 0.92rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cert-meta { color: var(--secondary); font-size: 0.78rem; }
+#detail-header {
+  display: none; align-items: center; gap: 12px; margin-bottom: 1rem;
+}
+#back-btn {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 12px; font-size: 0.85rem; cursor: pointer; color: var(--primary);
+}
+#back-btn:hover { border-color: var(--muted); }
+.detail { display: none; max-width: 900px; }
+.detail-title { font-size: 1.1rem; font-weight: 600; margin: 0 0 0.25rem; }
+.detail-subtitle { color: var(--secondary); font-size: 0.85rem; margin: 0 0 1rem; }
+#legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 1rem; }
+.legend-item { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; color: var(--secondary); }
+.legend-swatch { width: 11px; height: 11px; border-radius: 2px; flex: none; }
+"""
+
+
+def prom_query(base_url, promql):
+    url = f"{base_url.rstrip('/')}/api/v1/query?{urllib.parse.urlencode({'query': promql})}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        payload = json.load(resp)
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Prometheus query failed: {payload}")
+    return payload["data"]["result"]
+
+
+def fetch_all_certs(base_url):
+    """One entry per (cert_path, cert_index) -- cert-analyzer's own cert identity key."""
+    results = prom_query(base_url, "tls_certificate_expiry_days")
+    certs = {}
+    for r in results:
+        m = r["metric"]
+        key = (m.get("cert_path", ""), m.get("cert_index", "0"))
+        certs[key] = {
+            "common_name": m.get("common_name") or m.get("subject") or m.get("cert_path") or "certificate",
+            "serial": m.get("serial", ""),
+            "days_left": float(r["value"][1]),
+            "leaves": [],
+        }
+    return certs
+
+
+def fetch_all_process_pairings(base_url, certs):
+    results = prom_query(base_url, "tls_certificate_process_info")
+    for r in results:
+        m = r["metric"]
+        key = (m.get("cert_path", ""), m.get("cert_index", "0"))
+        if key not in certs:
+            continue  # process-info series with no matching expiry series -- shouldn't normally happen
+        certs[key]["leaves"].append({
+            "process": m.get("process", "?"),
+            "node_name": m.get("node_name", "?"),
+            "pod_name": m.get("pod_name", ""),
+            "namespace": m.get("namespace", ""),
+        })
+
+
+def status_bucket(days_left):
+    if days_left < EXPIRY_THRESHOLDS[0]:
+        return "critical"
+    if days_left < EXPIRY_THRESHOLDS[1]:
+        return "serious"
+    if days_left < EXPIRY_THRESHOLDS[2]:
+        return "warning"
+    return "good"
+
+
+def days_label(days_left):
+    if days_left < 0:
+        return f"expired {abs(days_left):.0f}d ago"
+    return f"{days_left:.0f}d left"
+
+
+def assign_namespace_colors(all_certs):
+    namespaces = sorted({
+        leaf["namespace"] or "(none)"
+        for cert in all_certs.values() for leaf in cert["leaves"]
+    })
+    color_var = {}
+    for i, ns in enumerate(namespaces):
+        color_var[ns] = f"var(--cat-{i + 1})" if i < CATEGORICAL_SLOTS else "var(--other)"
+    return color_var
+
+
+def esc(s):
+    return (str(s).replace("&", "&amp;").replace("<", "&lt;")
+            .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def render_detail_svg(cert, ns_color):
+    leaves = cert["leaves"]
+    w = h = 640
+    cx, cy = w / 2, h / 2
+    radius = min(w, h) / 2 - 130
+    n = max(len(leaves), 1)
+
+    parts = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 {w} {h}">']
+
+    positions = []
+    for i in range(n):
+        angle = (2 * math.pi * i / n) - math.pi / 2
+        x = cx + radius * math.cos(angle)
+        y = cy + radius * math.sin(angle)
+        positions.append((x, y, angle))
+        parts.append(f'<line x1="{cx:.1f}" y1="{cy:.1f}" x2="{x:.1f}" y2="{y:.1f}" '
+                      f'stroke="var(--spoke)" stroke-width="1.5"/>')
+
+    for leaf, (x, y, angle) in zip(leaves, positions):
+        ns = leaf["namespace"] or "(none)"
+        color = ns_color.get(ns, "var(--other)")
+        parts.append(f'<circle cx="{x:.1f}" cy="{y:.1f}" r="8" fill="{color}" '
+                      f'stroke="var(--surface)" stroke-width="2"/>')
+        deg = math.degrees(angle) % 360
+        right_half = deg < 90 or deg > 270
+        anchor = "start" if right_half else "end"
+        label_x = x + (12 if right_half else -12)
+        detail_bits = [b for b in (leaf["pod_name"], leaf["namespace"]) if b] or [leaf["node_name"]]
+        detail = " / ".join(detail_bits[:2])
+        parts.append(f'<text x="{label_x:.1f}" y="{y - 3:.1f}" text-anchor="{anchor}" '
+                      f'font-size="11" font-weight="600" fill="var(--primary)">{esc(leaf["process"])}</text>')
+        parts.append(f'<text x="{label_x:.1f}" y="{y + 10:.1f}" text-anchor="{anchor}" '
+                      f'font-size="9.5" fill="var(--secondary)">{esc(detail)}</text>')
+
+    parts.append('<circle cx="{0}" cy="{1}" r="22" fill="var(--surface)" '
+                  'stroke="var(--primary)" stroke-width="2.5"/>'.format(cx, cy))
+    body_x, body_y = cx - 7, cy - 2
+    parts.append(f'<rect x="{body_x:.1f}" y="{body_y:.1f}" width="14" height="10" rx="2" fill="var(--primary)"/>')
+    parts.append(f'<path d="M {cx - 5:.1f} {body_y:.1f} v -5 a 5 5 0 0 1 10 0 v 5" '
+                  f'fill="none" stroke="var(--primary)" stroke-width="2.2"/>')
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def render_page(all_certs):
+    ns_color = assign_namespace_colors(all_certs)
+    ordered = sorted(all_certs.items(), key=lambda kv: kv[1]["days_left"])
+
+    overview_cards = []
+    detail_blocks = []
+    for idx, (_key, cert) in enumerate(ordered):
+        status = status_bucket(cert["days_left"])
+        overview_cards.append(
+            f'<div class="cert-card" onclick="showDetail({idx})">'
+            f'<span class="cert-dot" style="background: var(--{status})"></span>'
+            f'<div><div class="cert-name">{esc(cert["common_name"])}</div>'
+            f'<div class="cert-meta">{esc(days_label(cert["days_left"]))} '
+            f'&middot; {len(cert["leaves"])} process pairing(s)</div></div></div>'
+        )
+
+        pod_count = len({leaf["pod_name"] for leaf in cert["leaves"] if leaf["pod_name"]})
+        ns_count = len({leaf["namespace"] for leaf in cert["leaves"] if leaf["namespace"]})
+        node_count = len({leaf["node_name"] for leaf in cert["leaves"]})
+        subtitle_bits = [f'{len(cert["leaves"])} process(es)']
+        if pod_count:
+            subtitle_bits.append(f"{pod_count} pod(s)")
+        if ns_count:
+            subtitle_bits.append(f"{ns_count} namespace(s)")
+        subtitle_bits.append(f"{node_count} node(s)")
+
+        detail_blocks.append(
+            f'<div class="detail" id="detail-{idx}">'
+            f'<div class="detail-title">{esc(cert["common_name"])}</div>'
+            f'<div class="detail-subtitle">{esc(" · ".join(subtitle_bits))}'
+            f'{" &middot; serial " + esc(cert["serial"][:16]) if cert["serial"] else ""}</div>'
+            f'{render_detail_svg(cert, ns_color)}'
+            f'</div>'
+        )
+
+    legend_items = sorted((ns, c) for ns, c in ns_color.items() if c != "var(--other)")
+    if any(c == "var(--other)" for c in ns_color.values()):
+        legend_items.append(("Other", "var(--other)"))
+    legend_html = "".join(
+        f'<div class="legend-item"><span class="legend-swatch" style="background:{color}"></span>{esc(ns)}</div>'
+        for ns, color in legend_items
+    )
+
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Certificate Blast Radius</title>
+<style>{PAGE_CSS}</style>
+</head>
+<body>
+<h1>Certificate Blast Radius</h1>
+<p class="subtitle">{len(all_certs)} certificate(s) monitored &middot; click one to see every process, pod, and node that loads it</p>
+
+<div id="overview">{"".join(overview_cards)}</div>
+
+<div id="detail-header">
+  <button id="back-btn" onclick="showOverview()">&larr; All certificates</button>
+</div>
+{"".join(detail_blocks)}
+<div id="legend">{legend_html}</div>
+
+<script>
+function showDetail(idx) {{
+  document.getElementById('overview').style.display = 'none';
+  document.getElementById('detail-header').style.display = 'flex';
+  document.getElementById('legend').style.display = 'flex';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+  document.getElementById('detail-' + idx).style.display = 'block';
+}}
+function showOverview() {{
+  document.getElementById('overview').style.display = 'grid';
+  document.getElementById('detail-header').style.display = 'none';
+  document.getElementById('legend').style.display = 'none';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+}}
+showOverview();
+</script>
+</body>
+</html>
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--prometheus-url", default="http://localhost:9090")
+    ap.add_argument("-o", "--output", default="blast_radius.html")
+    args = ap.parse_args()
+
+    try:
+        all_certs = fetch_all_certs(args.prometheus_url)
+        fetch_all_process_pairings(args.prometheus_url, all_certs)
+    except Exception as e:
+        sys.exit(f"Failed to query Prometheus at {args.prometheus_url}: {e}")
+
+    if not all_certs:
+        sys.exit("No tls_certificate_expiry_days series found -- is cert-analyzer running and scraped?")
+
+    with open(args.output, "w") as f:
+        f.write(render_page(all_certs))
+
+    print(f"Wrote {args.output}: {len(all_certs)} certificate(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/test-server/TEST-SERVER-README.md
+++ b/extras/test-server/TEST-SERVER-README.md
@@ -48,6 +48,10 @@ streamed live via Server-Sent Events as it arrives.
   RHEL8) TracingPolicy loaded, and `/usr/lib64/libssl.so.3` present on
   this host -- that's the literal path both policies hook, and the one
   this use case loads via `ctypes`
+- For the "Certificate blast radius explorer" link specifically: a
+  reachable Prometheus scraping cert-analyzer's `/metrics` endpoint (see
+  `--prometheus-url` / `TEST_SERVER_PROMETHEUS_URL` below) -- not required
+  for anything else in this console
 
 ## Install
 
@@ -118,7 +122,9 @@ Then open http://localhost:8090.
 broker is whatever you configured cert-analyzer's `[kafka] bootstrap_servers`
 to point at. `--topic` defaults to `cert-analyzer-events` (cert-analyzer's
 own default); pass `--port` to change this server's own listen port
-(default `8090`).
+(default `8090`). `--prometheus-url` defaults to `http://localhost:9090`
+and only matters for the "Certificate blast radius explorer" link -- adjust
+it if Prometheus lives elsewhere (env: `TEST_SERVER_PROMETHEUS_URL`).
 
 By default this only listens on `127.0.0.1`, so it's only reachable from a
 browser on the same host. If the target host is headless and you're
@@ -129,6 +135,50 @@ listen on all interfaces, then open `http://<target-host>:8090` instead of
 **Do not** bind this beyond localhost or a trusted lab network: every use
 case executes a real, hardcoded action against this host on request from
 any browser that can reach it.
+
+## Certificate blast radius explorer
+
+The "Certificate blast radius explorer" link in the header
+(`blast_radius.py`) is generated live, on click, against Prometheus --
+querying cert-analyzer's own `tls_certificate_expiry_days` and
+`tls_certificate_process_info` metrics fresh each time rather than a
+pre-baked snapshot. It shows every certificate cert-analyzer has
+discovered, colored by expiry urgency; clicking one reveals every
+distinct process/pod/node Tetragon has observed loading it, i.e. what
+would actually break if that certificate were rotated or revoked.
+
+Unlike the rest of this console it needs a reachable Prometheus, not just
+Tetragon/cert-analyzer/Kafka -- see `--prometheus-url` /
+`TEST_SERVER_PROMETHEUS_URL` above. If Prometheus is unreachable or has no
+matching series yet, the link returns a plain-text error explaining why
+instead of a broken page.
+
+This is a bundled copy of the standalone
+[`extras/cert_blast_radius.py`](../cert_blast_radius.py) script (same
+rendering logic, trimmed to a library) -- see that file if you want to
+generate a static HTML report without running this console at all.
+
+## Certificate chain explorer
+
+The "Certificate chain explorer" link (`chain_explorer.py`) is generated
+live the same way, grouping cert-analyzer's `tls_certificate_expiry_days`
+and `tls_certificate_self_signed` metrics by `cert_path` and ordering each
+bundle by `cert_index` (0 = leaf) to show its chain length and
+leaf/intermediate/root structure.
+
+It separately flags a real misconfiguration: any non-self-signed cert in a
+bundle whose issuer doesn't match any other cert's subject in that same
+bundle -- the "server forgot to include its intermediate CA" case. Bundles
+with a missing intermediate sort to the top of the overview. This mirrors
+[`extras/kafka/list_cert_chains.py`](../kafka/list_cert_chains.py)'s
+detection logic, but reads Prometheus's current live state instead of
+replaying Kafka's first-time-discovery history, so it reflects every
+bundle cert-analyzer currently knows about, not just what Kafka has seen
+since it was enabled.
+
+Also needs the reachable Prometheus described above (`--prometheus-url` /
+`TEST_SERVER_PROMETHEUS_URL`); same plain-text-error behavior if it's
+unreachable or has no data yet.
 
 ## Running under systemd (RPM install only)
 
@@ -176,8 +226,9 @@ sudo systemctl stop certsight-test-server      # sudo systemctl disable ... to a
 the same format as `cert-analyzer.conf` -- see the commented-out options
 in the shipped file for the full list (`TEST_SERVER_KAFKA_HOST`,
 `TEST_SERVER_KAFKA_PORT`, `TEST_SERVER_TOPIC`, `TEST_SERVER_PORT`,
-`TEST_SERVER_BIND`). It's marked `%config(noreplace)` in the spec, so an
-RPM upgrade won't overwrite edits you've made to it.
+`TEST_SERVER_BIND`, `TEST_SERVER_PROMETHEUS_URL`). It's marked
+`%config(noreplace)` in the spec, so an RPM upgrade won't overwrite edits
+you've made to it.
 
 ## Use cases
 

--- a/extras/test-server/blast_radius.py
+++ b/extras/test-server/blast_radius.py
@@ -1,0 +1,305 @@
+"""
+blast_radius.py -- Certificate blast-radius explorer, bundled into the
+test-server console so its "Blast radius explorer" link can generate it live
+against a running Prometheus.
+
+This is a bundled copy of extras/cert_blast_radius.py, trimmed to a library
+(no CLI/argparse -- server.py calls generate() directly) so the RPM package
+stays self-contained without reaching outside extras/test-server/ (see
+build-rpm.sh, which tars up this directory file-by-file). Keep the two in
+sync by hand if you change the rendering logic in one.
+
+Queries cert-analyzer's own `tls_certificate_expiry_days` /
+`tls_certificate_process_info` Prometheus metrics -- no separate inventory to
+keep in sync. Stdlib only -- no third-party packages required.
+"""
+import json
+import math
+import urllib.parse
+import urllib.request
+
+CATEGORICAL_SLOTS = 8
+# Matches the thresholds cert-analyzer's own tls_certificate_expiring_soon
+# metric buckets on (see extras/examples/grafana-dashboard.json).
+EXPIRY_THRESHOLDS = (0, 7, 30)  # expired / <7d critical / <30d warning / else good
+
+# Palette values (dataviz skill reference/palette.md), wired as CSS custom
+# properties in PAGE_CSS below so the page follows the OS/browser light-dark
+# preference automatically -- SVG marks reference them via fill="var(--...)"
+# rather than baking in one theme's hex values.
+PAGE_CSS = """
+:root {
+  color-scheme: light;
+  --surface: #fcfcfb; --page: #f9f9f7;
+  --primary: #0b0b0b; --secondary: #52514e; --muted: #898781;
+  --spoke: #c3c2b7; --border: rgba(11,11,11,0.10);
+  --good: #0ca30c; --warning: #fab219; --serious: #ec835a; --critical: #d03b3b;
+  --cat-1: #2a78d6; --cat-2: #008300; --cat-3: #e87ba4; --cat-4: #eda100;
+  --cat-5: #1baf7a; --cat-6: #eb6834; --cat-7: #4a3aa7; --cat-8: #e34948;
+  --other: #898781;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --surface: #1a1a19; --page: #0d0d0d;
+    --primary: #ffffff; --secondary: #c3c2b7; --muted: #898781;
+    --spoke: #383835; --border: rgba(255,255,255,0.10);
+    --good: #0ca30c; --warning: #fab219; --serious: #ec835a; --critical: #d03b3b;
+    --cat-1: #3987e5; --cat-2: #008300; --cat-3: #d55181; --cat-4: #c98500;
+    --cat-5: #199e70; --cat-6: #d95926; --cat-7: #9085e9; --cat-8: #e66767;
+    --other: #898781;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem; background: var(--page); color: var(--primary);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+.subtitle { color: var(--secondary); font-size: 0.9rem; margin: 0 0 1.5rem; }
+#overview {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px; max-width: 1100px;
+}
+.cert-card {
+  display: flex; align-items: center; gap: 10px; padding: 12px 14px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  cursor: pointer;
+}
+.cert-card:hover { border-color: var(--muted); }
+.cert-dot { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.cert-name { font-weight: 600; font-size: 0.92rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cert-meta { color: var(--secondary); font-size: 0.78rem; }
+#detail-header {
+  display: none; align-items: center; gap: 12px; margin-bottom: 1rem;
+}
+#back-btn {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 12px; font-size: 0.85rem; cursor: pointer; color: var(--primary);
+}
+#back-btn:hover { border-color: var(--muted); }
+.detail { display: none; max-width: 900px; }
+.detail-title { font-size: 1.1rem; font-weight: 600; margin: 0 0 0.25rem; }
+.detail-subtitle { color: var(--secondary); font-size: 0.85rem; margin: 0 0 1rem; }
+#legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 1rem; }
+.legend-item { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; color: var(--secondary); }
+.legend-swatch { width: 11px; height: 11px; border-radius: 2px; flex: none; }
+"""
+
+
+def _prom_query(base_url, promql):
+    url = f"{base_url.rstrip('/')}/api/v1/query?{urllib.parse.urlencode({'query': promql})}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        payload = json.load(resp)
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Prometheus query failed: {payload}")
+    return payload["data"]["result"]
+
+
+def _fetch_all_certs(base_url):
+    """One entry per (cert_path, cert_index) -- cert-analyzer's own cert identity key."""
+    results = _prom_query(base_url, "tls_certificate_expiry_days")
+    certs = {}
+    for r in results:
+        m = r["metric"]
+        key = (m.get("cert_path", ""), m.get("cert_index", "0"))
+        certs[key] = {
+            "common_name": m.get("common_name") or m.get("subject") or m.get("cert_path") or "certificate",
+            "serial": m.get("serial", ""),
+            "days_left": float(r["value"][1]),
+            "leaves": [],
+        }
+    return certs
+
+
+def _fetch_all_process_pairings(base_url, certs):
+    results = _prom_query(base_url, "tls_certificate_process_info")
+    for r in results:
+        m = r["metric"]
+        key = (m.get("cert_path", ""), m.get("cert_index", "0"))
+        if key not in certs:
+            continue  # process-info series with no matching expiry series -- shouldn't normally happen
+        certs[key]["leaves"].append({
+            "process": m.get("process", "?"),
+            "node_name": m.get("node_name", "?"),
+            "pod_name": m.get("pod_name", ""),
+            "namespace": m.get("namespace", ""),
+        })
+
+
+def _status_bucket(days_left):
+    if days_left < EXPIRY_THRESHOLDS[0]:
+        return "critical"
+    if days_left < EXPIRY_THRESHOLDS[1]:
+        return "serious"
+    if days_left < EXPIRY_THRESHOLDS[2]:
+        return "warning"
+    return "good"
+
+
+def _days_label(days_left):
+    if days_left < 0:
+        return f"expired {abs(days_left):.0f}d ago"
+    return f"{days_left:.0f}d left"
+
+
+def _assign_namespace_colors(all_certs):
+    namespaces = sorted({
+        leaf["namespace"] or "(none)"
+        for cert in all_certs.values() for leaf in cert["leaves"]
+    })
+    color_var = {}
+    for i, ns in enumerate(namespaces):
+        color_var[ns] = f"var(--cat-{i + 1})" if i < CATEGORICAL_SLOTS else "var(--other)"
+    return color_var
+
+
+def _esc(s):
+    return (str(s).replace("&", "&amp;").replace("<", "&lt;")
+            .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def _render_detail_svg(cert, ns_color):
+    leaves = cert["leaves"]
+    w = h = 640
+    cx, cy = w / 2, h / 2
+    radius = min(w, h) / 2 - 130
+    n = max(len(leaves), 1)
+
+    parts = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 {w} {h}">']
+
+    positions = []
+    for i in range(n):
+        angle = (2 * math.pi * i / n) - math.pi / 2
+        x = cx + radius * math.cos(angle)
+        y = cy + radius * math.sin(angle)
+        positions.append((x, y, angle))
+        parts.append(f'<line x1="{cx:.1f}" y1="{cy:.1f}" x2="{x:.1f}" y2="{y:.1f}" '
+                      f'stroke="var(--spoke)" stroke-width="1.5"/>')
+
+    for leaf, (x, y, angle) in zip(leaves, positions):
+        ns = leaf["namespace"] or "(none)"
+        color = ns_color.get(ns, "var(--other)")
+        parts.append(f'<circle cx="{x:.1f}" cy="{y:.1f}" r="8" fill="{color}" '
+                      f'stroke="var(--surface)" stroke-width="2"/>')
+        deg = math.degrees(angle) % 360
+        right_half = deg < 90 or deg > 270
+        anchor = "start" if right_half else "end"
+        label_x = x + (12 if right_half else -12)
+        detail_bits = [b for b in (leaf["pod_name"], leaf["namespace"]) if b] or [leaf["node_name"]]
+        detail = " / ".join(detail_bits[:2])
+        parts.append(f'<text x="{label_x:.1f}" y="{y - 3:.1f}" text-anchor="{anchor}" '
+                      f'font-size="11" font-weight="600" fill="var(--primary)">{_esc(leaf["process"])}</text>')
+        parts.append(f'<text x="{label_x:.1f}" y="{y + 10:.1f}" text-anchor="{anchor}" '
+                      f'font-size="9.5" fill="var(--secondary)">{_esc(detail)}</text>')
+
+    parts.append('<circle cx="{0}" cy="{1}" r="22" fill="var(--surface)" '
+                  'stroke="var(--primary)" stroke-width="2.5"/>'.format(cx, cy))
+    body_x, body_y = cx - 7, cy - 2
+    parts.append(f'<rect x="{body_x:.1f}" y="{body_y:.1f}" width="14" height="10" rx="2" fill="var(--primary)"/>')
+    parts.append(f'<path d="M {cx - 5:.1f} {body_y:.1f} v -5 a 5 5 0 0 1 10 0 v 5" '
+                  f'fill="none" stroke="var(--primary)" stroke-width="2.2"/>')
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def _render_page(all_certs):
+    ns_color = _assign_namespace_colors(all_certs)
+    ordered = sorted(all_certs.items(), key=lambda kv: kv[1]["days_left"])
+
+    overview_cards = []
+    detail_blocks = []
+    for idx, (_key, cert) in enumerate(ordered):
+        status = _status_bucket(cert["days_left"])
+        overview_cards.append(
+            f'<div class="cert-card" onclick="showDetail({idx})">'
+            f'<span class="cert-dot" style="background: var(--{status})"></span>'
+            f'<div><div class="cert-name">{_esc(cert["common_name"])}</div>'
+            f'<div class="cert-meta">{_esc(_days_label(cert["days_left"]))} '
+            f'&middot; {len(cert["leaves"])} process pairing(s)</div></div></div>'
+        )
+
+        pod_count = len({leaf["pod_name"] for leaf in cert["leaves"] if leaf["pod_name"]})
+        ns_count = len({leaf["namespace"] for leaf in cert["leaves"] if leaf["namespace"]})
+        node_count = len({leaf["node_name"] for leaf in cert["leaves"]})
+        subtitle_bits = [f'{len(cert["leaves"])} process(es)']
+        if pod_count:
+            subtitle_bits.append(f"{pod_count} pod(s)")
+        if ns_count:
+            subtitle_bits.append(f"{ns_count} namespace(s)")
+        subtitle_bits.append(f"{node_count} node(s)")
+
+        detail_blocks.append(
+            f'<div class="detail" id="detail-{idx}">'
+            f'<div class="detail-title">{_esc(cert["common_name"])}</div>'
+            f'<div class="detail-subtitle">{_esc(" · ".join(subtitle_bits))}'
+            f'{" &middot; serial " + _esc(cert["serial"][:16]) if cert["serial"] else ""}</div>'
+            f'{_render_detail_svg(cert, ns_color)}'
+            f'</div>'
+        )
+
+    legend_items = sorted((ns, c) for ns, c in ns_color.items() if c != "var(--other)")
+    if any(c == "var(--other)" for c in ns_color.values()):
+        legend_items.append(("Other", "var(--other)"))
+    legend_html = "".join(
+        f'<div class="legend-item"><span class="legend-swatch" style="background:{color}"></span>{_esc(ns)}</div>'
+        for ns, color in legend_items
+    )
+
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Certificate Blast Radius</title>
+<style>{PAGE_CSS}</style>
+</head>
+<body>
+<p><a href="/">&larr; Back to test console</a></p>
+<h1>Certificate Blast Radius</h1>
+<p class="subtitle">{len(all_certs)} certificate(s) monitored &middot; click one to see every process, pod, and node that loads it</p>
+
+<div id="overview">{"".join(overview_cards)}</div>
+
+<div id="detail-header">
+  <button id="back-btn" onclick="showOverview()">&larr; All certificates</button>
+</div>
+{"".join(detail_blocks)}
+<div id="legend">{legend_html}</div>
+
+<script>
+function showDetail(idx) {{
+  document.getElementById('overview').style.display = 'none';
+  document.getElementById('detail-header').style.display = 'flex';
+  document.getElementById('legend').style.display = 'flex';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+  document.getElementById('detail-' + idx).style.display = 'block';
+}}
+function showOverview() {{
+  document.getElementById('overview').style.display = 'grid';
+  document.getElementById('detail-header').style.display = 'none';
+  document.getElementById('legend').style.display = 'none';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+}}
+showOverview();
+</script>
+</body>
+</html>
+"""
+
+
+def generate(prometheus_url):
+    """Query Prometheus and return the rendered blast-radius HTML page as a str.
+
+    Raises RuntimeError if no certificates are currently exposed, and
+    propagates any underlying urllib/JSON error from a bad or unreachable
+    Prometheus URL -- callers (server.py) turn both into a clean HTTP error.
+    """
+    all_certs = _fetch_all_certs(prometheus_url)
+    _fetch_all_process_pairings(prometheus_url, all_certs)
+    if not all_certs:
+        raise RuntimeError(
+            "No tls_certificate_expiry_days series found at "
+            f"{prometheus_url} -- is cert-analyzer running and scraped?"
+        )
+    return _render_page(all_certs)

--- a/extras/test-server/build-rpm.sh
+++ b/extras/test-server/build-rpm.sh
@@ -66,6 +66,8 @@ trap 'rm -rf "$TMPDIR_SRC"' EXIT
 
 mkdir -p "$TMPDIR_SRC/$TARNAME"
 cp "$SCRIPT_DIR/server.py"                       "$TMPDIR_SRC/$TARNAME/"
+cp "$SCRIPT_DIR/blast_radius.py"                 "$TMPDIR_SRC/$TARNAME/"
+cp "$SCRIPT_DIR/chain_explorer.py"               "$TMPDIR_SRC/$TARNAME/"
 cp "$SCRIPT_DIR/use_cases.py"                    "$TMPDIR_SRC/$TARNAME/"
 cp "$SCRIPT_DIR/tls_probe_helper.py"             "$TMPDIR_SRC/$TARNAME/"
 cp "$SCRIPT_DIR/tcp_connect_probe_helper.py"     "$TMPDIR_SRC/$TARNAME/"

--- a/extras/test-server/certsight-test-server.spec
+++ b/extras/test-server/certsight-test-server.spec
@@ -119,6 +119,8 @@ install -d %{buildroot}%{app_venv}
 install -d %{buildroot}%{app_home}/static
 
 install -m 0644 server.py             %{buildroot}%{app_home}/server.py
+install -m 0644 blast_radius.py       %{buildroot}%{app_home}/blast_radius.py
+install -m 0644 chain_explorer.py     %{buildroot}%{app_home}/chain_explorer.py
 install -m 0644 use_cases.py          %{buildroot}%{app_home}/use_cases.py
 install -m 0644 tls_probe_helper.py   %{buildroot}%{app_home}/tls_probe_helper.py
 install -m 0644 tcp_connect_probe_helper.py %{buildroot}%{app_home}/tcp_connect_probe_helper.py
@@ -197,6 +199,8 @@ exit 0
 %license %{_defaultlicensedir}/%{name}/LICENSE
 %dir %{app_home}
 %{app_home}/server.py
+%{app_home}/blast_radius.py
+%{app_home}/chain_explorer.py
 %{app_home}/use_cases.py
 %{app_home}/tls_probe_helper.py
 %{app_home}/tcp_connect_probe_helper.py
@@ -211,6 +215,24 @@ exit 0
 
 
 %changelog
+* %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
+- Add a "Certificate chain explorer" link to the console header
+  (chain_explorer.py), generated live on click against Prometheus --
+  groups tls_certificate_expiry_days/tls_certificate_self_signed by
+  cert_path, and renders each bundle's chain length and leaf/intermediate/
+  root structure, flagging any non-self-signed cert whose issuer isn't
+  present elsewhere in the same bundle (mirrors
+  extras/kafka/list_cert_chains.py's missing-intermediate detection, but
+  from Prometheus's current state rather than replayed Kafka history); no
+  new package dependencies (stdlib only)
+* %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
+- Add a "Certificate blast radius explorer" link to the console header
+  (blast_radius.py), generated live on click against Prometheus --
+  queries tls_certificate_expiry_days/tls_certificate_process_info and
+  renders an interactive, click-through overview of every discovered
+  certificate and the processes/pods/nodes that load it; configurable via
+  --prometheus-url / TEST_SERVER_PROMETHEUS_URL (default
+  http://localhost:9090), no new package dependencies (stdlib only)
 * %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
 - Add java-jca-keystore use case (CertAgentTest.java, compiled at build
   time) exercising CertSight's java_cert_agent_write uprobe detection path

--- a/extras/test-server/chain_explorer.py
+++ b/extras/test-server/chain_explorer.py
@@ -1,0 +1,306 @@
+"""
+chain_explorer.py -- Certificate chain explorer, bundled into the test-server
+console alongside blast_radius.py.
+
+Groups cert-analyzer's own `tls_certificate_expiry_days` /
+`tls_certificate_self_signed` Prometheus metrics by `cert_path`, orders each
+bundle by `cert_index` (0 = leaf, per cert-analyzer's own convention), and
+renders an interactive, click-through view of every certificate bundle's
+chain length and role structure (leaf / intermediate CA / root).
+
+Separately flags a real chain-of-trust misconfiguration: any non-self-signed
+cert in a bundle whose issuer doesn't match any other cert's subject in that
+same bundle -- the "server forgot to include its intermediate CA" case. This
+mirrors extras/kafka/list_cert_chains.py's detection logic, but sources from
+Prometheus's current live state instead of replaying Kafka's first-time-
+discovery history, so it reflects every bundle cert-analyzer currently knows
+about rather than only what's been seen since Kafka was enabled.
+
+Stdlib only -- no third-party packages required.
+"""
+import json
+import urllib.parse
+import urllib.request
+
+# Shares its visual language (CSS vars, palette, dark/light auto-switching)
+# with blast_radius.py -- see that file's PAGE_CSS comment for the palette
+# source. Status colors (good/critical) are reserved for chain completeness;
+# role (leaf/intermediate/root) is conveyed by label text, not color, since
+# role isn't a "categorical identity" in the dataviz-skill sense here.
+PAGE_CSS = """
+:root {
+  color-scheme: light;
+  --surface: #fcfcfb; --page: #f9f9f7;
+  --primary: #0b0b0b; --secondary: #52514e; --muted: #898781;
+  --spoke: #c3c2b7; --border: rgba(11,11,11,0.10);
+  --good: #0ca30c; --critical: #d03b3b;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --surface: #1a1a19; --page: #0d0d0d;
+    --primary: #ffffff; --secondary: #c3c2b7; --muted: #898781;
+    --spoke: #383835; --border: rgba(255,255,255,0.10);
+    --good: #0ca30c; --critical: #d03b3b;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem; background: var(--page); color: var(--primary);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+.subtitle { color: var(--secondary); font-size: 0.9rem; margin: 0 0 1.5rem; }
+#overview {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px; max-width: 1200px;
+}
+.chain-card {
+  display: flex; align-items: center; gap: 10px; padding: 12px 14px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  cursor: pointer;
+}
+.chain-card:hover { border-color: var(--muted); }
+.chain-dot { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.chain-path { font-weight: 600; font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: ui-monospace, monospace; }
+.chain-meta { color: var(--secondary); font-size: 0.78rem; }
+.chain-meta.critical { color: var(--critical); font-weight: 600; }
+#detail-header {
+  display: none; align-items: center; gap: 12px; margin-bottom: 1rem;
+}
+#back-btn {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 12px; font-size: 0.85rem; cursor: pointer; color: var(--primary);
+}
+#back-btn:hover { border-color: var(--muted); }
+.detail { display: none; max-width: 1100px; }
+.detail-title { font-size: 1.05rem; font-weight: 600; margin: 0 0 0.25rem; font-family: ui-monospace, monospace; }
+.detail-subtitle { color: var(--secondary); font-size: 0.85rem; margin: 0 0 1rem; }
+.detail-subtitle.critical { color: var(--critical); font-weight: 600; }
+.chain-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0; margin-bottom: 0.5rem; }
+.chain-box {
+  width: 170px; min-height: 76px; padding: 8px 10px; border-radius: 8px;
+  border: 1.5px solid var(--border); background: var(--surface);
+  display: flex; flex-direction: column; justify-content: center; gap: 2px;
+}
+.chain-box.root { border-color: var(--good); border-width: 2px; }
+.chain-box.missing {
+  border: 1.5px dashed var(--critical); background: transparent;
+  color: var(--critical); align-items: center; justify-content: center; text-align: center;
+}
+.chain-role { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+.chain-cn { font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chain-issuer { font-size: 0.72rem; color: var(--secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chain-arrow { width: 28px; text-align: center; color: var(--muted); font-size: 1rem; flex: none; }
+"""
+
+
+def _prom_query(base_url, promql):
+    url = f"{base_url.rstrip('/')}/api/v1/query?{urllib.parse.urlencode({'query': promql})}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        payload = json.load(resp)
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Prometheus query failed: {payload}")
+    return payload["data"]["result"]
+
+
+def _fetch_bundles(base_url):
+    """One bundle per cert_path, one entry per cert_index within it."""
+    bundles = {}
+    for r in _prom_query(base_url, "tls_certificate_expiry_days"):
+        m = r["metric"]
+        path = m.get("cert_path", "")
+        idx = int(m.get("cert_index", "0"))
+        bundles.setdefault(path, {})[idx] = {
+            "subject": m.get("subject", ""),
+            "issuer": m.get("issuer", ""),
+            "common_name": m.get("common_name") or m.get("subject") or "(no subject)",
+            "is_self_signed": False,
+            "is_ca": "unknown",
+        }
+
+    for r in _prom_query(base_url, "tls_certificate_self_signed"):
+        m = r["metric"]
+        path = m.get("cert_path", "")
+        idx = int(m.get("cert_index", "0"))
+        entry = bundles.get(path, {}).get(idx)
+        if entry is None:
+            continue  # self-signed series with no matching expiry series -- shouldn't normally happen
+        entry["is_self_signed"] = r["value"][1] == "1"
+        entry["is_ca"] = m.get("is_ca", "unknown")
+
+    return bundles
+
+
+def _find_missing_intermediates(by_index):
+    """
+    Mirrors extras/kafka/list_cert_chains.py's find_missing_intermediates():
+    every non-self-signed cert in this bundle whose issuer doesn't match any
+    other cert's subject in the same bundle. Only meaningful for bundles
+    with more than one cert -- a lone leaf never embeds its own issuer.
+    """
+    if len(by_index) <= 1:
+        return []
+    subjects = {entry["subject"] for entry in by_index.values()}
+    missing = []
+    for idx in sorted(by_index):
+        entry = by_index[idx]
+        if entry["is_self_signed"]:
+            continue
+        issuer = entry["issuer"]
+        if issuer and issuer not in subjects:
+            missing.append((idx, entry, issuer))
+    return missing
+
+
+def _role(entry):
+    if entry["is_self_signed"]:
+        return "root"
+    if entry["is_ca"] == "true":
+        return "intermediate ca"
+    return "leaf"
+
+
+def _esc(s):
+    return (str(s).replace("&", "&amp;").replace("<", "&lt;")
+            .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def _render_chain_row(by_index, missing_by_idx):
+    indices = sorted(by_index)
+    boxes = []
+    for pos, idx in enumerate(indices):
+        entry = by_index[idx]
+        role = _role(entry)
+        cls = "root" if role == "root" else ""
+        boxes.append(
+            f'<div class="chain-box {cls}">'
+            f'<div class="chain-role">{_esc(role)}</div>'
+            f'<div class="chain-cn">{_esc(entry["common_name"])}</div>'
+            f'<div class="chain-issuer">{_esc(entry["issuer"] or "(no issuer)")}</div>'
+            f'</div>'
+        )
+        if idx in missing_by_idx:
+            issuer = missing_by_idx[idx]
+            boxes.append('<div class="chain-arrow">&rarr;</div>')
+            boxes.append(
+                f'<div class="chain-box missing">MISSING<br>{_esc(issuer)}</div>'
+            )
+        if pos < len(indices) - 1:
+            boxes.append('<div class="chain-arrow">&rarr;</div>')
+
+    # wrap every 5 boxes+arrows-worth onto a new visual row so long bundles
+    # (e.g. a flat CA trust store with dozens of unrelated roots) don't
+    # produce one unreadably wide strip
+    rows, current = [], []
+    box_count = 0
+    for chunk in boxes:
+        current.append(chunk)
+        if 'chain-box' in chunk and 'missing' not in chunk or 'chain-box missing' in chunk:
+            box_count += 1
+        if box_count >= 5 and chunk.startswith('<div class="chain-arrow"'):
+            rows.append(current)
+            current = []
+            box_count = 0
+    if current:
+        rows.append(current)
+
+    return "".join(f'<div class="chain-row">{"".join(row)}</div>' for row in rows)
+
+
+def generate(prometheus_url):
+    """Query Prometheus and return the rendered chain-explorer HTML page as a str.
+
+    Raises RuntimeError if no certificates are currently exposed, and
+    propagates any underlying urllib/JSON error from a bad or unreachable
+    Prometheus URL -- callers (server.py) turn both into a clean HTTP error.
+    """
+    bundles = _fetch_bundles(prometheus_url)
+    if not bundles:
+        raise RuntimeError(
+            "No tls_certificate_expiry_days series found at "
+            f"{prometheus_url} -- is cert-analyzer running and scraped?"
+        )
+
+    rows = []
+    for path, by_index in bundles.items():
+        missing = _find_missing_intermediates(by_index)
+        missing_by_idx = {idx: issuer for idx, _entry, issuer in missing}
+        rows.append({
+            "path": path,
+            "by_index": by_index,
+            "chain_length": len(by_index),
+            "missing_by_idx": missing_by_idx,
+            "has_missing": bool(missing),
+        })
+
+    # broken chains first, then longest chains first, then alphabetical
+    rows.sort(key=lambda r: (not r["has_missing"], -r["chain_length"], r["path"]))
+
+    broken_count = sum(1 for r in rows if r["has_missing"])
+
+    overview_cards = []
+    detail_blocks = []
+    for idx, row in enumerate(rows):
+        status = "critical" if row["has_missing"] else "good"
+        meta_cls = " critical" if row["has_missing"] else ""
+        meta_text = f'{row["chain_length"]} cert(s) in chain'
+        if row["has_missing"]:
+            meta_text += " &middot; MISSING INTERMEDIATE"
+        overview_cards.append(
+            f'<div class="chain-card" onclick="showDetail({idx})">'
+            f'<span class="chain-dot" style="background: var(--{status})"></span>'
+            f'<div><div class="chain-path">{_esc(row["path"])}</div>'
+            f'<div class="chain-meta{meta_cls}">{meta_text}</div></div></div>'
+        )
+
+        subtitle = f'{row["chain_length"]} cert(s) in chain'
+        subtitle_cls = ""
+        if row["has_missing"]:
+            subtitle += " &middot; missing intermediate detected"
+            subtitle_cls = " critical"
+
+        detail_blocks.append(
+            f'<div class="detail" id="detail-{idx}">'
+            f'<div class="detail-title">{_esc(row["path"])}</div>'
+            f'<div class="detail-subtitle{subtitle_cls}">{subtitle}</div>'
+            f'{_render_chain_row(row["by_index"], row["missing_by_idx"])}'
+            f'</div>'
+        )
+
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Certificate Chain Explorer</title>
+<style>{PAGE_CSS}</style>
+</head>
+<body>
+<p><a href="/">&larr; Back to test console</a></p>
+<h1>Certificate Chain Explorer</h1>
+<p class="subtitle">{len(rows)} bundle(s) monitored &middot; {broken_count} with a missing intermediate &middot; click one to see its chain</p>
+
+<div id="overview">{"".join(overview_cards)}</div>
+
+<div id="detail-header">
+  <button id="back-btn" onclick="showOverview()">&larr; All chains</button>
+</div>
+{"".join(detail_blocks)}
+
+<script>
+function showDetail(idx) {{
+  document.getElementById('overview').style.display = 'none';
+  document.getElementById('detail-header').style.display = 'flex';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+  document.getElementById('detail-' + idx).style.display = 'block';
+}}
+function showOverview() {{
+  document.getElementById('overview').style.display = 'grid';
+  document.getElementById('detail-header').style.display = 'none';
+  document.querySelectorAll('.detail').forEach(function (d) {{ d.style.display = 'none'; }});
+}}
+showOverview();
+</script>
+</body>
+</html>
+"""

--- a/extras/test-server/server.py
+++ b/extras/test-server/server.py
@@ -47,6 +47,8 @@ except ImportError:
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from use_cases import USE_CASES, USE_CASES_BY_ID, UseCaseResult  # noqa: E402
+import blast_radius  # noqa: E402
+import chain_explorer  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("test-server")
@@ -115,7 +117,7 @@ def _consume_kafka(broadcaster: EventBroadcaster, host: str, port: int, topic: s
             time.sleep(5)
 
 
-def make_handler(broadcaster: EventBroadcaster):
+def make_handler(broadcaster: EventBroadcaster, prometheus_url: str):
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
             logger.info("%s - %s", self.address_string(), fmt % args)
@@ -130,6 +132,10 @@ def make_handler(broadcaster: EventBroadcaster):
                 self._serve_use_cases()
             elif path == "/api/events":
                 self._serve_events()
+            elif path == "/blast-radius":
+                self._serve_generated_page(blast_radius, "blast radius")
+            elif path == "/chain-explorer":
+                self._serve_generated_page(chain_explorer, "chain explorer")
             else:
                 self.send_error(404)
 
@@ -230,6 +236,28 @@ def make_handler(broadcaster: EventBroadcaster):
             self.end_headers()
             self.wfile.write(body)
 
+        def _serve_generated_page(self, generator_module, label):
+            # Generated fresh on every request rather than cached -- these are
+            # low-traffic, manually-clicked links, and always reflect
+            # cert-analyzer's current state rather than a stale snapshot.
+            try:
+                html = generator_module.generate(prometheus_url)
+            except Exception as e:
+                logger.exception("%s generation failed", label)
+                body = f"Failed to generate {label} view: {e}".encode("utf-8")
+                self.send_response(502)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            body = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
         def _serve_events(self):
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
@@ -293,6 +321,14 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("TEST_SERVER_TOPIC", "cert-analyzer-events"),
         help="Kafka topic to watch (default: cert-analyzer-events, env: TEST_SERVER_TOPIC)",
     )
+    parser.add_argument(
+        "--prometheus-url",
+        default=os.environ.get("TEST_SERVER_PROMETHEUS_URL", "http://localhost:9090"),
+        help=(
+            "Prometheus base URL for the 'Blast radius explorer' link (default: "
+            "http://localhost:9090, env: TEST_SERVER_PROMETHEUS_URL)"
+        ),
+    )
     args = parser.parse_args()
     if args.kafka_host is None or args.kafka_port is None:
         parser.error(
@@ -313,11 +349,11 @@ def main() -> None:
     )
     consumer_thread.start()
 
-    server = ThreadingHTTPServer((args.bind, args.port), make_handler(broadcaster))
+    server = ThreadingHTTPServer((args.bind, args.port), make_handler(broadcaster, args.prometheus_url))
     server.daemon_threads = True
     logger.info(
-        "serving on http://%s:%d (Kafka: %s:%d, topic '%s')",
-        args.bind, args.port, args.kafka_host, args.kafka_port, args.topic,
+        "serving on http://%s:%d (Kafka: %s:%d, topic '%s'; Prometheus: %s)",
+        args.bind, args.port, args.kafka_host, args.kafka_port, args.topic, args.prometheus_url,
     )
     try:
         server.serve_forever()

--- a/extras/test-server/static/app.css
+++ b/extras/test-server/static/app.css
@@ -20,6 +20,26 @@ header p {
   max-width: 60em;
 }
 
+.tool-links {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.tool-link {
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+}
+
+.tool-link:hover {
+  border-color: currentColor;
+}
+
 main {
   display: flex;
   gap: 1.5rem;

--- a/extras/test-server/static/index.html
+++ b/extras/test-server/static/index.html
@@ -10,6 +10,10 @@
   <header>
     <h1>CertSight detection test console</h1>
     <p>Pick a use case on the left to trigger it on this host. Matching <strong>CertSight</strong> Kafka events appear on the right as they arrive.</p>
+    <p class="tool-links">
+      <a class="tool-link" href="/blast-radius" target="_blank" rel="noopener">Certificate blast radius explorer &rarr;</a>
+      <a class="tool-link" href="/chain-explorer" target="_blank" rel="noopener">Certificate chain explorer &rarr;</a>
+    </p>
   </header>
   <main>
     <section id="use-cases-pane">

--- a/extras/test-server/test-server.conf
+++ b/extras/test-server/test-server.conf
@@ -19,6 +19,11 @@
 #TEST_SERVER_TOPIC=cert-analyzer-events
 #TEST_SERVER_PORT=8090
 
+# Prometheus base URL the "Certificate blast radius explorer" link queries
+# on click (default: http://localhost:9090). Only needs to be set if
+# Prometheus isn't reachable at the default address from this host.
+#TEST_SERVER_PROMETHEUS_URL=http://localhost:9090
+
 # Listen address. Defaults to 0.0.0.0 (all interfaces) here so the console
 # is reachable from elsewhere on the lab network without extra flags, since
 # a systemd-managed instance is typically running on a headless host.


### PR DESCRIPTION
Both are generated live on click against Prometheus, with no new package dependencies (stdlib only):

- Certificate blast radius explorer (blast_radius.py): shows every certificate cert-analyzer has discovered, colored by expiry urgency; clicking one reveals every distinct process/pod/node that loads it, i.e. what would break if it were rotated or revoked. Bundled from the standalone extras/cert_blast_radius.py, which still works as a stand-alone offline report generator.

- Certificate chain explorer (chain_explorer.py): groups certs by cert_path and orders by cert_index (0 = leaf) to show each bundle's chain length and leaf/intermediate/root structure, flagging any non-self-signed cert whose issuer isn't present elsewhere in the same bundle -- mirrors extras/kafka/list_cert_chains.py's missing- intermediate detection, but from Prometheus's current state instead of replayed Kafka history.

New --prometheus-url / TEST_SERVER_PROMETHEUS_URL setting (default http://localhost:9090); both links return a clean error if Prometheus is unreachable or has no data yet.