### PR TITLE
Filter test-console Kafka pane to only the active browser tab's events

### DIFF
--- a/extras/test-server/server.py
+++ b/extras/test-server/server.py
@@ -229,7 +229,7 @@ def make_handler(broadcaster: EventBroadcaster, prometheus_url: str):
                 # error -- always return a clean 500 with the exception text.
                 logger.exception("use case '%s' raised", use_case_id)
                 result = UseCaseResult(ok=False, detail=f"use case raised an unhandled exception: {sys.exc_info()[1]}")
-            body = json.dumps({"ok": result.ok, "detail": result.detail}).encode("utf-8")
+            body = json.dumps({"ok": result.ok, "detail": result.detail, "token": result.token}).encode("utf-8")
             self.send_response(200 if result.ok else 500)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))

--- a/extras/test-server/static/app.js
+++ b/extras/test-server/static/app.js
@@ -104,6 +104,35 @@ async function loadUseCases() {
   }
 }
 
+// Tracks the CN tokens this browser tab's own use-case runs have generated
+// (see use_cases.py's `token = uuid.uuid4().hex[:12]`, folded into every CN
+// it produces) so the Kafka pane can show only this visitor's activity
+// instead of everyone's on a shared/public test-server instance. Backed by
+// sessionStorage so a reload doesn't lose it, but scoped to the tab -- a
+// fresh tab is a fresh "session" with no prior activity to filter in.
+const MY_TOKENS_KEY = 'certsight-my-tokens';
+
+function loadMyTokens() {
+  try {
+    return new Set(JSON.parse(sessionStorage.getItem(MY_TOKENS_KEY) || '[]'));
+  } catch (err) {
+    return new Set();
+  }
+}
+
+function rememberMyToken(token) {
+  if (!token) return;
+  myTokens.add(token);
+  try {
+    sessionStorage.setItem(MY_TOKENS_KEY, JSON.stringify([...myTokens]));
+  } catch (err) {
+    // sessionStorage unavailable (e.g. private browsing) -- filtering still
+    // works for the rest of this page load via the in-memory Set alone
+  }
+}
+
+const myTokens = loadMyTokens();
+
 async function runUseCase(id, button, li) {
   const status = document.getElementById('run-status');
   button.disabled = true;
@@ -132,6 +161,7 @@ async function runUseCase(id, button, li) {
       return;
     }
     const result = await res.json();
+    rememberMyToken(result.token);
     setRichText(status, result.detail);
     status.className = result.ok ? 'ok' : 'error';
   } catch (err) {
@@ -146,14 +176,21 @@ function connectEventStream() {
   const log = document.getElementById('event-log');
   const source = new EventSource('/api/events');
   source.onmessage = (evt) => {
-    let text = evt.data;
+    let parsed;
     try {
-      text = JSON.stringify(JSON.parse(evt.data), null, 2);
+      parsed = JSON.parse(evt.data);
     } catch (err) {
-      // not JSON -- show the raw payload as-is
+      // not JSON -- cert-analyzer's schema is always JSON in practice, but
+      // there's no CN to attribute this to, so drop it rather than risk
+      // showing another visitor's activity
+      return;
     }
+    const commonName = parsed && typeof parsed.common_name === 'string' ? parsed.common_name : '';
+    const isMine = [...myTokens].some((token) => commonName.includes(token));
+    if (!isMine) return;
+
     const entry = document.createElement('pre');
-    entry.textContent = `[${new Date().toLocaleTimeString()}]\n${text}`;
+    entry.textContent = `[${new Date().toLocaleTimeString()}]\n${JSON.stringify(parsed, null, 2)}`;
     log.prepend(entry);
   };
 }

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -34,6 +34,12 @@ from cryptography.x509.oid import NameOID
 class UseCaseResult:
     ok: bool
     detail: str
+    # The random token folded into every CN this run generated (see the
+    # per-use-case `token = uuid.uuid4().hex[:12]` lines below) -- returned
+    # to the browser so it can tell its own Kafka events apart from other
+    # visitors' on a shared/public test-server instance. Empty on failure,
+    # since a failed run never produces a cert for cert-analyzer to see.
+    token: str = ""
 
 
 @dataclass
@@ -222,6 +228,7 @@ def _generate_and_read_fresh_cert(params: dict) -> UseCaseResult:
             "guarantee CertSight treats this as a first-time discovery, so a new "
             "Kafka event should always appear"
         ),
+        token=token,
     )
 
 
