### PR TITLE
Fix openssl3-cert-load uprobe path for containerized OpenShift Tetragon

### DIFF
--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -247,17 +247,30 @@ kubectl apply -f tetragon-policies/experimental/tls-service-tracking.yaml
 kubectl get tracingpolicies
 ```
 
-**Known gap on containerized/RHCOS nodes**: the `openssl3-cert-load`, `java-fips-nss-cert`, and
-`java-non-fips-cert` experimental policies are host-uprobe policies that hook a specific
-absolute host library/agent path (`/usr/lib64/libssl.so.3`, `libsoftokn3.so`, the cert-agent
-native stub respectively). On a bare RHCOS node none of these paths exist by default, so the
-tetragon agent logs `adding tracing policy failed: open <path>: no such file or directory` for
-each and the policy simply doesn't attach — this is expected, not a misconfiguration, unless
-those libraries/agents are actually present at those exact host paths (e.g. via the optional
-Java agent RPM, or a workload that installs OpenSSL 3 at the host level rather than inside its
-own container image). Revisit whether in-memory OpenSSL/Java cert detection is in scope for the
-pilot, and if so, confirm the actual library paths on the real pilot cluster's nodes before
-assuming these three policies will "just work".
+**Known gap on containerized nodes — two distinct failure classes.** All three experimental
+uprobe policies (`openssl3-cert-load`, `java-fips-nss-cert`, `java-non-fips-cert`) fail to load
+on the OpenShift/CRC Tetragon DaemonSet with `adding tracing policy failed: open <path>: no such
+file or directory`, but for different reasons:
+
+- `java-fips-nss-cert` (`/usr/lib64/libsoftokn3.so`) and `java-non-fips-cert`
+  (`/opt/cert-agent/libcert_agent_stub.so`) fail because those paths genuinely don't exist on a
+  bare RHCOS node — confirmed via `oc debug node`. This is expected, not a misconfiguration,
+  unless those libraries/agents are actually installed at those exact host paths (e.g. via the
+  optional Java agent RPM). Revisit whether in-memory Java cert detection is in scope for the
+  pilot, and if so, confirm the actual paths on the real pilot cluster's nodes first.
+- `openssl3-cert-load` (`/usr/lib64/libssl.so.3`) fails for a *different* reason: the library
+  genuinely exists on the RHCOS host (`openssl-libs` RPM), but the Tetragon DaemonSet's
+  container only mounts host `/proc` (at `/procRoot`, used internally for cgroup resolution) —
+  it has no view of host `/usr/lib64` in its own mount namespace, so the plain host path can't
+  be opened from inside the container. Use
+  [`tetragon-policies/experimental/openshift/openssl3-cert-load.yaml`](../tetragon-policies/experimental/openshift/openssl3-cert-load.yaml)
+  instead of the bare-metal version for containerized/OpenShift deployments — it rewrites both
+  uprobe paths to `/procRoot/1/root/usr/lib64/libssl.so.3`, reusing the same host-proc mount
+  Tetragon already has rather than patching the Helm-managed DaemonSet with an extra host-root
+  volume. Verified loading cleanly (`Loaded generic uprobe sensor ... (3 functions)`, no error)
+  against CRC. The plain `tetragon-policies/experimental/openssl3-cert-load.yaml` stays correct
+  as-is for the bare-metal RHEL9 RPM deployment, where Tetragon runs directly on the host and
+  already sees `/usr/lib64` natively — don't apply the `/procRoot`-prefixed variant there.
 
 ---
 

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -244,13 +244,18 @@ Identical to the vanilla Kubernetes path — `TracingPolicy` is a cluster-scoped
 kubectl apply -f tetragon-policies/certificate-file-access.yaml
 kubectl apply -f tetragon-policies/tcp-connect-tls.yaml
 kubectl apply -f tetragon-policies/experimental/tls-service-tracking.yaml
+kubectl apply -f tetragon-policies/experimental/openshift/openssl3-cert-load.yaml
 kubectl get tracingpolicies
 ```
 
-**Known gap on containerized nodes — two distinct failure classes.** All three experimental
-uprobe policies (`openssl3-cert-load`, `java-fips-nss-cert`, `java-non-fips-cert`) fail to load
-on the OpenShift/CRC Tetragon DaemonSet with `adding tracing policy failed: open <path>: no such
-file or directory`, but for different reasons:
+Note the last policy is the OpenShift-specific variant, not
+`tetragon-policies/experimental/openssl3-cert-load.yaml` — see below for why.
+
+**Known gap on containerized nodes — two distinct failure classes.** The `java-fips-nss-cert` and
+`java-non-fips-cert` experimental uprobe policies still fail to load on the OpenShift/CRC
+Tetragon DaemonSet with `adding tracing policy failed: open <path>: no such file or directory`.
+`openssl3-cert-load` used to fail the same way but is now covered by the OpenShift variant
+applied above; both failure classes are explained here for context:
 
 - `java-fips-nss-cert` (`/usr/lib64/libsoftokn3.so`) and `java-non-fips-cert`
   (`/opt/cert-agent/libcert_agent_stub.so`) fail because those paths genuinely don't exist on a

