### PR TITLE
Add air-gapped OpenShift install path for cert-analyzer, test-server,…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,6 +396,117 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**RPM:** \`${{ steps.rpm.outputs.name }}\`" >> $GITHUB_STEP_SUMMARY
 
+  build-test-server-container:
+    name: Build Test Server Container (UBI ${{ matrix.ubi-version }})
+    runs-on: ubuntu-latest
+    needs: changes
+    # Same trigger conditions as build-test-server-rpm -- workflow_dispatch is
+    # included so this can be built on demand from any branch without cutting
+    # a tag release, see extras/test-server/TEST-SERVER-README.md.
+    if: |
+      github.ref_type == 'tag' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.test-server == 'true'
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ubi-version: "8"
+            python-version: "311"
+          - ubi-version: "9"
+            python-version: "311"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Determine version string
+      id: version
+      run: |
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          echo "value=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "value=${{ github.sha }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate image metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-test-server
+        flavor: |
+          suffix=-ubi${{ matrix.ubi-version }},onlatest=true
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,prefix=sha-
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+    - name: Build (and push on merge)
+      uses: docker/build-push-action@v5
+      with:
+        context: extras/test-server
+        file: extras/test-server/Containerfile
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          UBI_VERSION=${{ matrix.ubi-version }}
+          PYTHON_VERSION=${{ matrix.python-version }}
+        cache-from: type=gha,scope=test-server-ubi${{ matrix.ubi-version }}
+        cache-to: type=gha,scope=test-server-ubi${{ matrix.ubi-version }},mode=max
+        platforms: linux/amd64
+
+    - name: Export container image as tar
+      if: github.event_name != 'pull_request'
+      id: tar
+      run: |
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+        PULL_TAG="${{ env.REGISTRY }}/${{ github.repository_owner }}/cert-test-server:sha-${SHORT_SHA}-ubi${{ matrix.ubi-version }}"
+        TAR_NAME="cert-test-server-ubi${{ matrix.ubi-version }}-${{ steps.version.outputs.value }}.tar.gz"
+        docker pull "${PULL_TAG}"
+        docker save "${PULL_TAG}" | gzip > "${TAR_NAME}"
+        echo "tar_name=${TAR_NAME}" >> $GITHUB_OUTPUT
+
+    - name: Upload container image as artifact
+      if: github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: cert-test-server-container-ubi${{ matrix.ubi-version }}-${{ steps.version.outputs.value }}
+        path: ${{ steps.tar.outputs.tar_name }}
+        retention-days: 30
+
+    - name: Build summary
+      run: |
+        echo "## 🐳 Test Server Container Build (UBI ${{ matrix.ubi-version }})" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Event:** \`${{ github.event_name }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Pushed:** \`${{ github.event_name != 'pull_request' }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** \`${{ steps.version.outputs.value }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
   build-policies:
     name: Build Tetragon Policies Archive
     runs-on: ubuntu-latest
@@ -773,7 +884,7 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
-    needs: [ build, build-rpm, build-policies, build-test-generator, build-probe-tests, build-java-agent-rpms, build-test-server-rpm ]
+    needs: [ build, build-rpm, build-policies, build-test-generator, build-probe-tests, build-java-agent-rpms, build-test-server-rpm, build-test-server-container ]
     permissions:
       contents: write
 
@@ -827,6 +938,13 @@ jobs:
         merge-multiple: true
         path: ./release-assets
 
+    - name: Download cert-test-server container artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: cert-test-server-container-*
+        merge-multiple: true
+        path: ./release-assets
+
     - name: Download Grafana dashboard artifact
       uses: actions/download-artifact@v4
       with:
@@ -859,6 +977,12 @@ jobs:
         echo "test_server_ubi8_name=$(basename ${TEST_SERVER_UBI8_PATH})" >> $GITHUB_OUTPUT
         TEST_SERVER_UBI9_PATH=$(find ./release-assets -name "certsight-test-server-*.el9*.rpm" | head -1)
         echo "test_server_ubi9_name=$(basename ${TEST_SERVER_UBI9_PATH})" >> $GITHUB_OUTPUT
+        TEST_SERVER_CONTAINER_UBI8_PATH=$(find ./release-assets -name "cert-test-server-ubi8-*.tar.gz" | head -1)
+        echo "test_server_container_ubi8_path=${TEST_SERVER_CONTAINER_UBI8_PATH}" >> $GITHUB_OUTPUT
+        echo "test_server_container_ubi8_name=$(basename ${TEST_SERVER_CONTAINER_UBI8_PATH})" >> $GITHUB_OUTPUT
+        TEST_SERVER_CONTAINER_UBI9_PATH=$(find ./release-assets -name "cert-test-server-ubi9-*.tar.gz" | head -1)
+        echo "test_server_container_ubi9_path=${TEST_SERVER_CONTAINER_UBI9_PATH}" >> $GITHUB_OUTPUT
+        echo "test_server_container_ubi9_name=$(basename ${TEST_SERVER_CONTAINER_UBI9_PATH})" >> $GITHUB_OUTPUT
 
     - name: Publish to GitHub Release
       uses: softprops/action-gh-release@v2
@@ -876,6 +1000,8 @@ jobs:
           ${{ steps.assets.outputs.generator_path }}
           ${{ steps.assets.outputs.probe_tests_path }}
           ${{ steps.assets.outputs.dashboard_path }}
+          ${{ steps.assets.outputs.test_server_container_ubi8_path }}
+          ${{ steps.assets.outputs.test_server_container_ubi9_path }}
         fail_on_unmatched_files: true
         body: |
           ## cert-analyzer ${{ github.ref_name }}
@@ -887,14 +1013,24 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/cert-analyzer:${{ github.ref_name }}-ubi8
           ghcr.io/${{ github.repository_owner }}/cert-analyzer:${{ github.ref_name }}-ubi9
           ghcr.io/${{ github.repository_owner }}/cert-test-generator:${{ github.ref_name }}
+          ghcr.io/${{ github.repository_owner }}/cert-test-server:${{ github.ref_name }}-ubi8
+          ghcr.io/${{ github.repository_owner }}/cert-test-server:${{ github.ref_name }}-ubi9
           ```
 
