### PR TITLE
Add OpenShift-specific certificate-file-access policy to cut kubelet-…

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -1036,7 +1036,7 @@ class CertificateAnalyzer:
         node_name: str,
     ) -> None:
         """Apply pod/event context, update metrics, log, cache, and publish for a freshly-parsed file."""
-        # update_certificate_metrics() writes ~10 Prometheus series per cert.
+        # update_certificate_metrics() writes ~7 Prometheus series per cert.
         # A bundle file (e.g. a system CA trust store) can hold hundreds of
         # certs, so tracking every one individually turns a single file event
         # into thousands of new series in one burst — this is what drove

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -260,7 +260,7 @@ class PrometheusMetrics:
 
         # Certificate status
         #
-        # issuer/serial are included on all four so a dashboard can group by
+        # issuer/serial are included on both so a dashboard can group by
         # them to get a true distinct-certificate count (e.g. the same cert
         # served on several TLS-probed network endpoints, or present at
         # several file paths) instead of counting one row per observation.
@@ -276,22 +276,6 @@ class PrometheusMetrics:
         # series when checksum_enabled=false (the default), and grouping by a
         # label with the same value on every series is a no-op, so this is
         # free when the feature is off.
-        self.cert_expired = Gauge(
-            'tls_certificate_expired',
-            'Whether certificate is expired (1=expired, 0=valid)',
-            ['cert_path', 'cert_index', 'pod_name', 'namespace',
-             'workload_kind', 'workload_name', 'node_name', 'app_label', 'container_name',
-             'issuer', 'serial', 'checksum']
-        )
-
-        self.cert_expiring_soon = Gauge(
-            'tls_certificate_expiring_soon',
-            'Whether certificate expires within threshold (1=yes, 0=no)',
-            ['cert_path', 'threshold_days', 'cert_index', 'pod_name',
-             'namespace', 'workload_kind', 'workload_name', 'node_name',
-             'app_label', 'container_name', 'issuer', 'serial', 'checksum']
-        )
-
         self.cert_fips_compliant = Gauge(
             'tls_certificate_fips_compliant',
             'Whether certificate uses FIPS-approved algorithms (1=compliant, 0=non-compliant)',
@@ -549,38 +533,6 @@ class PrometheusMetrics:
         self.cert_valid_from.labels(**labels).set(info.not_before.replace(tzinfo=timezone.utc).timestamp())
         self.cert_last_accessed.labels(**labels).set(now.timestamp())
 
-        self.cert_expired.labels(
-            cert_path=info.path,
-            cert_index=str(info.cert_index),
-            pod_name=info.pod_name,
-            namespace=info.namespace,
-            workload_kind=info.workload_kind,
-            workload_name=info.workload_name,
-            node_name=info.node_name,
-            app_label=info.app_label,
-            container_name=info.container_name,
-            issuer=info.issuer[:100],
-            serial=info.serial_number,
-            checksum=info.checksum,
-        ).set(1 if info.is_expired else 0)
-
-        for threshold in [7, 30, 90]:
-            self.cert_expiring_soon.labels(
-                cert_path=info.path,
-                threshold_days=str(threshold),
-                cert_index=str(info.cert_index),
-                pod_name=info.pod_name,
-                namespace=info.namespace,
-                workload_kind=info.workload_kind,
-                workload_name=info.workload_name,
-                node_name=info.node_name,
-                app_label=info.app_label,
-                container_name=info.container_name,
-                issuer=info.issuer[:100],
-                serial=info.serial_number,
-                checksum=info.checksum,
-            ).set(1 if 0 < days_left < threshold else 0)
-
         if info.key_algorithm:
             self.cert_fips_compliant.labels(
                 cert_path=info.path,
@@ -633,7 +585,7 @@ class PrometheusMetrics:
         Called from LRUCache's on_evict callback when a cert falls out of
         known_certs, so Prometheus's own memory tracks cache occupancy instead
         of growing for the entire life of the process — update_certificate_metrics
-        creates ~10 new label-sets per newly-discovered cert and nothing
+        creates ~7 new label-sets per newly-discovered cert and nothing
         previously removed them on eviction, so every certificate ever seen
         stayed resident in the registry forever.
 
@@ -670,21 +622,6 @@ class PrometheusMetrics:
                 process, parent_process, info.node_name,
                 pod_name, namespace, app_label, container_name,
                 info.checksum,
-            ))
-
-        self._safe_remove(self.cert_expired, (
-            info.path, str(info.cert_index), info.pod_name, info.namespace,
-            info.workload_kind, info.workload_name, info.node_name,
-            info.app_label, info.container_name,
-            info.issuer[:100], info.serial_number, info.checksum,
-        ))
-
-        for threshold in (7, 30, 90):
-            self._safe_remove(self.cert_expiring_soon, (
-                info.path, str(threshold), str(info.cert_index), info.pod_name,
-                info.namespace, info.workload_kind, info.workload_name,
-                info.node_name, info.app_label, info.container_name,
-                info.issuer[:100], info.serial_number, info.checksum,
             ))
 
         if info.key_algorithm:

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -122,7 +122,7 @@ large_file_cert_threshold = 20
 # Kafka if enabled, just not individually tracked in Prometheus. Default
 # of 300 comfortably covers a real system CA trust bundle (~130-150
 # certs) without truncation. Raise with care: each additional cert here
