### PR TITLE
Add persistent port-forwarding daemon for external OpenShift/CRC metrics access

### DIFF
--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -715,6 +715,15 @@ of forwarding:
 The same two-layer pattern is used for the API server (port 6443, via the cluster's
 built-in `kubernetes` Service in the `default` namespace) and the test server (port 8090).
 
+**Why not just an OpenShift Route?** The Helm chart's `route.enabled`
+([`extras/helm/cert-analyzer/README.md`](helm/cert-analyzer/README.md#external-metrics-access))
+is the right answer on a real cluster, where the router's wildcard subdomain resolves to a
+real, externally-reachable IP. It doesn't help on CRC: `crc setup` points `*.apps-crc.testing`
+at `127.0.0.1`, same as everything else on the VM, so a Route's hostname is no more reachable
+from another host than the bare Service was. A Route also can't stand in for the API-server or
+test-server forwarding below either way — Routes only proxy HTTP(S) on 80/443, not arbitrary
+raw TCP ports like 6443/8090.
+
 `oc port-forward` is not persistent — it exits if the API server restarts or the host is
 suspended. A systemd user service wrapping a restart-loop daemon
 ([`extras/openshift/scripts/certsight-port-forwarding-daemon.sh`](openshift/scripts/certsight-port-forwarding-daemon.sh))

--- a/extras/OPENSHIFT-DEPLOYMENT-README.md
+++ b/extras/OPENSHIFT-DEPLOYMENT-README.md
@@ -699,3 +699,68 @@ a host reboot without re-running every step above by hand, use the menu-driven
 [`extras/openshift/openshift-utils.sh`](openshift/openshift-utils.sh) — it currently offers
 "start the soak demo from a reboot", "rebuild/redeploy cert-analyzer", and "build/deploy the
 interactive test-console Pod" (§6 above), and is the home for future OpenShift utility scripts.
+
+---
+
+## External metrics access via persistent port-forwarding daemon
+
+When Prometheus and Grafana run outside the CRC VM and need to scrape `/metrics` at an
+externally reachable address, CRC's default `127.0.0.1`-only binding requires two layers
+of forwarding:
+
+1. `oc port-forward` — bridges the in-cluster `cert-expiry-monitor` Service to
+   `localhost:9090` on the CRC host.
+2. `socat` — binds the host's external IP and forwards to `localhost:9090`.
+
+The same two-layer pattern is used for the API server (port 6443, via the cluster's
+built-in `kubernetes` Service in the `default` namespace) and the test server (port 8090).
+
+`oc port-forward` is not persistent — it exits if the API server restarts or the host is
+suspended. A systemd user service wrapping a restart-loop daemon
+([`extras/openshift/scripts/certsight-port-forwarding-daemon.sh`](openshift/scripts/certsight-port-forwarding-daemon.sh))
+keeps all forwarders running automatically.
+
+### Install (one-time)
+
+```bash
+bash extras/openshift/scripts/install-certsight-port-forwarding-service.sh
+```
+
+This copies `certsight-port-forwarding-daemon.sh` and `certsight-port-forwarding.service` into
+`~/.config/systemd/user/`, enables the service, and starts it. The daemon waits for the
+cluster to be reachable before starting forwarders, and restarts each forwarder individually
+on failure within 5 seconds.
+
+`HOST_IP` is auto-detected from the default route. All ports default to the chart's own defaults
+(metrics: 9090, test server: 8090, API: 6443). Override any of these via flags or the systemd
+service unit's `ExecStart` line:
+
+```
+ExecStart=/bin/bash %h/.config/systemd/user/certsight-port-forwarding-daemon.sh \
+  --host-ip <ip> \
+  --metrics-pod-port 9090 \
+  --metrics-host-port 9091 \
+  --test-server-port 8090
+```
+
+Run `certsight-port-forwarding-daemon.sh --help` for the full option list.
+
+### After `crc start` / reboot
+
+The service starts automatically on login (`WantedBy=default.target`). No manual action
+needed — the daemon's `wait_for_cluster` loop handles the delay between the VM coming up
+and the API server being ready.
+
+### Manual control
+
+```bash
+systemctl --user status certsight-port-forwarding.service
+systemctl --user restart certsight-port-forwarding.service
+journalctl --user -u certsight-port-forwarding.service -n 50
+```
+
+### Verify
+
+```bash
+curl http://<host-ip>:9090/metrics | head -5
+```

--- a/extras/helm/cert-analyzer/README.md
+++ b/extras/helm/cert-analyzer/README.md
@@ -157,6 +157,18 @@ host-level Prometheus feeding a Grafana instance that isn't part of this chart. 
 left unset so OpenShift assigns its standard `<name>-<namespace>.<router subdomain>` default
 rather than hardcoding one cluster's subdomain; set `route.host` to override.
 
+**Not sufficient on CRC.** The Route only helps if its hostname actually resolves to something
+reachable from outside the cluster -- true on a real OpenShift cluster, where the router's
+wildcard subdomain has a real external IP/LoadBalancer behind it. On CRC, `*.apps-crc.testing`
+(and `api.crc.testing`) are configured by `crc setup` to resolve to `127.0.0.1`, same as
+everything else on the VM -- so a Route's hostname is exactly as unreachable from another host
+as the raw Service was. For CRC specifically (or any cluster whose router subdomain isn't
+externally resolvable), use the persistent port-forwarding daemon instead -- see "External
+metrics access via persistent port-forwarding daemon" in
+[`OPENSHIFT-DEPLOYMENT-README.md`](../../OPENSHIFT-DEPLOYMENT-README.md#external-metrics-access-via-persistent-port-forwarding-daemon).
+It also covers the API server and test-console ports, neither of which a Route can expose
+anyway (Routes only proxy HTTP(S) on 80/443, not arbitrary raw TCP ports like 6443/8090).
+
 ## Upgrade
 
 ```bash

--- a/extras/openshift/scripts/certsight-port-forwarding-daemon.sh
+++ b/extras/openshift/scripts/certsight-port-forwarding-daemon.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# description: Persistent restart-loop daemon exposing CertSight metrics, the OpenShift API server, and the test console to an externally reachable host IP (installed as a systemd --user service by install-certsight-port-forwarding-service.sh)
+#
+# For each forwarded port this runs one `oc port-forward` (bridges the in-cluster
+# Service/Pod to localhost on the CRC host) plus one `socat` (binds the host's
+# external IP and relays to that localhost port) — see the "External metrics access
+# via persistent port-forwarding daemon" section of ../../OPENSHIFT-DEPLOYMENT-README.md
+# for why both layers are needed. Each of the six processes is supervised
+# independently and restarted a fixed delay after it exits, so a single failure
+# (API server restart, host suspend/resume, etc.) doesn't take down the others.
+set -uo pipefail
+
+NAMESPACE=certsight
+METRICS_SERVICE=cert-expiry-monitor
+TEST_SERVER_POD=cert-test-server
+# The API server has no dedicated Pod/Service of its own to `oc port-forward` to;
+# every cluster exposes it internally via the built-in `kubernetes` Service in the
+# `default` namespace, so that's what gets bridged for the same two-layer treatment.
+API_NAMESPACE=default
+API_SERVICE=kubernetes
+API_SERVICE_PORT=443
+
+HOST_IP=""
+METRICS_POD_PORT=9090
+METRICS_HOST_PORT=9090
+TEST_SERVER_PORT=8090
+API_PORT=6443
+RESTART_DELAY=5
+CLUSTER_WAIT_INTERVAL=5
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Persistent restart-loop daemon exposing CertSight's metrics endpoint, the
+OpenShift API server, and the test-console Pod on an externally reachable
+address. Waits for the cluster to become reachable, then runs one
+oc port-forward + one socat per forwarded port, each independently supervised
+and restarted ${RESTART_DELAY}s after it exits.
+
+Normally installed as a systemd --user service via
+install-certsight-port-forwarding-service.sh rather than run directly.
+
+Options:
+  --host-ip <ip>              External IP to bind the socat listeners to
+                               (default: auto-detected from the default route)
+  --namespace <ns>            Namespace cert-expiry-monitor/cert-test-server run in
+                               (default: $NAMESPACE)
+  --metrics-pod-port <port>    Target port on the cert-expiry-monitor Service
+                               (default: $METRICS_POD_PORT)
+  --metrics-host-port <port>   Local/external port for metrics
+                               (default: $METRICS_HOST_PORT)
+  --test-server-port <port>    Local/external port for the test console
+                               (default: $TEST_SERVER_PORT)
+  --api-port <port>            Local/external port for the API server
+                               (default: $API_PORT)
+  --restart-delay <secs>       Delay before restarting a failed forwarder
+                               (default: ${RESTART_DELAY}s)
+  -h, --help                   Show this help and exit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host-ip) HOST_IP="$2"; shift 2 ;;
+        --host-ip=*) HOST_IP="${1#*=}"; shift ;;
+        --namespace) NAMESPACE="$2"; shift 2 ;;
+        --namespace=*) NAMESPACE="${1#*=}"; shift ;;
+        --metrics-pod-port) METRICS_POD_PORT="$2"; shift 2 ;;
+        --metrics-pod-port=*) METRICS_POD_PORT="${1#*=}"; shift ;;
+        --metrics-host-port) METRICS_HOST_PORT="$2"; shift 2 ;;
+        --metrics-host-port=*) METRICS_HOST_PORT="${1#*=}"; shift ;;
+        --test-server-port) TEST_SERVER_PORT="$2"; shift 2 ;;
+        --test-server-port=*) TEST_SERVER_PORT="${1#*=}"; shift ;;
+        --api-port) API_PORT="$2"; shift 2 ;;
+        --api-port=*) API_PORT="${1#*=}"; shift ;;
+        --restart-delay) RESTART_DELAY="$2"; shift 2 ;;
+        --restart-delay=*) RESTART_DELAY="${1#*=}"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+for bin in oc socat; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "Required command not found: $bin" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "$HOST_IP" ]]; then
+    HOST_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')
+    if [[ -z "$HOST_IP" ]]; then
+        echo "Could not auto-detect the host's IP -- pass it explicitly: $0 --host-ip <ip>" >&2
+        exit 1
+    fi
+    echo "Auto-detected --host-ip: $HOST_IP"
+fi
+
+# No job control here, so background jobs (and everything they spawn) stay in this
+# script's own process group -- `kill 0` reaches all of them in one shot. Also
+# covered independently by systemd's default KillMode=control-group when run as
+# the service's ExecStart. Each `supervise` subshell below inherits this same
+# trap, so it must disarm itself (`trap - TERM INT`) before broadcasting --
+# otherwise every subshell's own `kill 0` re-delivers TERM to every other
+# subshell that hasn't disarmed yet, which re-enters this handler and
+# broadcasts again, cascading into a signal storm instead of a clean exit.
+trap 'trap - TERM INT; echo "Stopping forwarders..."; kill 0; exit 0' TERM INT
+
+wait_for_cluster() {
+    echo "Waiting for the cluster to become reachable..."
+    until oc whoami >/dev/null 2>&1; do
+        sleep "$CLUSTER_WAIT_INTERVAL"
+    done
+    echo "Cluster reachable."
+}
+
+supervise() {
+    local label="$1"
+    shift
+    while true; do
+        echo "[$label] starting: $*"
+        "$@"
+        echo "[$label] exited (rc=$?) -- restarting in ${RESTART_DELAY}s"
+        sleep "$RESTART_DELAY"
+    done
+}
+
+wait_for_cluster
+
+supervise metrics-oc-pf \
+    oc port-forward -n "$NAMESPACE" "svc/$METRICS_SERVICE" "${METRICS_HOST_PORT}:${METRICS_POD_PORT}" &
+
+supervise metrics-socat \
+    socat "TCP-LISTEN:${METRICS_HOST_PORT},bind=${HOST_IP},fork,reuseaddr" "TCP:127.0.0.1:${METRICS_HOST_PORT}" &
+
+supervise test-server-oc-pf \
+    oc port-forward -n "$NAMESPACE" "pod/$TEST_SERVER_POD" "${TEST_SERVER_PORT}:${TEST_SERVER_PORT}" &
+
+supervise test-server-socat \
+    socat "TCP-LISTEN:${TEST_SERVER_PORT},bind=${HOST_IP},fork,reuseaddr" "TCP:127.0.0.1:${TEST_SERVER_PORT}" &
+
+supervise api-oc-pf \
+    oc port-forward -n "$API_NAMESPACE" "svc/$API_SERVICE" "${API_PORT}:${API_SERVICE_PORT}" &
+
+supervise api-socat \
+    socat "TCP-LISTEN:${API_PORT},bind=${HOST_IP},fork,reuseaddr" "TCP:127.0.0.1:${API_PORT}" &
+
+wait

--- a/extras/openshift/scripts/certsight-port-forwarding.service
+++ b/extras/openshift/scripts/certsight-port-forwarding.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=CertSight persistent port-forwarding daemon (metrics, API server, test console)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash %h/.config/systemd/user/certsight-port-forwarding-daemon.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/extras/openshift/scripts/install-certsight-port-forwarding-service.sh
+++ b/extras/openshift/scripts/install-certsight-port-forwarding-service.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# description: One-time install of the persistent port-forwarding daemon as a systemd --user service (see OPENSHIFT-DEPLOYMENT-README.md)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+SERVICE_NAME=certsight-port-forwarding.service
+
+step() { echo; echo "==> $*"; }
+
+step "Checking prerequisites"
+for bin in oc socat systemctl; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "Required command not found: $bin" >&2
+        exit 1
+    fi
+done
+
+step "Installing daemon script and service unit into $UNIT_DIR"
+mkdir -p "$UNIT_DIR"
+install -m 755 "$SCRIPT_DIR/certsight-port-forwarding-daemon.sh" "$UNIT_DIR/certsight-port-forwarding-daemon.sh"
+install -m 644 "$SCRIPT_DIR/$SERVICE_NAME" "$UNIT_DIR/$SERVICE_NAME"
+
+step "Enabling and starting the service"
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE_NAME"
+
+step "Done"
+echo "Status:   systemctl --user status $SERVICE_NAME"
+echo "Logs:     journalctl --user -u $SERVICE_NAME -n 50 -f"
+echo
+echo "The unit is WantedBy=default.target, so it (re)starts automatically on login."
+echo "If you need it running before any interactive login too -- e.g. right after a"
+echo "host reboot with no session open yet -- enable lingering for this user:"
+echo "  sudo loginctl enable-linger $(whoami)"
+echo
+echo "To customize ports/host IP, edit the ExecStart line in:"
+echo "  $UNIT_DIR/$SERVICE_NAME"
+echo "then: systemctl --user daemon-reload && systemctl --user restart $SERVICE_NAME"


### PR DESCRIPTION
CRC binds the API server, cert-expiry-monitor metrics, and the test console to 127.0.0.1 only, so an external Prometheus/Grafana can't scrape them directly. Adds a systemd --user service wrapping a restart-loop daemon that layers oc port-forward + socat per port, with each forwarder supervised and restarted independently on failure.