### PR TITLE
Add in-cluster interactive test-console Pod for OpenShift demos

### DIFF
--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -296,6 +296,61 @@ basic operational needs.
 
 ---
 
+## 6. Interactive test-console Pod (optional)
+
+For demos: run [`extras/test-server/`](test-server/TEST-SERVER-README.md) — the two-pane
+test-console UI used to exercise CertSight's detections one at a time — inside the cluster
+instead of on the operator's laptop, so its use cases (file writes, TLS binds/connects,
+PKCS12/JKS loads) happen in-cluster and get picked up by the same Tetragon + cert-expiry-monitor
+already watching the node.
+
+```bash
+bash extras/openshift/scripts/deploy-test-server.sh
+```
+
+(also reachable via the [`openshift-utils.sh`](openshift/openshift-utils.sh) menu) — builds
+[`extras/test-server/Containerfile`](test-server/Containerfile), pushes it under a fresh tag to
+the internal registry (same reasoning as "Why a fresh tag, not just re-pushing `:latest`" below),
+and applies/updates [`extras/openshift/test-server-pod.yaml`](openshift/test-server-pod.yaml).
+
+Drive it:
+
+```bash
+oc port-forward -n certsight pod/cert-test-server 8090:8090   # then open http://localhost:8090
+```
+
+or skip the UI and run a use case straight from a shell:
+
+```bash
+oc rsh -n certsight cert-test-server
+python3 -c "from use_cases import USE_CASES_BY_ID; print(USE_CASES_BY_ID['fresh-test-cert'].run({}))"
+```
+
+No `hostPath`, `hostNetwork`, or elevated SCC needed — Tetragon's `fd_install`/`tcp_connect`
+kprobes are node-wide with no path or namespace filter (see
+[`tetragon-policies/certificate-file-access.yaml`](../tetragon-policies/certificate-file-access.yaml),
+[`tcp-connect-tls.yaml`](../tetragon-policies/tcp-connect-tls.yaml)), so this Pod's real
+file/network activity is picked up exactly like any other process on the node would be. The one
+thing it *can't* exercise is cert-analyzer's periodic filesystem scan (`CERT_SCAN_PATHS` above is
+restricted to literal host paths under `/host/etc/...`) — that needs the same `hostPath` +
+`spc_t` SELinux grant [`probe_tests/openshift-soak/job.yaml`](../probe_tests/openshift-soak/job.yaml)
+uses.
+
+The Kafka event pane (right-hand side of the UI) stays empty by default —
+`TEST_SERVER_KAFKA_HOST`/`TEST_SERVER_KAFKA_PORT` in `test-server-pod.yaml` point at an
+unreachable placeholder, and the consumer thread retries quietly in the background rather than
+crashing the server. Every use case still runs and triggers real detections; point those two env
+vars at a real broker if you also want the live event feed.
+
+> **If you ever edit `extras/test-server/Containerfile`**: `use_cases.py` locates
+> `cert-agent.jar` via `Path(__file__).resolve().parents[2]`, which assumes it lives at
+> `<repo-root>/extras/test-server/use_cases.py`. Copying the app files into a flatter directory
+> than that (e.g. straight into `/app`) makes `parents[2]` raise `IndexError` at import and the
+> container crash-loops on startup — the `WORKDIR /app/extras/test-server` in the checked-in
+> Containerfile is deliberately there to preserve that depth, not a stray leftover.
+
+---
+
 ## Rebuilding and redeploying after a code change
 
 Once the DaemonSet is up, iterating on `agent/`/`cert_analyzer.py` changes means getting a new
@@ -394,4 +449,5 @@ cardinality-cap checks over hours instead of a single burst — see
 To bring the whole demo (CRC, Tetragon, cert-analyzer, tracing policies, soak Job) back up after
 a host reboot without re-running every step above by hand, use the menu-driven
 [`extras/openshift/openshift-utils.sh`](openshift/openshift-utils.sh) — it currently offers
-"start the soak demo from a reboot" and is the home for future OpenShift utility scripts.
+"start the soak demo from a reboot", "rebuild/redeploy cert-analyzer", and "build/deploy the
+interactive test-console Pod" (§6 above), and is the home for future OpenShift utility scripts.

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -332,17 +332,43 @@ restricted to literal host paths under `/host/etc/...`) — that needs the same 
 `spc_t` SELinux grant [`probe_tests/openshift-soak/job.yaml`](../probe_tests/openshift-soak/job.yaml)
 uses.
 