-# costs ~10 Prometheus series.
+# costs ~7 Prometheus series.
 large_file_metrics_cap = 300
 
 # Caps how many bytes are read to decide whether a file is "large" (see

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -58,10 +58,17 @@ observed loading them (see below).
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `tls_certificate_expired` | Gauge | `cert_path`, `cert_index`, `pod_name`, `namespace`, `workload_kind`, `workload_name`, `node_name`, `app_label`, `container_name`, `issuer`, `serial`, `checksum` | `1` if expired, `0` if valid. `checksum` is empty unless `checksum_enabled=true` |
-| `tls_certificate_expiring_soon` | Gauge | above + `threshold_days` | `1` if expiring within threshold, `0` otherwise. Emitted for thresholds `7`, `30`, and `90` days |
 | `tls_certificate_fips_compliant` | Gauge | `cert_path`, `cert_index`, `pod_name`, `namespace`, `workload_kind`, `workload_name`, `node_name`, `app_label`, `container_name`, `key_algorithm`, `signature_hash`, `key_size`, `curve_name`, `issuer`, `serial`, `checksum` | `1` if FIPS-compliant, `0` if not. Only emitted when `fips_compliance_enabled=true` |
 | `tls_certificate_self_signed` | Gauge | `cert_path`, `cert_index`, `pod_name`, `namespace`, `workload_kind`, `workload_name`, `node_name`, `app_label`, `container_name`, `is_ca`, `issuer`, `serial`, `checksum` | `1` if the certificate is self-signed, `0` if issued by a separate CA. Always emitted. `is_ca` label: `true` / `false` / `unknown` (when Basic Constraints extension is absent) |
+
+There is no separate "expired" or "expiring soon" gauge — both are derivable from
+`tls_certificate_expiry_days` (see above) with a plain comparison, exactly how
+`CertificateExpiringCritical`/`CertificateExpiringWarning`/`CertificateExpired` in
+`extras/openshift/prometheus-rule.yaml` already alert (`tls_certificate_expiry_days < 0`
+for expired, `< 7 and > 0` / `< 30 and > 7` for the two warning tiers). Pre-computing
+these as their own boolean gauges used to cost 4 extra Prometheus series per certificate
+(one "expired" plus three "expiring_soon" threshold buckets) for values a query can derive
+for free.
 
 ### Certificate-to-process map
 

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -325,15 +325,27 @@ below for why it's needed); omit it to auto-detect the host's default-route IP.
 Identical to the vanilla Kubernetes path — `TracingPolicy` is a cluster-scoped CRD:
 
 ```bash
-kubectl apply -f tetragon-policies/certificate-file-access.yaml
+kubectl apply -f tetragon-policies/openshift/certificate-file-access.yaml
 kubectl apply -f tetragon-policies/tcp-connect-tls.yaml
 kubectl apply -f tetragon-policies/experimental/tls-service-tracking.yaml
 kubectl apply -f tetragon-policies/experimental/openshift/openssl3-cert-load.yaml
 kubectl get tracingpolicies
 ```
 
-Note the last policy is the OpenShift-specific variant, not
+Note the first and last policies are OpenShift-specific variants, not
+`tetragon-policies/certificate-file-access.yaml` or
 `tetragon-policies/experimental/openssl3-cert-load.yaml` — see below for why.