-          Or load from the attached tar files:
+          Or load from the attached tar files (for locked-down/air-gapped hosts with no
+          registry egress — download the tar elsewhere, copy it over, then `podman load`):
           ```bash
           docker load < ${{ steps.assets.outputs.container_ubi8_name }}
           docker load < ${{ steps.assets.outputs.container_ubi9_name }}
           docker load < ${{ steps.assets.outputs.generator_name }}
+          docker load < ${{ steps.assets.outputs.test_server_container_ubi8_name }}
+          docker load < ${{ steps.assets.outputs.test_server_container_ubi9_name }}
           ```
+
+          For OpenShift installs on a locked-down host that can't build images locally, see
+          `extras/openshift/scripts/deploy-cert-analyzer-from-release.sh` and
+          `extras/openshift/scripts/deploy-test-server-from-release.sh` — they load one of
+          these tars and push it into the cluster's internal registry for you.
 
           ### RPM Packages
 
@@ -921,7 +1057,7 @@ jobs:
           sudo dnf install ./${{ steps.assets.outputs.test_server_ubi9_name }}   # RHEL 9
           certsight-test-server --kafka-host localhost --kafka-port 9092
           ```
-          See `extras/test-server/TEST-SERVER-README.md` for prerequisites and how the detection pipeline works end to end.
+          See `extras/test-server/TEST-SERVER-README.md` for prerequisites and how the detection pipeline works end to end. A container image is also published (see Container Images above) for running it in-cluster instead of installing the RPM directly on a host.
 
           ### Tetragon Policies (tar.gz)
 

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -75,6 +75,43 @@ its ServiceAccount:
 oc adm policy add-scc-to-user privileged -z tetragon -n kube-system
 ```
 
+**On a locked-down/air-gapped host** where neither `helm.cilium.io` nor `quay.io` (the chart's
+image registry) is reachable, `helm repo add`/`helm install` above won't work — the repo add
+needs to fetch an index over HTTPS, and the install still needs to pull
+`quay.io/cilium/tetragon` (plus the operator and stdout-export sidecar images, both enabled by
+default) onto the cluster's nodes. Instead, on any machine with internet access:
+
+```bash
+helm repo add cilium https://helm.cilium.io
+helm pull cilium/tetragon --version 1.7.0                       # -> tetragon-1.7.0.tgz
+docker pull quay.io/cilium/tetragon:v1.7.0
+docker save quay.io/cilium/tetragon:v1.7.0 | gzip > tetragon-agent.tar.gz
+docker pull quay.io/cilium/tetragon-operator:v1.7.0
+docker save quay.io/cilium/tetragon-operator:v1.7.0 | gzip > tetragon-operator.tar.gz
+docker pull quay.io/cilium/hubble-export-stdout:v1.1.1
+docker save quay.io/cilium/hubble-export-stdout:v1.1.1 | gzip > hubble-export-stdout.tar.gz
+```
+
+(check `helm show values cilium/tetragon --version 1.7.0` for the exact image/tag pairs if
+using a different chart version — they can change between releases). Copy all four files onto
+the VM, `oc login`, then:
+
+```bash
+bash extras/openshift/scripts/deploy-tetragon-from-release.sh \
+  --chart /path/to/tetragon-1.7.0.tgz \
+  --agent-image-tar /path/to/tetragon-agent.tar.gz \
+  --operator-image-tar /path/to/tetragon-operator.tar.gz \
+  --export-stdout-image-tar /path/to/hubble-export-stdout.tar.gz
+```
+
+The script mirrors each image into a dedicated `tetragon-mirror` namespace in the cluster's
+internal registry, grants `kube-system` pull access to it, then runs `helm upgrade --install`
+against the local chart tarball with `--set <component>.image.override=<mirrored-ref>` for each
+image you supplied (the chart's templates check that field before falling back to
+`repository`/`tag` — confirmed against the real chart, not assumed), and finally binds the
+`privileged` SCC for you. `--skip-operator`/`--skip-export-stdout` are available if you've
+disabled those components entirely via `--extra-set`. Run it with no arguments for full usage.
+
 > Some clusters' `kube-system` namespace already carries
 > `pod-security.kubernetes.io/enforce: privileged` out of the box (true of the CRC bundle used
 > to validate this guide), in which case the Tetragon pod admits without the explicit grant