-It *does* need a small `hostPath` grant (a dedicated `cert-test-server` ServiceAccount bound to
-the `hostmount-anyuid` SCC — narrower than `hostaccess`, since this Pod needs neither
-`hostNetwork` nor `hostPID`). Detection firing isn't enough on its own: cert-analyzer resolves
-every Tetragon-reported path as `HOST_PREFIX + path` before it can read the file (`agent/analyzer.py`),
-and a file this Pod writes under `/dev/shm` — a private per-container tmpfs — never exists at that
-resolved path on the node, no matter what Tetragon reports. `test-server-pod.yaml` mounts a
-`hostPath` volume at `/var/certsight-test-server` (same path in the container and on the node, so
-the `HOST_PREFIX` translation lands on the real file) and points `TEST_SERVER_CERT_DIR` at it —
-`use_cases.py`'s `_GENERATED_CERT_DIR` reads that env var, defaulting to the old `/dev/shm` path
-for the standalone (non-OpenShift) deployment where it's actually correct, since there
-test-server and cert-analyzer share one kernel/mount namespace.
+It *does* need a small `hostPath` grant (a dedicated `cert-test-server` ServiceAccount). Detection
+firing isn't enough on its own: cert-analyzer resolves every Tetragon-reported path as
+`HOST_PREFIX + path` before it can read the file (`agent/analyzer.py`), and a file this Pod writes
+under `/dev/shm` — a private per-container tmpfs — never exists at that resolved path on the node,
+no matter what Tetragon reports. `test-server-pod.yaml` mounts a `hostPath` volume at
+`/var/certsight-test-server` (same path in the container and on the node, so the `HOST_PREFIX`
+translation lands on the real file) and points `TEST_SERVER_CERT_DIR` at it — `use_cases.py`'s
+`_GENERATED_CERT_DIR` reads that env var, defaulting to the old `/dev/shm` path for the standalone
+(non-OpenShift) deployment where it's actually correct, since there test-server and cert-analyzer
+share one kernel/mount namespace.
+
+The narrower `hostmount-anyuid` SCC (just a hostPath grant, no `hostNetwork`/`hostPID`) is **not**
+enough for that mount, though: kubelet's `DirectoryOrCreate` labels a fresh hostPath dir with the
+confined `container_t` SELinux type, and any normal container gets an AVC write denial against it
+regardless of UID. Same root cause and fix as `probe_tests/openshift-soak/job.yaml`'s
+`host-pki-certs` mount — needs the `privileged` SCC (`seLinuxContext: RunAsAny`) plus
+`seLinuxOptions.type: spc_t` on both the init container that `chmod`s the mount and the main
+container that writes into it.
+
+The "Certificate blast radius explorer" / "Certificate chain explorer" links need a real
+Prometheus that's *scraped* cert-analyzer's `/metrics` — cert-analyzer's own `:9090` only exposes
+raw metrics for scraping, not a query API (see `TEST-SERVER-README.md`'s Prometheus section).
+Since CRC has cluster monitoring disabled by default (see the note near the top of this file) and
+enabling User Workload Monitoring just for this would need a Thanos Querier bearer-token/TLS dance
+`blast_radius.py`/`chain_explorer.py`'s plain `urllib` calls don't handle,
+[`extras/openshift/demo-prometheus.yaml`](openshift/demo-prometheus.yaml) deploys a minimal
+standalone Prometheus in the `certsight` namespace instead, scraping only
+`cert-expiry-monitor.certsight.svc:9090`:
+
+```bash
+oc apply -f extras/openshift/demo-prometheus.yaml
+```
+
+`test-server-pod.yaml`'s `TEST_SERVER_PROMETHEUS_URL` already points at it
+(`http://demo-prometheus.certsight.svc:9090`). This is purely a demo/test dependency, same
+reasoning as the SCC grant above — not meant to represent how a real deployment would wire up
+monitoring.
 
 The Kafka event pane (right-hand side of the UI) stays empty by default — the consumer thread
 retries quietly in the background rather than crashing the server, so every use case still runs

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -311,23 +311,19 @@ bash extras/openshift/scripts/deploy-test-server.sh
 (also reachable via the [`openshift-utils.sh`](openshift/openshift-utils.sh) menu) — builds
 [`extras/test-server/Containerfile`](test-server/Containerfile), pushes it under a fresh tag to
 the internal registry (same reasoning as "Why a fresh tag, not just re-pushing `:latest`" below),
-and applies/updates [`extras/openshift/test-server-pod.yaml`](openshift/test-server-pod.yaml).
+applies/updates [`extras/openshift/test-server-pod.yaml`](openshift/test-server-pod.yaml), and
+port-forwards it for you — the script prints `http://localhost:8090` once it's confirmed the
+console is actually responding.
 
-Drive it:
-
-```bash
-oc port-forward -n certsight pod/cert-test-server 8090:8090   # then open http://localhost:8090
-```
-
-or skip the UI and run a use case straight from a shell:
+Or skip the UI and run a use case straight from a shell:
 
 ```bash
 oc rsh -n certsight cert-test-server
 python3 -c "from use_cases import USE_CASES_BY_ID; print(USE_CASES_BY_ID['fresh-test-cert'].run({}))"
 ```
 
-No `hostPath`, `hostNetwork`, or elevated SCC needed — Tetragon's `fd_install`/`tcp_connect`
-kprobes are node-wide with no path or namespace filter (see
+No `hostNetwork`/`hostPID` needed — Tetragon's `fd_install`/`tcp_connect` kprobes are node-wide
+with no path or namespace filter (see
 [`tetragon-policies/certificate-file-access.yaml`](../tetragon-policies/certificate-file-access.yaml),
 [`tcp-connect-tls.yaml`](../tetragon-policies/tcp-connect-tls.yaml)), so this Pod's real
 file/network activity is picked up exactly like any other process on the node would be. The one
@@ -336,11 +332,71 @@ restricted to literal host paths under `/host/etc/...`) — that needs the same 
 `spc_t` SELinux grant [`probe_tests/openshift-soak/job.yaml`](../probe_tests/openshift-soak/job.yaml)
 uses.
 
-The Kafka event pane (right-hand side of the UI) stays empty by default —
-`TEST_SERVER_KAFKA_HOST`/`TEST_SERVER_KAFKA_PORT` in `test-server-pod.yaml` point at an
-unreachable placeholder, and the consumer thread retries quietly in the background rather than
-crashing the server. Every use case still runs and triggers real detections; point those two env
-vars at a real broker if you also want the live event feed.
+It *does* need a small `hostPath` grant (a dedicated `cert-test-server` ServiceAccount bound to
+the `hostmount-anyuid` SCC — narrower than `hostaccess`, since this Pod needs neither
+`hostNetwork` nor `hostPID`). Detection firing isn't enough on its own: cert-analyzer resolves
+every Tetragon-reported path as `HOST_PREFIX + path` before it can read the file (`agent/analyzer.py`),
+and a file this Pod writes under `/dev/shm` — a private per-container tmpfs — never exists at that
+resolved path on the node, no matter what Tetragon reports. `test-server-pod.yaml` mounts a
+`hostPath` volume at `/var/certsight-test-server` (same path in the container and on the node, so
+the `HOST_PREFIX` translation lands on the real file) and points `TEST_SERVER_CERT_DIR` at it —
+`use_cases.py`'s `_GENERATED_CERT_DIR` reads that env var, defaulting to the old `/dev/shm` path
+for the standalone (non-OpenShift) deployment where it's actually correct, since there
+test-server and cert-analyzer share one kernel/mount namespace.
+
+The Kafka event pane (right-hand side of the UI) stays empty by default — the consumer thread
+retries quietly in the background rather than crashing the server, so every use case still runs
+and triggers real detections either way. To get the live event feed, point the Pod at a real
+broker:
+
+```bash
+bash extras/openshift/scripts/deploy-test-server.sh                    # auto-detects the host IP
+bash extras/openshift/scripts/deploy-test-server.sh --kafka-host <ip>  # or set it explicitly
+```
+
+`TEST_SERVER_KAFKA_HOST` in `test-server-pod.yaml` is a `__TEST_SERVER_KAFKA_HOST__` substitution
+placeholder, not a literal value — the script fills it in (`--kafka-host` if given, else the
+host's default-route source IP via `ip -4 route get 1.1.1.1`) before `oc apply`. Don't `oc apply`
+the manifest directly; the raw placeholder is not a resolvable hostname.
+
+If Kafka is running on the operator's host machine (e.g. the local dev stack's broker) rather
+than in-cluster, two host-side things also have to be true — neither is tracked by this repo, so
+they don't survive a Kafka reinstall or a fresh host:
+
+1. **The broker must listen on more than `localhost`.** A single-node dev broker's
+   `/etc/kafka/server.properties` typically ships with `listeners=PLAINTEXT://localhost:9092` and
+   `advertised.listeners=PLAINTEXT://localhost:9092` — both loopback-only. The pod can open a TCP
+   connection to the bootstrap address, but the client then reconnects using whatever
+   `advertised.listeners` says, and `localhost` from inside the pod resolves to the pod's own
+   loopback, not the host. Fix:
+
+   ```bash
+   sudo sed -i \
+     -e 's|^listeners=PLAINTEXT://localhost:9092,CONTROLLER://localhost:9093|listeners=PLAINTEXT://0.0.0.0:9092,CONTROLLER://localhost:9093|' \
+     -e 's|^advertised.listeners=PLAINTEXT://localhost:9092|advertised.listeners=PLAINTEXT://<host-ip>:9092|' \
+     /etc/kafka/server.properties
+   sudo systemctl restart kafka   # brief outage for anything else consuming/producing right now
+   ```
+
+2. **`firewalld` must allow the port.** OpenShift's pod network (CRC's OVN overlay, or any other
+   CNI) reaches the host over its real interface, which lands in the host firewall's active zone
+   — a default `public` zone only allows a handful of named services (`ssh`, `cockpit`, ...), not
+   arbitrary ports:
+
+   ```bash
+   sudo firewall-cmd --add-port=9092/tcp --permanent
+   sudo firewall-cmd --reload
+   ```
+
+Verify from inside the Pod once both are done:
+
+```bash
+oc rsh -n certsight cert-test-server python3 -c \
+  "import socket; socket.create_connection(('<host-ip>', 9092), timeout=3); print('TCP connect OK')"
+```
+
+Note `<host-ip>` is typically DHCP-assigned — re-run `deploy-test-server.sh` (no `--kafka-host`)
+to re-detect it if it changes after a reboot, or check `ip -4 route get 1.1.1.1`.
 
 > **If you ever edit `extras/test-server/Containerfile`**: `use_cases.py` locates
 > `cert-agent.jar` via `Path(__file__).resolve().parents[2]`, which assumes it lives at