@@ -352,6 +359,7 @@ def _generate_chain_with_missing_intermediates(params: dict) -> UseCaseResult:
             f"cat'd it -- expect the chain-explorer view to show a MISSING gap between "
             f"{gap_note} and the root"
         ),
+        token=token,
     )
 
 
@@ -416,6 +424,7 @@ def _generate_chain_across_multiple_files(params: dict) -> UseCaseResult:
             f"MISSING even with intermediates dropped -- single-cert bundles are never flagged "
             f"missing, to avoid flagging every ordinary standalone leaf cert on the host"
         ),
+        token=token,
     )
 
 
@@ -516,6 +525,7 @@ def _bind_tls_service_for_discovery(params: dict) -> UseCaseResult:
             "IP on OpenShift, or 127.0.0.1 on a bare-metal/host-network deployment) and "
             f"confirm its 'pid' field reads {proc.pid} -- the same process that bound the socket"
         ),
+        token=token,
     )
 
 
@@ -635,6 +645,7 @@ def _dial_outbound_tls_port(params: dict) -> UseCaseResult:
             "cache. This is independent of the bind-probe use case's own dedup, even against "
             "the identical 127.0.0.1:<port> -- each mechanism now tracks its own discoveries."
         ),
+        token=token,
     )
 
 
@@ -715,6 +726,7 @@ def _load_in_memory_cert_via_libssl(params: dict) -> UseCaseResult:
             "ever written to disk -- unique serial guarantees CertSight treats this as a "
             "first-time discovery, so a new Kafka event should always appear"
         ),
+        token=token,
     )
 
 
@@ -914,6 +926,7 @@ def _run_java_keystore_cert(params: dict) -> UseCaseResult:
             f"~{int(_JAVA_KEYSTORE_LOOP_INTERVAL_MS / 1000) + 1}s; unique PID+serial guarantees "
             "a first-time discovery"
         ),
+        token=token,
     )
 
 

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -5088,15 +5088,19 @@ class TestRetryQueueDrainer:
         """A throttled file sitting in the queue is fully processed once tokens free up."""
         from agent.analyzer import _TokenBucket
 
-        # Start fully exhausted so the initial enqueue is forced, then refill
-        # fast (10/sec) so the drainer's own backoff loop picks it up quickly.
-        bucket = _TokenBucket(rate=10)
-        bucket._tokens = 0
-        analyzer._new_cert_rate_limiter = bucket
-
         cert, _ = TestCertificateGeneration.generate_certificate("drain-me.example.com", 365)
         path = os.path.join(temp_dir, "drain-me.pem")
         TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        # Exhaust the bucket right before the throttled call, not before cert
+        # generation above -- keygen+signing+disk-write can occasionally take
+        # >100ms under CI load, long enough at 10/sec for a token to trickle
+        # back in and make this call succeed instead of queue, flaking the
+        # assertion below. Refilled fast (10/sec) so the drainer's own
+        # backoff loop still picks the queued entry up quickly.
+        bucket = _TokenBucket(rate=10)
+        bucket._tokens = 0
+        analyzer._new_cert_rate_limiter = bucket
 
         result = analyzer._analyze_and_finish_new_certificate_file(
             path, "test", 1, "", None, "", 0, "test-node",
@@ -5125,13 +5129,17 @@ class TestRetryQueueDrainer:
     def test_drainer_preserves_original_process_attribution_on_replay(self, analyzer, temp_dir, monkeypatch):
         """Unlike periodic_scan's rediscovery, a replay keeps the real triggering process/pid."""
         from agent.analyzer import _TokenBucket
-        bucket = _TokenBucket(rate=10)
-        bucket._tokens = 0
-        analyzer._new_cert_rate_limiter = bucket
 
         cert, _ = TestCertificateGeneration.generate_certificate("attributed.example.com", 365)
         path = os.path.join(temp_dir, "attributed.pem")
         TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        # Exhaust the bucket right before the throttled call -- see the
+        # matching comment in test_drainer_replays_queued_entry_once_capacity_available
+        # for why this can't happen before cert generation above.
+        bucket = _TokenBucket(rate=10)
+        bucket._tokens = 0
+        analyzer._new_cert_rate_limiter = bucket
 
         analyzer._analyze_and_finish_new_certificate_file(
             path, "/usr/bin/original-proc", 4242, "", None, "", 0, "test-node",


### PR DESCRIPTION
Right-hand pane previously showed every visitor's Kafka activity on a shared/public test-server instance. Each use case already folds a random
per-run token into every CN it generates, so reuse that: /api/run/<id>
now returns the token, app.js remembers its own (per-tab, sessionStorage) and only renders SSE events whose common_name contains one it caused.