@@ -93,6 +130,12 @@ oc get events -n kube-system --field-selector reason=FailedCreate
 ---
 
 ## 2. Build and import the cert-analyzer image
+
+**On a locked-down/air-gapped host** where a local container build is impractical (no
+outbound network access for base images/pip, hardened build tooling, etc.), skip building
+entirely and use the pre-built images published to GHCR on every tagged release instead —
+see "Air-gapped install from pre-built release images" below. The rest of this section
+assumes a normal host that can build locally.
 
 Build exactly as documented in the main guide (from the repository root, not `extras/`):
 
@@ -236,6 +279,49 @@ unreachable on OpenShift.
 
 ---
 
+## Air-gapped install (pre-built release images, no local build)
+
+Alternative to steps 2–3 above (and to the build step in §6 below) for a locked-down host
+that can't build container images locally — no outbound network access for UBI/pip during
+the build, hardened build tooling disabled, etc. Every tagged release publishes ready-to-run
+images for both `cert-analyzer` and `cert-test-server` (the interactive test-console from §6)
+in two forms:
+
+- **Pushed to GHCR**: `ghcr.io/<owner>/cert-analyzer:<tag>-ubi9` /
+  `ghcr.io/<owner>/cert-test-server:<tag>-ubi9` (`-ubi8` variants also published). Usable
+  directly if the cluster/nodes have outbound HTTPS access to `ghcr.io` — e.g. via
+  `oc import-image` into an `ImageStream`, or by pointing `daemonset.yaml`/`test-server-pod.yaml`
+  straight at the GHCR reference instead of the internal registry path.
+- **Attached to the GitHub Release as `.tar.gz` files** (`docker save` format) — for a fully
+  air-gapped host with no registry egress at all. Download
+  `cert-analyzer-ubi9-<version>.tar.gz` and `cert-test-server-ubi9-<version>.tar.gz` (pick
+  `-ubi8` instead if the cluster's nodes are RHEL 8) from the repo's Releases page on any
+  machine that does have internet access, then copy them onto the locked-down VM (`scp`, USB,
+  whatever your environment allows).
+
+Both images are UBI-based (`registry.access.redhat.com/ubi9/python-311`) and run fine under
+OpenShift's `restricted-v2`/`hostaccess` SCCs exactly as described in §3 below — nothing about
+using a pre-built image changes the SCC/RBAC requirements.
+
+Once the tar files are on the VM and `oc login` has been run against the cluster:
+
+```bash
+bash extras/openshift/scripts/deploy-cert-analyzer-from-release.sh \
+  --image-tar /path/to/cert-analyzer-ubi9-<version>.tar.gz
+
+bash extras/openshift/scripts/deploy-test-server-from-release.sh \
+  --image-tar /path/to/cert-test-server-ubi9-<version>.tar.gz
+```
+
+Both scripts (also reachable via the [`openshift-utils.sh`](openshift/openshift-utils.sh) menu)
+do the same `podman load` → tag → push-to-internal-registry → apply/`oc set image` → rollout
+sequence as their build-from-source counterparts
+(`rebuild-redeploy-cert-analyzer.sh`/`deploy-test-server.sh`), just starting from `podman load`
+instead of `podman build`. `--kafka-host <ip>` works the same way as the other scripts (see §6
+below for why it's needed); omit it to auto-detect the host's default-route IP.
+
+---
+
 ## 4. Load Tetragon tracing policies
 
 Identical to the vanilla Kubernetes path — `TracingPolicy` is a cluster-scoped CRD:
@@ -331,7 +417,9 @@ bash extras/openshift/scripts/deploy-test-server.sh
 the internal registry (same reasoning as "Why a fresh tag, not just re-pushing `:latest`" below),
 applies/updates [`extras/openshift/test-server-pod.yaml`](openshift/test-server-pod.yaml), and
 port-forwards it for you — the script prints `http://localhost:8090` once it's confirmed the
-console is actually responding.
+console is actually responding. On a locked-down host that can't build the image locally, use
+`deploy-test-server-from-release.sh` instead — see "Air-gapped install from pre-built release
+images" above.
 
 If the Pod dies mid-demo (CRC is single-node, and this bare Pod has no priority class — it's a
 recurring preemption target for OpenShift's periodic operator-catalog refresh pods in

--- a/extras/openshift/scripts/deploy-cert-analyzer-from-release.sh
+++ b/extras/openshift/scripts/deploy-cert-analyzer-from-release.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# description: Load a pre-built cert-analyzer image from a downloaded GitHub Release tar and deploy it to OpenShift (no local build required)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NAMESPACE=certsight
+MANIFEST="$REPO_ROOT/extras/openshift/daemonset.yaml"
+
+step() { echo; echo "==> $*"; }
+
+usage() {
+    echo "Usage: $0 --image-tar <path> [--kafka-host <ip>]" >&2
+    echo >&2
+    echo "  --image-tar   Path to a cert-analyzer-ubi{8,9}-<version>.tar.gz asset downloaded" >&2
+    echo "                from this repo's GitHub Releases page (docker save/gzip format)." >&2
+    echo "                For locked-down hosts with no registry egress: download it on any" >&2
+    echo "                machine with internet access, then copy the file over." >&2
+    exit 1
+}
+
+IMAGE_TAR=""
+KAFKA_HOST_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-tar)
+            IMAGE_TAR="$2"
+            shift 2
+            ;;
+        --image-tar=*)
+            IMAGE_TAR="${1#*=}"
+            shift
+            ;;
+        --kafka-host)
+            KAFKA_HOST_ARG="$2"
+            shift 2
+            ;;
+        --kafka-host=*)
+            KAFKA_HOST_ARG="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$IMAGE_TAR" ]] || usage
+[[ -f "$IMAGE_TAR" ]] || { echo "No such file: $IMAGE_TAR" >&2; exit 1; }
+
+step "Resolving the Kafka host"
+if [[ -n "$KAFKA_HOST_ARG" ]]; then
+    KAFKA_HOST="$KAFKA_HOST_ARG"
+    echo "Using --kafka-host: $KAFKA_HOST"
+else
+    # Default-route source IP -- the address the hostNetwork DaemonSet pod can actually reach
+    # the host broker on (see the Kafka reachability section of
+    # extras/OPENSHIFT-DEPLOYMENT-README.md).
+    KAFKA_HOST=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')
+    if [[ -z "$KAFKA_HOST" ]]; then
+        echo "Could not auto-detect the host's IP -- pass it explicitly: $0 --image-tar $IMAGE_TAR --kafka-host <ip>" >&2
+        exit 1
+    fi
+    echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
+fi
+
+render_manifest() {
+    sed "s#__KAFKA_BOOTSTRAP_SERVERS__#$KAFKA_HOST:9092#g" "$MANIFEST"
+}
+
+step "Checking cluster login"
+if ! oc whoami >/dev/null 2>&1; then
+    echo "Not logged in to the cluster — run 'oc login ...' first." >&2
+    exit 1
+fi
+
+step "Loading $IMAGE_TAR"
+# sudo podman throughout, same as every other script in this directory -- keeps every
+# tag/push below reading from the same podman storage the image was just loaded into,
+# rather than a separate (and possibly stale) plain-user rootless storage.
+LOAD_OUTPUT=$(sudo podman load -i "$IMAGE_TAR")
+echo "$LOAD_OUTPUT"
+LOADED_IMAGE=$(echo "$LOAD_OUTPUT" | sed -nE 's/^Loaded image\(s\)?: *//p' | tail -1)
+if [[ -z "$LOADED_IMAGE" ]]; then
+    echo "Could not determine the loaded image reference from the 'podman load' output above." >&2
+    exit 1
+fi
+echo "Loaded: $LOADED_IMAGE"
+
+step "Locating the internal image registry route"
+HOST=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -z "$HOST" ]]; then
+    echo "Could not find the internal registry route. Enable it first:" >&2
+    echo "  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{\"spec\":{\"defaultRoute\":true}}' --type=merge" >&2
+    exit 1
+fi
+
+step "Logging into the internal registry"
+sudo podman login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$HOST"
+
+# A fresh tag every run, not :latest -- imagePullPolicy: IfNotPresent means a node that
+# already pulled ":latest" once will never re-pull it just because the registry content
+# changed under the same tag. See "Why a fresh tag, not just re-pushing :latest" in
+# extras/OPENSHIFT-DEPLOYMENT-README.md.
+TAG="dev-$(date +%s)"
+PUSH_IMAGE="$HOST/certsight/cert-analyzer:$TAG"
+IN_CLUSTER_IMAGE="image-registry.openshift-image-registry.svc:5000/certsight/cert-analyzer:$TAG"
+
+step "Tagging and pushing $PUSH_IMAGE"
+sudo podman tag "$LOADED_IMAGE" "$PUSH_IMAGE"
+sudo podman push --tls-verify=false "$PUSH_IMAGE"
+
+step "Applying the DaemonSet manifest"
+render_manifest | oc apply -f -
+
+step "Pointing the DaemonSet at the new tag"
+oc set image daemonset/cert-expiry-monitor analyzer="$IN_CLUSTER_IMAGE" -n "$NAMESPACE"
+
+step "Waiting for the rollout"
+if ! oc rollout status daemonset/cert-expiry-monitor -n "$NAMESPACE" --timeout=180s; then
+    echo "Rollout did not finish — check: oc get pods -n $NAMESPACE -o wide" >&2
+    exit 1
+fi
+
+step "Deployed"
+oc get pods -n "$NAMESPACE" -l app=cert-expiry-monitor -o wide
+NEW_POD=$(oc get pods -n "$NAMESPACE" -l app=cert-expiry-monitor -o jsonpath='{.items[0].metadata.name}')
+echo
+echo "Image now running: $(oc get pod "$NEW_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].image}')"
+echo "Digest:             $(oc get pod "$NEW_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+echo
+echo "Once you're happy with this build, tag a real version and update"
+echo "extras/openshift/daemonset.yaml's image field to match — the checked-in manifest should"
+echo "stay on a stable tag rather than $TAG."