--- a/extras/openshift/daemonset.yaml
+++ b/extras/openshift/daemonset.yaml
@@ -59,6 +59,19 @@ spec:
           value: "300"
         - name: HOST_PREFIX
           value: "/host"
+        - name: KAFKA_ENABLED
+          value: "true"
+        - name: KAFKA_BOOTSTRAP_SERVERS
+          # The value below is a substitution placeholder --
+          # rebuild-redeploy-cert-analyzer.sh fills it in (--kafka-host if
+          # given, else the host's auto-detected default-route IP) before
+          # applying. Don't 'oc apply' this file directly; the raw
+          # placeholder is not a resolvable address. See the Kafka
+          # reachability section of extras/OPENSHIFT-DEPLOYMENT-README.md --
+          # this DaemonSet runs with hostNetwork: true, so once the host
+          # broker's listeners/advertised.listeners are off localhost and
+          # firewalld allows 9092/tcp, it reaches Kafka directly.
+          value: "__KAFKA_BOOTSTRAP_SERVERS__"
         volumeMounts:
         - name: tetragon-sock
           mountPath: /var/run/tetragon

--- a/extras/openshift/demo-prometheus.yaml
+++ b/extras/openshift/demo-prometheus.yaml
@@ -1,0 +1,102 @@
+# Minimal standalone Prometheus for the test-console's "Certificate blast
+# radius explorer" / "Certificate chain explorer" links (blast_radius.py /
+# chain_explorer.py) -- both query a real Prometheus's /api/v1/query API for
+# cert-analyzer's own tls_certificate_expiry_days / tls_certificate_self_signed
+# / tls_certificate_process_info series; cert-analyzer's own :9090 only
+# exposes raw /metrics for scraping, not a query API.
+#
+# Deliberately its own throwaway instance scraping only cert-expiry-monitor,
+# not OpenShift's User Workload Monitoring stack -- UWM is a cluster-wide
+# config change, and querying it needs bearer-token auth + TLS through Thanos
+# Querier's RBAC proxy that blast_radius.py/chain_explorer.py's plain
+# urllib.request.urlopen() calls don't handle. This is purely a demo/test
+# dependency, same reasoning as test-server-pod.yaml's own SCC grant.
+#
+# Deploy: oc apply -f extras/openshift/demo-prometheus.yaml
+# Then point test-server-pod.yaml's TEST_SERVER_PROMETHEUS_URL at
+# http://demo-prometheus.certsight.svc:9090 (already wired up there).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-prometheus-config
+  namespace: certsight
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+    - job_name: cert-expiry-monitor
+      static_configs:
+      - targets: ["cert-expiry-monitor.certsight.svc:9090"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-prometheus
+  namespace: certsight
+  labels:
+    app: demo-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-prometheus
+  template:
+    metadata:
+      labels:
+        app: demo-prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: quay.io/prometheus/prometheus:latest
+        args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.path=/prometheus
+        - --storage.tsdb.retention.time=6h
+        ports:
+        - containerPort: 9090
+          name: http
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 200m
+          requests:
+            memory: 64Mi
+            cpu: 50m
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+        - name: data
+          mountPath: /prometheus
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      volumes:
+      - name: config
+        configMap:
+          name: demo-prometheus-config
+      - name: data
+        emptyDir: {}
+      # No fixed runAsUser -- the default restricted-v2 SCC assigns one from
+      # the namespace's allocated range; the upstream Prometheus image
+      # already runs as an arbitrary non-root UID by default (see its own
+      # Dockerfile), so no extra grant is needed here unlike cert-test-server.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-prometheus
+  namespace: certsight
+  labels:
+    app: demo-prometheus
+spec:
+  selector:
+    app: demo-prometheus
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+    protocol: TCP
+  type: ClusterIP

--- a/extras/openshift/scripts/deploy-test-server.sh
+++ b/extras/openshift/scripts/deploy-test-server.sh
@@ -5,8 +5,49 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 NAMESPACE=certsight
+MANIFEST="$REPO_ROOT/extras/openshift/test-server-pod.yaml"
 
 step() { echo; echo "==> $*"; }
+
+KAFKA_HOST_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --kafka-host)
+            KAFKA_HOST_ARG="$2"
+            shift 2
+            ;;
+        --kafka-host=*)
+            KAFKA_HOST_ARG="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: $0 [--kafka-host <ip>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+step "Resolving the Kafka host"
+if [[ -n "$KAFKA_HOST_ARG" ]]; then
+    KAFKA_HOST="$KAFKA_HOST_ARG"
+    echo "Using --kafka-host: $KAFKA_HOST"
+else
+    # Default-route source IP -- the address the pod network can actually
+    # reach back to (see the Kafka reachability section of
+    # extras/OPENSHIFT-DEPLOYMENT-README.md for why plain localhost/127.0.0.1
+    # doesn't work here).
+    KAFKA_HOST=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')
+    if [[ -z "$KAFKA_HOST" ]]; then
+        echo "Could not auto-detect the host's IP -- pass it explicitly: $0 --kafka-host <ip>" >&2
+        exit 1
+    fi
+    echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
+fi
+
+render_manifest() {
+    sed "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" "$MANIFEST"
+}
 
 step "Checking cluster login"
 if ! oc whoami >/dev/null 2>&1; then