+
+**`certificate-file-access` variant**: adds a kernel-side `NotPrefix` exclusion for
+`/var/lib/kubelet/pods/` on top of the bare-metal policy's extension filter. Kubelet
+bind-mounts the same handful of underlying CA bundles/service-account certs into every
+pod's projected volume, so without this exclusion the fd_install hook fires once per pod
+per mount for what's usually the same underlying cert — on a real cluster this is the
+dominant source of tracked-certificate cardinality (and the periodic Prometheus-scrape
+CPU cost that comes from serializing all of them), not distinct certs actually present on
+the node. Filtering at the kernel boundary means these events never reach cert-analyzer
+at all. Not applicable to the bare-metal RPM policy, since `/var/lib/kubelet/pods/`
+doesn't exist on a non-Kubernetes host.
 
 **Known gap on containerized nodes — two distinct failure classes.** The `java-fips-nss-cert` and
 `java-non-fips-cert` experimental uprobe policies still fail to load on the OpenShift/CRC

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -657,10 +657,9 @@ oc exec -n certsight <pod> -- curl -s http://localhost:8086/healthz
 oc exec -n certsight <pod> -- curl -s http://localhost:8086/readyz
 ```
 
-A 5-day test certificate should produce `tls_certificate_expiry_days` just under `5.0` and
-`tls_certificate_expiring_soon{threshold_days="7"} 1.0` — the exact condition
-`CertificateExpiringCritical`'s expression (`tls_certificate_expiry_days < 7 and
-tls_certificate_expiry_days > 0`) checks for. Where a live UWM Prometheus is available, confirm
+A 5-day test certificate should produce `tls_certificate_expiry_days` just under `5.0`,
+satisfying `CertificateExpiringCritical`'s expression (`tls_certificate_expiry_days < 7 and
+tls_certificate_expiry_days > 0`). Where a live UWM Prometheus is available, confirm
 the alert actually fires (`for: 5m`) via `Observe → Alerting` in the console rather than just
 checking the raw metric value.
 

--- a/extras/README-QUICKSTART.md
+++ b/extras/README-QUICKSTART.md
@@ -148,15 +148,15 @@ sudo podman logs cert-analyzer | tail -30 | grep -E "🔴|⚠️|✅"
 ```bash
 # Expired certificates
 echo "Expired certificates:"
-curl -s http://localhost:9090/metrics | grep 'tls_certificate_expired.*1$' | head -3
+curl -s http://localhost:9090/metrics | grep '^tls_certificate_expiry_days' | awk '$NF < 0' | head -3
 
 # Certificates expiring within 7 days
 echo -e "\nCertificates expiring soon (< 7 days):"
-curl -s http://localhost:9090/metrics | grep 'tls_certificate_expiring_soon.*"7".*1$' | head -3
+curl -s http://localhost:9090/metrics | grep '^tls_certificate_expiry_days' | awk '$NF > 0 && $NF < 7' | head -3
 
 # Certificates expiring within 30 days
 echo -e "\nCertificates expiring soon (< 30 days):"