--- a/extras/openshift/scripts/deploy-test-server-from-release.sh
+++ b/extras/openshift/scripts/deploy-test-server-from-release.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# description: Load a pre-built cert-test-server image from a downloaded GitHub Release tar and (re)deploy the Pod on OpenShift (no local build required)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NAMESPACE=certsight
+MANIFEST="$REPO_ROOT/extras/openshift/test-server-pod.yaml"
+
+step() { echo; echo "==> $*"; }
+
+usage() {
+    echo "Usage: $0 --image-tar <path> [--kafka-host <ip>]" >&2
+    echo >&2
+    echo "  --image-tar   Path to a cert-test-server-ubi{8,9}-<version>.tar.gz asset downloaded" >&2
+    echo "                from this repo's GitHub Releases page (docker save/gzip format)." >&2
+    echo "                For locked-down hosts with no registry egress: download it on any" >&2
+    echo "                machine with internet access, then copy the file over." >&2
+    exit 1
+}
+
+IMAGE_TAR=""
+KAFKA_HOST_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-tar)
+            IMAGE_TAR="$2"
+            shift 2
+            ;;
+        --image-tar=*)
+            IMAGE_TAR="${1#*=}"
+            shift
+            ;;
+        --kafka-host)
+            KAFKA_HOST_ARG="$2"
+            shift 2
+            ;;
+        --kafka-host=*)
+            KAFKA_HOST_ARG="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$IMAGE_TAR" ]] || usage
+[[ -f "$IMAGE_TAR" ]] || { echo "No such file: $IMAGE_TAR" >&2; exit 1; }
+
+step "Resolving the Kafka host"
+if [[ -n "$KAFKA_HOST_ARG" ]]; then
+    KAFKA_HOST="$KAFKA_HOST_ARG"
+    echo "Using --kafka-host: $KAFKA_HOST"
+else
+    # Default-route source IP -- the address the pod network can actually reach back to
+    # (see the Kafka reachability section of extras/OPENSHIFT-DEPLOYMENT-README.md).
+    KAFKA_HOST=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')
+    if [[ -z "$KAFKA_HOST" ]]; then
+        echo "Could not auto-detect the host's IP -- pass it explicitly: $0 --image-tar $IMAGE_TAR --kafka-host <ip>" >&2
+        exit 1
+    fi
+    echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
+fi
+
+render_manifest() {
+    sed "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" "$MANIFEST"
+}
+
+step "Checking cluster login"
+if ! oc whoami >/dev/null 2>&1; then
+    echo "Not logged in to the cluster — run 'oc login ...' first." >&2
+    exit 1
+fi
+
+step "Loading $IMAGE_TAR"
+LOAD_OUTPUT=$(sudo podman load -i "$IMAGE_TAR")
+echo "$LOAD_OUTPUT"
+LOADED_IMAGE=$(echo "$LOAD_OUTPUT" | sed -nE 's/^Loaded image\(s\)?: *//p' | tail -1)
+if [[ -z "$LOADED_IMAGE" ]]; then
+    echo "Could not determine the loaded image reference from the 'podman load' output above." >&2
+    exit 1
+fi
+echo "Loaded: $LOADED_IMAGE"
+
+step "Locating the internal image registry route"
+HOST=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -z "$HOST" ]]; then
+    echo "Could not find the internal registry route. Enable it first:" >&2
+    echo "  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{\"spec\":{\"defaultRoute\":true}}' --type=merge" >&2
+    exit 1
+fi
+
+step "Logging into the internal registry"
+sudo podman login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$HOST"
+
+TAG="dev-$(date +%s)"
+PUSH_IMAGE="$HOST/certsight/cert-test-server:$TAG"
+IN_CLUSTER_IMAGE="image-registry.openshift-image-registry.svc:5000/certsight/cert-test-server:$TAG"
+LATEST_PUSH_IMAGE="$HOST/certsight/cert-test-server:latest"
+
+step "Tagging and pushing $PUSH_IMAGE"
+sudo podman tag "$LOADED_IMAGE" "$PUSH_IMAGE"
+sudo podman push --tls-verify=false "$PUSH_IMAGE"
+
+step "Also pushing :latest"
+# test-server-pod.yaml's fix-cert-dir-perms initContainer has 'image:' hardcoded to the
+# ':latest' tag (not a substitution placeholder like the main container's image field) --
+# nothing else in this script updates it via 'oc set image', so on a namespace where
+# ':latest' was never pushed before, that initContainer would ImagePullBackOff even though
+# the main container below deploys fine under the fresh dev-<timestamp> tag. Pushing the
+# same freshly-loaded image under ':latest' too keeps the initContainer working without
+# having to restructure the manifest/other scripts.
+sudo podman tag "$LOADED_IMAGE" "$LATEST_PUSH_IMAGE"
+sudo podman push --tls-verify=false "$LATEST_PUSH_IMAGE"
+
+step "Deploying the Pod"
+# Almost every field on a live Pod other than spec.containers[*].image is immutable -- see
+# the comment in deploy-test-server.sh. Just delete and recreate rather than chase
+# field-by-field drift detection.
+if oc get pod cert-test-server -n "$NAMESPACE" >/dev/null 2>&1; then
+    oc delete pod cert-test-server -n "$NAMESPACE" --wait=true
+fi
+render_manifest | oc apply -f -
+oc set image pod/cert-test-server test-server="$IN_CLUSTER_IMAGE" -n "$NAMESPACE"
+
+step "Waiting for the rollout"
+if ! oc wait --for=condition=Ready pod/cert-test-server -n "$NAMESPACE" --timeout=120s; then
+    echo "Pod not ready — check: oc get pod cert-test-server -n $NAMESPACE -o wide" >&2
+    echo "                       oc logs cert-test-server -n $NAMESPACE" >&2
+    exit 1
+fi
+
+step "Deployed"
+oc get pod cert-test-server -n "$NAMESPACE" -o wide
+echo
+echo "Image now running: $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].image}')"
+echo "Digest:             $(oc get pod cert-test-server -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+
+step "Port-forwarding to the Pod"
+PF_LOG="$(mktemp)"
+pkill -f "oc port-forward -n $NAMESPACE pod/cert-test-server 8090:8090" 2>/dev/null || true
+nohup oc port-forward -n "$NAMESPACE" pod/cert-test-server 8090:8090 >"$PF_LOG" 2>&1 &
+PF_PID=$!
+disown "$PF_PID"
+
+for _ in $(seq 1 20); do
+    if curl -sf -o /dev/null http://localhost:8090/; then
+        break
+    fi
+    if ! kill -0 "$PF_PID" 2>/dev/null; then
+        echo "port-forward exited unexpectedly:" >&2
+        cat "$PF_LOG" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+if ! curl -sf -o /dev/null http://localhost:8090/; then
+    echo "Port-forward did not come up in time — check $PF_LOG" >&2
+    exit 1
+fi
+
+echo
+echo "Test console:  http://localhost:8090"
+echo "Stop it with:  kill $PF_PID"
+echo "Or shell in:   oc rsh -n $NAMESPACE cert-test-server"
+echo
+echo "Once you're happy with this build, tag a real version and update"
+echo "extras/openshift/test-server-pod.yaml's image field to match — the checked-in manifest"
+echo "should stay on a stable tag rather than $TAG."