@@ -44,9 +85,18 @@ sudo podman tag localhost/cert-test-server:latest "$PUSH_IMAGE"
 sudo podman push --tls-verify=false "$PUSH_IMAGE"
 
 step "Deploying the Pod"
-if ! oc get pod cert-test-server -n "$NAMESPACE" >/dev/null 2>&1; then
-    oc apply -f "$REPO_ROOT/extras/openshift/test-server-pod.yaml"
+# Almost every field on a live Pod other than spec.containers[*].image is
+# immutable (env vars, volumes, serviceAccountName, ...), and this manifest
+# has grown several of those over time -- Kafka host, the hostPath mount for
+# TEST_SERVER_CERT_DIR, etc. Trying to special-case which fields changed has
+# already missed a real change once (the hostPath volume slipped through a
+# check that only compared image/Kafka-host). This is a lightweight demo
+# pod with no state worth preserving, so just always delete and recreate
+# rather than chase field-by-field drift detection.
+if oc get pod cert-test-server -n "$NAMESPACE" >/dev/null 2>&1; then
+    oc delete pod cert-test-server -n "$NAMESPACE" --wait=true
 fi
+render_manifest | oc apply -f -
 oc set image pod/cert-test-server test-server="$IN_CLUSTER_IMAGE" -n "$NAMESPACE"
 
 step "Waiting for the rollout"
@@ -61,9 +111,36 @@ oc get pod cert-test-server -n "$NAMESPACE" -o wide
 echo
 echo "Image now running: $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].image}')"
 echo "Digest:             $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+
+step "Port-forwarding to the Pod"
+PF_LOG="$(mktemp)"
+# Kill any stale forward left running from a previous invocation of this script.
+pkill -f "oc port-forward -n $NAMESPACE pod/cert-test-server 8090:8090" 2>/dev/null || true
+nohup oc port-forward -n "$NAMESPACE" pod/cert-test-server 8090:8090 >"$PF_LOG" 2>&1 &
+PF_PID=$!
+disown "$PF_PID"
+
+for _ in $(seq 1 20); do
+    if curl -sf -o /dev/null http://localhost:8090/; then
+        break
+    fi
+    if ! kill -0 "$PF_PID" 2>/dev/null; then
+        echo "port-forward exited unexpectedly:" >&2
+        cat "$PF_LOG" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+if ! curl -sf -o /dev/null http://localhost:8090/; then
+    echo "Port-forward did not come up in time — check $PF_LOG" >&2
+    exit 1
+fi
+
 echo
-echo "Drive it:  oc port-forward -n $NAMESPACE pod/cert-test-server 8090:8090   (then open http://localhost:8090)"
-echo "Or:        oc rsh -n $NAMESPACE cert-test-server"
+echo "Test console:  http://localhost:8090"
+echo "Stop it with:  kill $PF_PID"
+echo "Or shell in:   oc rsh -n $NAMESPACE cert-test-server"
 echo
 echo "Once you're happy with this build, tag a real version and update"
 echo "extras/openshift/test-server-pod.yaml's image field to match — the checked-in manifest"