-curl -s http://localhost:9090/metrics | grep 'tls_certificate_expiring_soon.*"30".*1$' | head -3
+curl -s http://localhost:9090/metrics | grep '^tls_certificate_expiry_days' | awk '$NF > 0 && $NF < 30' | head -3
 ```
 
 ---

--- a/extras/cert_blast_radius.py
+++ b/extras/cert_blast_radius.py
@@ -24,8 +24,8 @@ import urllib.parse
 import urllib.request
 
 CATEGORICAL_SLOTS = 8
-# Matches the thresholds cert-analyzer's own tls_certificate_expiring_soon
-# metric buckets on (see extras/examples/grafana-dashboard.json).
+# Matches the thresholds the CertificateExpiringCritical/Warning alerting
+# rules use against tls_certificate_expiry_days (see extras/openshift/prometheus-rule.yaml).
 EXPIRY_THRESHOLDS = (0, 7, 30)  # expired / <7d critical / <30d warning / else good
 
 # Palette values (dataviz skill reference/palette.md), wired as CSS custom

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -761,7 +761,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expired{namespace=~\"$namespace\",node_name=~\"$node\"} == 1))",
+              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 0))",
               "instant": true,
               "format": "table",
               "refId": "B"
@@ -771,7 +771,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expiring_soon{threshold_days=\"7\",namespace=~\"$namespace\",node_name=~\"$node\"} == 1))",
+              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 7 and tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} > 0))",
               "instant": true,
               "format": "table",
               "refId": "C"
@@ -781,7 +781,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expiring_soon{threshold_days=\"30\",namespace=~\"$namespace\",node_name=~\"$node\"} == 1))",
+              "expr": "count by (node_name) (count by (node_name, issuer, serial, checksum) (tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} < 30 and tls_certificate_expiry_days{namespace=~\"$namespace\",node_name=~\"$node\"} > 0))",
               "instant": true,
               "format": "table",
               "refId": "D"

--- a/extras/quick-demo.sh
+++ b/extras/quick-demo.sh
@@ -63,11 +63,11 @@ echo ""
 echo "📈 Prometheus Metrics:"
 echo ""
 echo "Expired certificates:"
-curl -s http://localhost:9090/metrics | grep 'tls_certificate_expired{.*}.*1$' | \
+curl -s http://localhost:9090/metrics | grep '^tls_certificate_expiry_days{' | awk '$NF < 0' | \
     grep "pki/tls/certs" | head -3 | sed 's/^/  /'
 echo ""
 echo "Expiring soon (< 7 days):"
-curl -s http://localhost:9090/metrics | grep 'tls_certificate_expiring_soon{.*threshold_days="7"}.*1$' | \
+curl -s http://localhost:9090/metrics | grep '^tls_certificate_expiry_days{' | awk '$NF > 0 && $NF < 7' | \
     grep "pki/tls/certs" | head -3 | sed 's/^/  /'
 echo ""
 

--- a/extras/test-server/blast_radius.py
+++ b/extras/test-server/blast_radius.py
@@ -19,8 +19,8 @@ import urllib.parse
 import urllib.request
 
 CATEGORICAL_SLOTS = 8
-# Matches the thresholds cert-analyzer's own tls_certificate_expiring_soon
-# metric buckets on (see extras/examples/grafana-dashboard.json).
+# Matches the thresholds the CertificateExpiringCritical/Warning alerting
+# rules use against tls_certificate_expiry_days (see extras/openshift/prometheus-rule.yaml).
 EXPIRY_THRESHOLDS = (0, 7, 30)  # expired / <7d critical / <30d warning / else good
 
 # Palette values (dataviz skill reference/palette.md), wired as CSS custom

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -2915,7 +2915,7 @@ class TestMetricsCleanupOnEviction:
     def test_per_cert_series_removed_on_lru_eviction(self, analyzer, temp_dir):
         """
         Evicting a cert from known_certs must remove its cert_expiry_days,
-        cert_expired, cert_process_info, and cert_self_signed series --
+        cert_expiry_timestamp, cert_process_info, and cert_self_signed series --
         otherwise Prometheus keeps every cert ever discovered in memory
         forever, independent of whether the LRU cache actually evicted it.
         """
@@ -2931,7 +2931,7 @@ class TestMetricsCleanupOnEviction:
 
         gauges = (
             analyzer.metrics.cert_expiry_days,
-            analyzer.metrics.cert_expired,
+            analyzer.metrics.cert_expiry_timestamp,
             analyzer.metrics.cert_process_info,
             analyzer.metrics.cert_self_signed,
         )

--- a/tetragon-policies/openshift/certificate-file-access.yaml
+++ b/tetragon-policies/openshift/certificate-file-access.yaml
@@ -1,0 +1,45 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: certificate-file-access
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    return: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Postfix"
+        values:
+        - ".crt"
+        - ".pem"
+        - ".cert"
+        - ".cer"
+        - ".jks"
+        - ".keystore"
+        - ".truststore"
+        - ".p12"
+        - ".pfx"
+      # OpenShift/Kubernetes-specific exclusion: kubelet bind-mounts the same
+      # handful of underlying CA bundles/service-account certs into every
+      # pod's projected volume under /var/lib/kubelet/pods/. Without this,
+      # fd_install fires once per pod per mount for what's usually the same
+      # underlying cert content, so known_certs cardinality grows roughly
+      # linearly with pod count rather than with distinct certs on the node
+      # -- on a real cluster this dwarfs every other source of tracked certs
+      # combined. Filtering here means the event never leaves the kernel for
+      # these paths at all. Not needed in the bare-metal RPM policy
+      # (tetragon-policies/certificate-file-access.yaml) since that path
+      # doesn't exist there.
+      - index: 1
+        operator: "NotPrefix"
+        values:
+        - "/var/lib/kubelet/pods/"
+      matchActions:
+      - action: Post


### PR DESCRIPTION
…pod cert noise

Kubelet bind-mounts the same handful of CA bundles/service-account certs into every pod's projected volume, so the shared fd_install policy tracked one near-duplicate cert entry per pod under /var/lib/kubelet/pods/ rather than per distinct cert -- on a 66-namespace CRC cluster this was 2,233 of 2,493 tracked certs, driving a ~15MB /metrics payload and a periodic CPU spike (up to 30% of a core against a 200m limit) every time Prometheus's scrape cache expired and cert-analyzer had to re-serialize all of it.

Adds a kernel-side NotPrefix exclusion for that path to a new OpenShift variant of the policy, verified live against the CRC cluster: tracked certs 2,493 -> 161, /metrics payload ~15MB -> ~1MB, scrape duration 3.79s -> 0.114s, periodic CPU spike gone.