--- a/extras/openshift/scripts/start-soak-demo.sh
+++ b/extras/openshift/scripts/start-soak-demo.sh
@@ -53,6 +53,7 @@ if [[ "$POLICY_COUNT" -eq 0 ]]; then
     oc apply -f "$REPO_ROOT/tetragon-policies/certificate-file-access.yaml"
     oc apply -f "$REPO_ROOT/tetragon-policies/tcp-connect-tls.yaml"
     oc apply -f "$REPO_ROOT/tetragon-policies/experimental/tls-service-tracking.yaml"
+    oc apply -f "$REPO_ROOT/tetragon-policies/experimental/openshift/openssl3-cert-load.yaml"
 else
     echo "$POLICY_COUNT tracing polic(y/ies) already loaded."
 fi

--- a/tetragon-policies/experimental/openshift/openssl3-cert-load.yaml
+++ b/tetragon-policies/experimental/openshift/openssl3-cert-load.yaml
@@ -1,0 +1,49 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: openssl3-cert-load
+spec:
+  uprobes:
+  # SSL_CTX_use_certificate_file(SSL_CTX*, const char* file, int type)
+  # SSL_CTX_use_certificate_chain_file(SSL_CTX*, const char* file)
+  # Hooks applications that load certificate files explicitly via OpenSSL.
+  # This covers: openssl s_client -CAfile, nginx, Apache, Java via OpenSSL, etc.
+  #
+  # RHEL9 path — Tetragon v1.1.0 compatible
+  #
+  # Container variant: the Tetragon DaemonSet on OpenShift/Kubernetes runs libssl.so.3
+  # inside its own container mount namespace, which doesn't have the host's /usr/lib64.
+  # The chart's DaemonSet only mounts host /proc at /procRoot (used internally for cgroup
+  # resolution), so the uprobe path is rewritten through /procRoot/1/root/ to reach the
+  # host's real root filesystem via PID 1's procfs root symlink — the same trick Tetragon
+  # itself relies on. Use tetragon-policies/experimental/openssl3-cert-load.yaml (no
+  # /procRoot prefix) instead for the bare-metal RHEL9 RPM deployment, where Tetragon runs
+  # directly on the host and already sees /usr/lib64 natively.
+  - path: "/procRoot/1/root/usr/lib64/libssl.so.3"
+    symbols:
+    - "SSL_CTX_use_certificate_file"
+    - "SSL_CTX_use_certificate_chain_file"
+    args:
+    - index: 0
+      type: "uint64"
+    - index: 1
+      type: "string"
+  # SSL_CTX_use_certificate_ASN1(SSL_CTX *ctx, int len, const unsigned char *d)
+  # Hooks explicit in-memory DER certificate loading via libssl. arg2 is a plain
+  # single pointer to the DER bytes — Tetragon reads them atomically in eBPF at
+  # hook entry via bpf_probe_read_user (char_buf), before the function executes.
+  # This avoids the double-pointer problem of d2i_X509 (const unsigned char **in)
+  # which cannot be safely resolved from userspace after function return.
+  #
+  # RHEL9 path — Tetragon v1.1.0 compatible
+  - path: "/procRoot/1/root/usr/lib64/libssl.so.3"
+    symbols:
+    - "SSL_CTX_use_certificate_ASN1"
+    args:
+    - index: 0
+      type: "uint64"
+    - index: 1
+      type: "int32"
+    - index: 2
+      type: "char_buf"
+      sizeArgIndex: 2


### PR DESCRIPTION
The Tetragon DaemonSet's container has no view of the host's /usr/lib64 (only host /proc is mounted, at /procRoot), so the uprobe path /usr/lib64/libssl.so.3 can't be opened even though the library genuinely exists on the RHCOS host. Add an OpenShift-specific policy variant that rewrites the path through /procRoot/1/root/, reusing the mount Tetragon already has instead of patching the Helm-managed DaemonSet. Verified loading cleanly against CRC. Also splits out java-fips-nss-cert and java-non-fips-cert in the docs as a genuinely different failure class (their host paths are actually absent, not a container-visibility issue).