--- a/extras/openshift/scripts/deploy-test-server.sh
+++ b/extras/openshift/scripts/deploy-test-server.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# description: Build the interactive test-console image and (re)deploy the cert-test-server Pod on OpenShift
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NAMESPACE=certsight
+
+step() { echo; echo "==> $*"; }
+
+step "Checking cluster login"
+if ! oc whoami >/dev/null 2>&1; then
+    echo "Not logged in to the cluster — run 'oc login ...' first." >&2
+    exit 1
+fi
+
+step "Building the test-server image"
+(cd "$REPO_ROOT/extras/test-server" && sudo podman build -t cert-test-server:latest -f Containerfile .)
+
+step "Locating the internal image registry route"
+HOST=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -z "$HOST" ]]; then
+    echo "Could not find the internal registry route. Enable it first:" >&2
+    echo "  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{\"spec\":{\"defaultRoute\":true}}' --type=merge" >&2
+    exit 1
+fi
+
+step "Logging into the internal registry"
+# Always sudo podman: extras/build.sh-style images are built via 'sudo podman build', which
+# writes into root's podman storage, separate from the current user's own storage.
+sudo podman login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$HOST"
+
+# A fresh tag every run, not :latest -- imagePullPolicy: IfNotPresent means a node that already
+# pulled ':latest' once will never re-pull it just because the registry content changed under
+# the same tag (see "Why a fresh tag, not just re-pushing :latest" in
+# extras/OPENSHIFT-DEPLOYMENT-README.md). A fresh tag was never cached, so the pull is
+# unconditionally fresh.
+TAG="dev-$(date +%s)"
+PUSH_IMAGE="$HOST/certsight/cert-test-server:$TAG"
+IN_CLUSTER_IMAGE="image-registry.openshift-image-registry.svc:5000/certsight/cert-test-server:$TAG"
+
+step "Tagging and pushing $PUSH_IMAGE"
+sudo podman tag localhost/cert-test-server:latest "$PUSH_IMAGE"
+sudo podman push --tls-verify=false "$PUSH_IMAGE"
+
+step "Deploying the Pod"
+if ! oc get pod cert-test-server -n "$NAMESPACE" >/dev/null 2>&1; then
+    oc apply -f "$REPO_ROOT/extras/openshift/test-server-pod.yaml"
+fi
+oc set image pod/cert-test-server test-server="$IN_CLUSTER_IMAGE" -n "$NAMESPACE"
+
+step "Waiting for the rollout"
+if ! oc wait --for=condition=Ready pod/cert-test-server -n "$NAMESPACE" --timeout=120s; then
+    echo "Pod not ready — check: oc get pod cert-test-server -n $NAMESPACE -o wide" >&2
+    echo "                       oc logs cert-test-server -n $NAMESPACE" >&2
+    exit 1
+fi
+
+step "Deployed"
+oc get pod cert-test-server -n "$NAMESPACE" -o wide
+echo
+echo "Image now running: $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].image}')"
+echo "Digest:             $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+echo
+echo "Drive it:  oc port-forward -n $NAMESPACE pod/cert-test-server 8090:8090   (then open http://localhost:8090)"
+echo "Or:        oc rsh -n $NAMESPACE cert-test-server"
+echo
+echo "Once you're happy with this build, tag a real version and update"
+echo "extras/openshift/test-server-pod.yaml's image field to match — the checked-in manifest"
+echo "should stay on a stable tag rather than $TAG."

--- a/extras/openshift/scripts/rebuild-redeploy-cert-analyzer.sh
+++ b/extras/openshift/scripts/rebuild-redeploy-cert-analyzer.sh
@@ -5,8 +5,48 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 NAMESPACE=certsight
+MANIFEST="$REPO_ROOT/extras/openshift/daemonset.yaml"
 
 step() { echo; echo "==> $*"; }
+
+KAFKA_HOST_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --kafka-host)
+            KAFKA_HOST_ARG="$2"
+            shift 2
+            ;;
+        --kafka-host=*)
+            KAFKA_HOST_ARG="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: $0 [--kafka-host <ip>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+step "Resolving the Kafka host"
+if [[ -n "$KAFKA_HOST_ARG" ]]; then
+    KAFKA_HOST="$KAFKA_HOST_ARG"
+    echo "Using --kafka-host: $KAFKA_HOST"
+else
+    # Default-route source IP -- the address the hostNetwork DaemonSet pod
+    # can actually reach the host broker on (see the Kafka reachability
+    # section of extras/OPENSHIFT-DEPLOYMENT-README.md).
+    KAFKA_HOST=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')
+    if [[ -z "$KAFKA_HOST" ]]; then
+        echo "Could not auto-detect the host's IP -- pass it explicitly: $0 --kafka-host <ip>" >&2
+        exit 1
+    fi
+    echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
+fi
+
+render_manifest() {
+    sed "s#__KAFKA_BOOTSTRAP_SERVERS__#$KAFKA_HOST:9092#g" "$MANIFEST"
+}
 
 step "Checking cluster login"
 if ! oc whoami >/dev/null 2>&1; then
@@ -44,6 +84,9 @@ IN_CLUSTER_IMAGE="image-registry.openshift-image-registry.svc:5000/certsight/cer
 step "Tagging and pushing $PUSH_IMAGE"
 sudo podman tag localhost/cert-analyzer:latest "$PUSH_IMAGE"
 sudo podman push --tls-verify=false "$PUSH_IMAGE"
+
+step "Applying the DaemonSet manifest"
+render_manifest | oc apply -f -
 
 step "Pointing the DaemonSet at the new tag"
 oc set image daemonset/cert-expiry-monitor analyzer="$IN_CLUSTER_IMAGE" -n "$NAMESPACE"

--- a/extras/openshift/test-server-pod.yaml
+++ b/extras/openshift/test-server-pod.yaml
@@ -102,6 +102,15 @@ spec:
       value: "__TEST_SERVER_KAFKA_HOST__"
     - name: TEST_SERVER_KAFKA_PORT
       value: "9092"
+    - name: TEST_SERVER_PROMETHEUS_URL
+      # server.py defaults to http://127.0.0.1:9090, correct only in the
+      # standalone deployment where a real Prometheus and cert-analyzer share
+      # a host. In-cluster, cert-analyzer's own :9090 only exposes raw
+      # /metrics for scraping, not a query API -- this points at the
+      # standalone demo Prometheus in demo-prometheus.yaml instead, which
+      # scrapes cert-expiry-monitor and serves /api/v1/query for
+      # blast_radius.py / chain_explorer.py.
+      value: "http://demo-prometheus.certsight.svc:9090"
     - name: TEST_SERVER_CERT_DIR
       # Overrides use_cases.py's /dev/shm default -- see that file's comment
       # above _GENERATED_CERT_DIR. /dev/shm is a private per-container tmpfs