--- a/extras/openshift/scripts/deploy-tetragon-from-release.sh
+++ b/extras/openshift/scripts/deploy-tetragon-from-release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# description: Mirror the Tetragon Helm chart's images into OpenShift's internal registry and install/upgrade it from them (for air-gapped hosts with no reachable quay.io/helm.cilium.io)
+set -uo pipefail
+
+step() { echo; echo "==> $*"; }
+
+MIRROR_NAMESPACE=tetragon-mirror
+RELEASE_NAMESPACE=kube-system
+RELEASE_NAME=tetragon
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: deploy-tetragon-from-release.sh --chart <tetragon-X.Y.Z.tgz> --agent-image-tar <path> [options]
+
+On a machine with internet access, first fetch the chart and the images it references
+(check 'helm show values cilium/tetragon --version X.Y.Z' for the exact image/tag pairs --
+they can change between chart versions):
+  helm repo add cilium https://helm.cilium.io
+  helm pull cilium/tetragon --version 1.7.0                        # -> tetragon-1.7.0.tgz
+  docker pull quay.io/cilium/tetragon:v1.7.0
+  docker save quay.io/cilium/tetragon:v1.7.0 | gzip > tetragon-agent.tar.gz
+  docker pull quay.io/cilium/tetragon-operator:v1.7.0
+  docker save quay.io/cilium/tetragon-operator:v1.7.0 | gzip > tetragon-operator.tar.gz
+  docker pull quay.io/cilium/hubble-export-stdout:v1.1.1
+  docker save quay.io/cilium/hubble-export-stdout:v1.1.1 | gzip > hubble-export-stdout.tar.gz
+Then copy the chart tarball and whichever image tars you need onto this host.
+
+Required:
+  --chart <path>                   Tetragon Helm chart tarball (from 'helm pull' above).
+  --agent-image-tar <path>         docker-save tar for quay.io/cilium/tetragon (the agent
+                                    DaemonSet -- always required, this component can't be
+                                    disabled).
+
+Optional (the chart's default values.yaml enables both of these -- pass the matching
+--skip-* flag only if you're also disabling the component itself via --extra-set):
+  --operator-image-tar <path>      docker-save tar for quay.io/cilium/tetragon-operator.
+  --export-stdout-image-tar <path> docker-save tar for quay.io/cilium/hubble-export-stdout.
+  --rthooks-image-tar <path>       docker-save tar for quay.io/cilium/tetragon-rthooks. Only
+                                    needed if you pass --extra-set rthooks.enabled=true (the
+                                    chart default is disabled).
+  --skip-operator                  Don't mirror/require the operator image -- pass
+                                    --extra-set tetragonOperator.enabled=false too, or the
+                                    install will still try to pull the real quay.io image.
+  --skip-export-stdout             Don't mirror/require the export-stdout image -- pass
+                                    --extra-set export.mode="" too, same reasoning.
+  --release-namespace <ns>         Default: kube-system.
+  --release-name <name>            Default: tetragon.
+  --extra-set <key=value>          Extra --set passed to 'helm upgrade --install' (repeatable).
+USAGE
+    exit 1
+}
+
+CHART=""
+AGENT_TAR=""
+OPERATOR_TAR=""
+EXPORT_TAR=""
+RTHOOKS_TAR=""
+SKIP_OPERATOR=false
+SKIP_EXPORT=false
+EXTRA_SET_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chart) CHART="$2"; shift 2 ;;
+        --chart=*) CHART="${1#*=}"; shift ;;
+        --agent-image-tar) AGENT_TAR="$2"; shift 2 ;;
+        --agent-image-tar=*) AGENT_TAR="${1#*=}"; shift ;;
+        --operator-image-tar) OPERATOR_TAR="$2"; shift 2 ;;
+        --operator-image-tar=*) OPERATOR_TAR="${1#*=}"; shift ;;
+        --export-stdout-image-tar) EXPORT_TAR="$2"; shift 2 ;;
+        --export-stdout-image-tar=*) EXPORT_TAR="${1#*=}"; shift ;;
+        --rthooks-image-tar) RTHOOKS_TAR="$2"; shift 2 ;;
+        --rthooks-image-tar=*) RTHOOKS_TAR="${1#*=}"; shift ;;
+        --skip-operator) SKIP_OPERATOR=true; shift ;;
+        --skip-export-stdout) SKIP_EXPORT=true; shift ;;
+        --release-namespace) RELEASE_NAMESPACE="$2"; shift 2 ;;
+        --release-namespace=*) RELEASE_NAMESPACE="${1#*=}"; shift ;;
+        --release-name) RELEASE_NAME="$2"; shift 2 ;;
+        --release-name=*) RELEASE_NAME="${1#*=}"; shift ;;
+        --extra-set) EXTRA_SET_ARGS+=(--set "$2"); shift 2 ;;
+        --extra-set=*) EXTRA_SET_ARGS+=(--set "${1#*=}"); shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+[[ -n "$CHART" ]] || usage
+[[ -f "$CHART" ]] || { echo "No such file: $CHART" >&2; exit 1; }
+[[ -n "$AGENT_TAR" ]] || usage
+[[ -f "$AGENT_TAR" ]] || { echo "No such file: $AGENT_TAR" >&2; exit 1; }
+for tar_var in OPERATOR_TAR EXPORT_TAR RTHOOKS_TAR; do
+    tar_path="${!tar_var}"
+    if [[ -n "$tar_path" ]]; then
+        [[ -f "$tar_path" ]] || { echo "No such file: $tar_path" >&2; exit 1; }
+    fi
+done
+
+if [[ -z "$OPERATOR_TAR" && "$SKIP_OPERATOR" != true ]]; then
+    echo "Default chart values enable the operator (tetragonOperator.enabled: true)." >&2
+    echo "Pass --operator-image-tar <path>, or --skip-operator if you're disabling it" >&2
+    echo "yourself via --extra-set tetragonOperator.enabled=false." >&2
+    exit 1
+fi
+if [[ -z "$EXPORT_TAR" && "$SKIP_EXPORT" != true ]]; then
+    echo "Default chart values enable stdout export (export.mode: stdout)." >&2
+    echo "Pass --export-stdout-image-tar <path>, or --skip-export-stdout if you're disabling" >&2
+    echo 'it yourself via --extra-set export.mode="".' >&2
+    exit 1
+fi
+
+step "Checking cluster login"
+if ! oc whoami >/dev/null 2>&1; then
+    echo "Not logged in to the cluster — run 'oc login ...' first." >&2
+    exit 1
+fi
+
+step "Ensuring the $MIRROR_NAMESPACE namespace exists"
+if oc get namespace "$MIRROR_NAMESPACE" >/dev/null 2>&1; then
+    echo "Already exists."
+else
+    oc new-project "$MIRROR_NAMESPACE" >/dev/null
+fi
+
+step "Granting $RELEASE_NAMESPACE service accounts pull access to $MIRROR_NAMESPACE"
+# Tetragon's agent/operator pods run under service accounts in $RELEASE_NAMESPACE (kube-system
+# by default), not in $MIRROR_NAMESPACE -- without this cross-namespace grant every pod sits
+# in ImagePullBackOff/Unauthorized even though the image is sitting right there in the
+# registry. Idempotent, safe to re-run.
+oc adm policy add-role-to-group system:image-puller \
+    "system:serviceaccounts:$RELEASE_NAMESPACE" -n "$MIRROR_NAMESPACE" >/dev/null
+
+step "Locating the internal image registry route"
+HOST=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -z "$HOST" ]]; then
+    echo "Could not find the internal registry route. Enable it first:" >&2
+    echo "  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{\"spec\":{\"defaultRoute\":true}}' --type=merge" >&2
+    exit 1
+fi
+
+step "Logging into the internal registry"
+sudo podman login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$HOST"
+
+# Populated by mirror_image() on each call.
+MIRRORED_REF=""
+
+mirror_image() {
+    local tar_path="$1" image_name="$2"
+    step "Loading $tar_path"
+    local load_output
+    load_output=$(sudo podman load -i "$tar_path")
+    echo "$load_output"
+    local loaded_image
+    loaded_image=$(echo "$load_output" | sed -nE 's/^Loaded image\(s\)?: *//p' | tail -1)
+    if [[ -z "$loaded_image" ]]; then
+        echo "Could not determine the loaded image reference from the 'podman load' output above ($tar_path)." >&2
+        exit 1
+    fi
+    echo "Loaded: $loaded_image"
+    # Keep the tag baked into the tar (e.g. v1.7.0) rather than inventing our own -- one
+    # less place for the mirrored version to drift out of sync with what was actually
+    # downloaded.
+    local tag="${loaded_image##*:}"
+    local push_image="$HOST/$MIRROR_NAMESPACE/$image_name:$tag"
+    step "Tagging and pushing $push_image"
+    sudo podman tag "$loaded_image" "$push_image"
+    sudo podman push --tls-verify=false "$push_image"
+    MIRRORED_REF="image-registry.openshift-image-registry.svc:5000/$MIRROR_NAMESPACE/$image_name:$tag"
+}
+
+# Every '.image.override' path below is a verbatim full-image-reference field the chart's
+# templates check first (see e.g. templates/_container_tetragon.tpl) -- confirmed against
+# the actual 1.7.0 chart, not assumed from values.yaml's repository/tag fields alone.
+mirror_image "$AGENT_TAR" "tetragon"
+SET_ARGS=(--set "tetragon.image.override=$MIRRORED_REF")
+
+if [[ -n "$OPERATOR_TAR" ]]; then
+    mirror_image "$OPERATOR_TAR" "tetragon-operator"
+    SET_ARGS+=(--set "tetragonOperator.image.override=$MIRRORED_REF")
+fi
+
+if [[ -n "$EXPORT_TAR" ]]; then
+    mirror_image "$EXPORT_TAR" "hubble-export-stdout"
+    SET_ARGS+=(--set "export.stdout.image.override=$MIRRORED_REF")
+fi
+
+if [[ -n "$RTHOOKS_TAR" ]]; then
+    mirror_image "$RTHOOKS_TAR" "tetragon-rthooks"
+    SET_ARGS+=(--set "rthooks.image.override=$MIRRORED_REF")
+fi
+
+step "Installing/upgrading the $RELEASE_NAME Helm release in $RELEASE_NAMESPACE"
+helm upgrade --install "$RELEASE_NAME" "$CHART" \
+    -n "$RELEASE_NAMESPACE" --create-namespace \
+    "${SET_ARGS[@]}" "${EXTRA_SET_ARGS[@]}"
+
+step "Binding the privileged SCC"
+# The chart's DaemonSet runs securityContext.privileged: true, hostNetwork: true, and mounts
+# several hostPath volumes (including /sys/fs/bpf) -- needs the 'privileged' SCC bound to its
+# ServiceAccount, same as the non-air-gapped path in OPENSHIFT-DEPLOYMENT-README.md. Both the
+# DaemonSet and its ServiceAccount default to the release name when nameOverride/
+# serviceAccount.name are unset (confirmed against the chart's _helpers.tpl), so
+# $RELEASE_NAME is correct for -z here even if you passed --release-name.
+oc adm policy add-scc-to-user privileged -z "$RELEASE_NAME" -n "$RELEASE_NAMESPACE"
+
+step "Waiting for the Tetragon DaemonSet"
+if ! oc rollout status daemonset/"$RELEASE_NAME" -n "$RELEASE_NAMESPACE" --timeout=180s; then
+    echo "Rollout did not finish — check:" >&2
+    echo "  oc get pods -n $RELEASE_NAMESPACE -l app.kubernetes.io/name=tetragon -o wide" >&2
+    echo "  oc get events -n $RELEASE_NAMESPACE --field-selector reason=FailedCreate" >&2
+    exit 1
+fi
+
+step "Deployed"
+oc get pods -n "$RELEASE_NAMESPACE" -l app.kubernetes.io/name=tetragon -o wide


### PR DESCRIPTION
… Tetragon

CI now also builds and publishes a cert-test-server container image to GHCR and attaches it to GitHub Releases (previously only an RPM was published). Adds three deploy-*-from-release.sh scripts that load pre-downloaded release tars via podman and deploy them, for locked-down hosts that can't build images or reach quay.io/helm.cilium.io directly.