--- a/extras/openshift/test-server-pod.yaml
+++ b/extras/openshift/test-server-pod.yaml
@@ -13,7 +13,12 @@
 #   sudo podman push --tls-verify=false "$HOST/certsight/cert-test-server:latest"
 #
 # Deploy:
-#   oc apply -f extras/openshift/test-server-pod.yaml
+#   bash extras/openshift/scripts/deploy-test-server.sh [--kafka-host <ip>]
+#
+#   TEST_SERVER_KAFKA_HOST below is a substitution placeholder -- the script
+#   fills it in (with --kafka-host if given, else the host's auto-detected
+#   default-route IP) before applying. Don't 'oc apply' this file directly;
+#   the raw placeholder would be taken as a literal, unreachable hostname.
 #
 # Drive it:
 #   oc port-forward -n certsight pod/cert-test-server 8090:8090
@@ -24,6 +29,37 @@
 #   oc rsh -n certsight cert-test-server
 #   python3 -c "from use_cases import USE_CASES_BY_ID; print(USE_CASES_BY_ID['fresh-test-cert'].run({}))"
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-test-server
+  namespace: certsight
+---
+# hostmount-anyuid (the narrower SCC that just permits a hostPath volume) is
+# NOT enough: kubelet's DirectoryOrCreate labels a fresh hostPath dir with
+# the confined container_t SELinux type, and a normal container -- any UID,
+# hostmount-anyuid included -- gets an AVC write denial against it regardless
+# of DAC permissions. Same root cause as probe_tests/openshift-soak/job.yaml's
+# host-pki-certs mount; same fix: the spc_t (super-privileged container)
+# SELinux type below, which requires the privileged SCC (seLinuxContext:
+# RunAsAny) to request. This Pod is purely a demo/test tool, not part of the
+# deployed product, so the wider grant here doesn't affect cert-analyzer's
+# own security posture. Equivalent to:
+#   oc adm policy add-scc-to-user privileged -z cert-test-server -n certsight
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-test-server-privileged-scc
+  namespace: certsight
+subjects:
+- kind: ServiceAccount
+  name: cert-test-server
+  namespace: certsight
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: cert-test-server
@@ -31,6 +67,26 @@ metadata:
   labels:
     app: cert-test-server
 spec:
+  serviceAccountName: cert-test-server
+  initContainers:
+  - name: fix-cert-dir-perms
+    # kubelet's DirectoryOrCreate creates the hostPath below as root:root
+    # 0755 the first time -- unwritable by the main container's non-root
+    # image UID. Reusing the same image avoids an extra pull; this needs
+    # root and default capabilities so chmod on a directory it doesn't own
+    # actually works ('drop: ALL' would strip CAP_FOWNER and defeat the
+    # point), plus spc_t (see the RoleBinding comment above) so SELinux
+    # doesn't block the chmod regardless of UID/capabilities.
+    image: image-registry.openshift-image-registry.svc:5000/certsight/cert-test-server:latest
+    imagePullPolicy: IfNotPresent
+    command: ["chmod", "0777", "/var/certsight-test-server"]
+    volumeMounts:
+    - name: generated-certs
+      mountPath: /var/certsight-test-server
+    securityContext:
+      runAsUser: 0
+      seLinuxOptions:
+        type: spc_t
   containers:
   - name: test-server
     # Internal OpenShift registry path -- see the build/push steps above.
@@ -38,14 +94,21 @@ spec:
     imagePullPolicy: IfNotPresent
     env:
     - name: TEST_SERVER_KAFKA_HOST
-      # Placeholder -- the Kafka consumer thread retries quietly in the
-      # background and never crashes the server (see server.py's
-      # _consume_kafka), so an unreachable default is safe. Point this at a
-      # real broker if you want the live right-hand event pane; every other
-      # use case works without it.
-      value: "127.0.0.1"
+      # Substituted by deploy-test-server.sh -- see the Deploy note above and
+      # extras/OPENSHIFT-DEPLOYMENT-README.md's Kafka reachability section.
+      # Requires the host broker's listeners/advertised.listeners bound off
+      # localhost and firewalld port 9092/tcp open (both host-side, not
+      # tracked by this repo).
+      value: "__TEST_SERVER_KAFKA_HOST__"
     - name: TEST_SERVER_KAFKA_PORT
       value: "9092"
+    - name: TEST_SERVER_CERT_DIR
+      # Overrides use_cases.py's /dev/shm default -- see that file's comment
+      # above _GENERATED_CERT_DIR. /dev/shm is a private per-container tmpfs
+      # here, invisible to cert-analyzer's /host bind mount no matter what's
+      # written there; this path is hostPath-backed (volumes below) so it's
+      # the same file on both sides of that mount.
+      value: "/var/certsight-test-server"
     resources:
       limits:
         memory: 256Mi
@@ -57,19 +120,41 @@ spec:
     - containerPort: 8090
       name: http
       protocol: TCP
+    volumeMounts:
+    - name: generated-certs
+      mountPath: /var/certsight-test-server
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL
-  # No hostPath, hostNetwork, or elevated SCC -- OpenShift's default
-  # restricted-v2 SCC is enough. Detections rely on Tetragon's node-wide
-  # fd_install / tcp_connect kprobes, which have no path or namespace filter
-  # (see tetragon-policies/certificate-file-access.yaml and
-  # tcp-connect-tls.yaml), so they fire for this pod's real file/network
-  # activity same as they would for any other process on the node. The only
-  # thing this pod can't reach is cert-analyzer's periodic filesystem *scan*
-  # (CERT_SCAN_PATHS in daemonset.yaml is restricted to literal host paths
-  # under /host/etc/...) -- that one needs the same hostPath + spc_t grant
-  # probe_tests/openshift-soak/job.yaml uses.
+      # spc_t so writes into the hostPath mount above aren't AVC-denied --
+      # see the RoleBinding comment. Otherwise unprivileged: no runAsUser
+      # override (still the image's non-root default), same capability drop
+      # as before.
+      seLinuxOptions:
+        type: spc_t
+  volumes:
+  - name: generated-certs
+    # Mounted at the *same* path in both places deliberately: cert-analyzer
+    # resolves Tetragon-reported paths as HOST_PREFIX + path (agent/analyzer.py),
+    # so a cert this container writes to /var/certsight-test-server/x.crt only
+    # resolves to a real file at cert-analyzer's /host/var/certsight-test-server/x.crt
+    # if that's genuinely where it landed on the node -- i.e. hostPath and
+    # mountPath must match.
+    hostPath:
+      path: /var/certsight-test-server
+      type: DirectoryOrCreate
+  # hostNetwork/hostPID still aren't needed -- Tetragon's node-wide fd_install /
+  # tcp_connect kprobes (see tetragon-policies/certificate-file-access.yaml and
+  # tcp-connect-tls.yaml) have no path or namespace filter, so they fire for
+  # this Pod's real file/network activity same as they would for any other
+  # process on the node. hostPath above is only there so a file this Pod
+  # writes is resolvable through cert-analyzer's /host bind mount -- without
+  # it, cert-analyzer would see the Tetragon event but the path would never
+  # resolve to a readable file (logged as "Skipping non-regular-file cert
+  # path"), and no Kafka event would follow. This pod still can't reach
+  # cert-analyzer's periodic filesystem *scan* (CERT_SCAN_PATHS in
+  # daemonset.yaml is restricted to literal host paths under /host/etc/...)
+  # -- that's a separate mechanism from the Tetragon-driven detection above.
   restartPolicy: Never

--- a/extras/openshift/test-server-pod.yaml
+++ b/extras/openshift/test-server-pod.yaml
@@ -1,0 +1,75 @@
+# Interactive test-console Pod for demos: runs extras/test-server/ in-cluster
+# so use cases (file writes, TLS binds/connects, PKCS12/JKS loads) happen
+# inside the OpenShift cluster instead of on the operator's laptop, and get
+# picked up by the same Tetragon + cert-expiry-monitor already watching the
+# node.
+#
+# Build & push (same pattern as extras/openshift/scripts/rebuild-redeploy-cert-analyzer.sh):
+#   cd extras/test-server
+#   sudo podman build -t cert-test-server:latest -f Containerfile .
+#   HOST=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+#   sudo podman login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$HOST"
+#   sudo podman tag localhost/cert-test-server:latest "$HOST/certsight/cert-test-server:latest"
+#   sudo podman push --tls-verify=false "$HOST/certsight/cert-test-server:latest"
+#
+# Deploy:
+#   oc apply -f extras/openshift/test-server-pod.yaml
+#
+# Drive it:
+#   oc port-forward -n certsight pod/cert-test-server 8090:8090
+#   # then open http://localhost:8090
+#
+# Or skip the UI and run a use case from a shell instead (params dict is
+# whatever that use case's UseCaseParam list expects, {} for none):
+#   oc rsh -n certsight cert-test-server
+#   python3 -c "from use_cases import USE_CASES_BY_ID; print(USE_CASES_BY_ID['fresh-test-cert'].run({}))"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cert-test-server
+  namespace: certsight
+  labels:
+    app: cert-test-server
+spec:
+  containers:
+  - name: test-server
+    # Internal OpenShift registry path -- see the build/push steps above.
+    image: image-registry.openshift-image-registry.svc:5000/certsight/cert-test-server:latest
+    imagePullPolicy: IfNotPresent
+    env:
+    - name: TEST_SERVER_KAFKA_HOST
+      # Placeholder -- the Kafka consumer thread retries quietly in the
+      # background and never crashes the server (see server.py's
+      # _consume_kafka), so an unreachable default is safe. Point this at a
+      # real broker if you want the live right-hand event pane; every other
+      # use case works without it.
+      value: "127.0.0.1"
+    - name: TEST_SERVER_KAFKA_PORT
+      value: "9092"
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 500m
+      requests:
+        memory: 64Mi
+        cpu: 100m
+    ports:
+    - containerPort: 8090
+      name: http
+      protocol: TCP
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  # No hostPath, hostNetwork, or elevated SCC -- OpenShift's default
+  # restricted-v2 SCC is enough. Detections rely on Tetragon's node-wide
+  # fd_install / tcp_connect kprobes, which have no path or namespace filter
+  # (see tetragon-policies/certificate-file-access.yaml and
+  # tcp-connect-tls.yaml), so they fire for this pod's real file/network
+  # activity same as they would for any other process on the node. The only
+  # thing this pod can't reach is cert-analyzer's periodic filesystem *scan*
+  # (CERT_SCAN_PATHS in daemonset.yaml is restricted to literal host paths
+  # under /host/etc/...) -- that one needs the same hostPath + spc_t grant
+  # probe_tests/openshift-soak/job.yaml uses.
+  restartPolicy: Never

--- a/extras/test-server/Containerfile
+++ b/extras/test-server/Containerfile
@@ -1,0 +1,42 @@
+ARG UBI_VERSION=9
+ARG PYTHON_VERSION=311
+
+FROM registry.access.redhat.com/ubi${UBI_VERSION}/python-${PYTHON_VERSION}:latest
+
+ARG PIP_INDEX_URL=https://pypi.org/simple/
+ARG PIP_TRUSTED_HOST=pypi.org
+
+USER 0
+
+# use_cases.py locates probe_tests/java/cert-agent/cert-agent.jar via
+# Path(__file__).resolve().parents[2], assuming it lives at
+# <repo-root>/extras/test-server/use_cases.py -- a flat /app copy leaves too
+# few parent directories and parents[2] raises IndexError at import time, so
+# this mirrors the same repo-relative depth instead of flattening it.
+WORKDIR /app/extras/test-server
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir \
+    --index-url ${PIP_INDEX_URL} \
+    --trusted-host ${PIP_TRUSTED_HOST} \
+    -r requirements.txt
+
+COPY server.py use_cases.py blast_radius.py chain_explorer.py \
+     tls_probe_helper.py tcp_connect_probe_helper.py CertAgentTest.java ./
+COPY static ./static
+
+# Unlike probe_tests/openshift-soak/'s image, this one needs no hostPath
+# writes or privileged SCC -- use cases here write generated certs under
+# /dev/shm (world-writable in any container) and the detections that matter
+# for a demo (fd_install / tcp_connect kprobes) are node-wide and fire
+# regardless of which pod triggered them. OpenShift's default restricted-v2
+# SCC will assign a random non-root UID at runtime and override this image's
+# USER 0 anyway.
+#
+# --bind must be 0.0.0.0 here (the upstream default of 127.0.0.1 is meant for
+# the "don't expose beyond localhost" local-host use case in
+# TEST-SERVER-README.md) so the UI is reachable via 'oc port-forward'.
+ENV TEST_SERVER_BIND=0.0.0.0
+EXPOSE 8090
+
+ENTRYPOINT ["python3", "-u", "server.py"]

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -11,6 +11,7 @@ performs the action and returns a UseCaseResult. Nothing else needs to
 change -- server.py and the frontend both read this list at request time.
 """
 import ctypes
+import os
 import queue
 import re
 import subprocess
@@ -72,7 +73,15 @@ class UseCase:
 # ProtectHome=true (which only covers /home, /root, /run/user) or
 # ProtectSystem=strict (which leaves /dev alone), so it's visible to both
 # this script and cert-analyzer, and world-writable like /tmp.
-_GENERATED_CERT_DIR = Path("/dev/shm/certsight-test-server")
+#
+# This reasoning only holds when test-server and cert-analyzer share a
+# kernel/mount namespace (the standalone host deployment). Under OpenShift
+# (extras/openshift/test-server-pod.yaml), /dev/shm is a private per-container
+# tmpfs -- invisible to cert-analyzer's own /host bind mount no matter what's
+# written there. TEST_SERVER_CERT_DIR overrides this for that deployment,
+# pointed at a hostPath-backed directory instead; see the Kafka reachability
+# section of extras/OPENSHIFT-DEPLOYMENT-README.md.
+_GENERATED_CERT_DIR = Path(os.environ.get("TEST_SERVER_CERT_DIR", "/dev/shm/certsight-test-server"))
 
 # CertSight's FIPS compliance checker (agent/fips_compliance_checker.py)
 # flags RSA keys under 2048 bits, so 1024 reliably triggers a
@@ -912,12 +921,12 @@ USE_CASES: List[UseCase] = [
         id="fresh-test-cert",
         label="generate + read a fresh test certificate",
         description=(
-            "Generates a new self-signed certificate at a unique path under "
-            "/dev/shm and cat's it. Guaranteed to be a first-time discovery "
-            "every click, so a new Kafka event always appears. Pick a key size "
-            "below 2048 bits to trigger a FIPS non-compliance finding, or check "
-            "'expired' to generate a cert that's already past its validity "
-            "window and verify CertSight flags that in the Kafka event."
+            f"Generates a new self-signed certificate at a unique path under "
+            f"{_GENERATED_CERT_DIR} and cat's it. Guaranteed to be a first-time "
+            "discovery every click, so a new Kafka event always appears. Pick a "
+            "key size below 2048 bits to trigger a FIPS non-compliance finding, "
+            "or check 'expired' to generate a cert that's already past its "
+            "validity window and verify CertSight flags that in the Kafka event."
         ),
         run=_generate_and_read_fresh_cert,
         params=[
@@ -945,7 +954,7 @@ USE_CASES: List[UseCase] = [
         ],
         pipeline=[
             "This server generates a self-signed X.509 certificate in memory "
-            "and writes it to a brand-new path under /dev/shm/certsight-test-server/.",
+            f"and writes it to a brand-new path under {_GENERATED_CERT_DIR}/.",
 
             "This server then runs 'cat <path>' as a real subprocess -- a real "
             "process performing a real open()/read() of that file, no different "
@@ -999,7 +1008,7 @@ USE_CASES: List[UseCase] = [
         run=_bind_tls_service_for_discovery,
         pipeline=[
             "This server generates a fresh self-signed X.509 cert + private "
-            "key in memory and writes both to /dev/shm/certsight-test-server/.",
+            f"key in memory and writes both to {_GENERATED_CERT_DIR}/.",
 
             "This server spawns tls_probe_helper.py as a separate OS "
             "process (not a thread) specifically so the bind() call below "
@@ -1065,7 +1074,7 @@ USE_CASES: List[UseCase] = [
         run=_dial_outbound_tls_port,
         pipeline=[
             "This server generates a fresh self-signed X.509 cert + private "
-            "key in memory and writes both to /dev/shm/certsight-test-server/.",
+            f"key in memory and writes both to {_GENERATED_CERT_DIR}/.",
 
             "This server spawns tcp_connect_probe_helper.py as a separate OS "
             "process (not a thread) specifically so the connect() call below "
@@ -1219,7 +1228,7 @@ USE_CASES: List[UseCase] = [
         pipeline=[
             "This server generates a fresh self-signed X.509 cert and "
             "writes it to a throwaway path under "
-            "/dev/shm/certsight-test-server/ -- only as seed input for the "
+            f"{_GENERATED_CERT_DIR}/ -- only as seed input for the "
             "JVM below to load once at startup, not as something "
             "cert-analyzer is meant to detect itself (its extension is "
             "deliberately not one of certificate-file-access.yaml's "
@@ -1374,7 +1383,7 @@ USE_CASES: List[UseCase] = [
             "This server drops the same N intermediates closest to the "
             "root, but writes each *surviving* cert (leaf, remaining "
             "intermediates, root) to its own separate file under "
-            "/dev/shm/certsight-test-server/, running 'cat <path>' "
+            f"{_GENERATED_CERT_DIR}/, running 'cat <path>' "
             "against each one individually -- so this is several real "
             "open()/read() calls, not one.",
 


### PR DESCRIPTION
extras/test-server/ previously only ran on the operator's own host. Adds a Containerfile, a Pod manifest, and a deploy-test-server.sh utility (auto-picked up by openshift-utils.sh) so the same use cases can run inside the cluster and be picked up by Tetragon/cert-analyzer there instead. No hostPath/hostNetwork/elevated SCC needed since Tetragon's kprobes are node-wide. Documents the manifest's WORKDIR-depth requirement (use_cases.py's parents[2] lookup) so a future Containerfile edit doesn't reintroduce the import crash found while validating this against a live CRC cluster.