### PR TITLE
Add node_name label to cert-event, analysis-error, and probe counters

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -396,7 +396,7 @@ class CertificateAnalyzer:
                     "not tracking additional process %r",
                     self._max_processes_per_cert, cert_info.path, process,
                 )
-                self.metrics.cert_analysis_errors.labels(error_type='process_fanout_cap_reached').inc()
+                self.metrics.cert_analysis_errors.labels(error_type='process_fanout_cap_reached', node_name=self.metrics._node_name).inc()
                 return False
             cert_info._seen_processes.add(key)
         self.metrics.record_cert_process_access(
@@ -435,7 +435,7 @@ class CertificateAnalyzer:
                 f"Skipping JKS file {cert_path}: pyjks not installed. "
                 "Add 'pyjks' to requirements.txt to enable JKS support."
             )
-            self.metrics.cert_analysis_errors.labels(error_type='jks_unavailable').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='jks_unavailable', node_name=self.metrics._node_name).inc()
             return []
 
         # Skip files that have already failed — avoids repeating crypto work on
@@ -473,7 +473,7 @@ class CertificateAnalyzer:
                 f"Could not open JKS {cert_path}: all passwords failed. "
                 "Set JKS_PASSWORD env var if the keystore uses a custom password."
             )
-            self.metrics.cert_analysis_errors.labels(error_type='jks_password_failed').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='jks_password_failed', node_name=self.metrics._node_name).inc()
             self.password_failed_paths.add(cert_path)
             self._update_cache_metrics()
             return []
@@ -535,11 +535,11 @@ class CertificateAnalyzer:
                 p12_data = f.read()
         except FileNotFoundError:
             logger.debug(f"PKCS12 file not found: {cert_path}")
-            self.metrics.cert_analysis_errors.labels(error_type='file_not_found').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='file_not_found', node_name=self.metrics._node_name).inc()
             return []
         except PermissionError:
             logger.debug(f"Permission denied reading PKCS12: {cert_path}")
-            self.metrics.cert_analysis_errors.labels(error_type='permission_denied').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='permission_denied', node_name=self.metrics._node_name).inc()
             return []
 
         p12 = None
@@ -560,7 +560,7 @@ class CertificateAnalyzer:
                 f"Could not open PKCS12 {cert_path}: all passwords failed. "
                 "Set PKCS12_PASSWORD env var if the file uses a custom password."
             )
-            self.metrics.cert_analysis_errors.labels(error_type='pkcs12_password_failed').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='pkcs12_password_failed', node_name=self.metrics._node_name).inc()
             self.password_failed_paths.add(cert_path)
             self._update_cache_metrics()
             return []
@@ -649,15 +649,15 @@ class CertificateAnalyzer:
 
         except FileNotFoundError:
             logger.debug(f"Certificate file not found: {cert_path}")
-            self.metrics.cert_analysis_errors.labels(error_type='file_not_found').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='file_not_found', node_name=self.metrics._node_name).inc()
             return []
         except PermissionError:
             logger.debug(f"Permission denied reading certificate: {cert_path}")
-            self.metrics.cert_analysis_errors.labels(error_type='permission_denied').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='permission_denied', node_name=self.metrics._node_name).inc()
             return []
         except Exception as e:
             logger.debug(f"Error reading certificate {cert_path}: {e}")
-            self.metrics.cert_analysis_errors.labels(error_type='read_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='read_error', node_name=self.metrics._node_name).inc()
             return []
 
     def extract_certificate_info(
@@ -681,21 +681,21 @@ class CertificateAnalyzer:
             subject = cert.subject.rfc4514_string()
         except Exception as e:
             logger.warning(f"Could not extract subject from cert {cert_index} in {cert_path}: {e}")
-            self.metrics.cert_analysis_errors.labels(error_type='extraction_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=self.metrics._node_name).inc()
             return None
 
         try:
             issuer = cert.issuer.rfc4514_string()
         except Exception as e:
             logger.warning(f"Could not extract issuer from cert {cert_index} in {cert_path}: {e}")
-            self.metrics.cert_analysis_errors.labels(error_type='extraction_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=self.metrics._node_name).inc()
             return None
 
         try:
             serial_number = str(cert.serial_number)
         except Exception as e:
             logger.warning(f"Could not extract serial number from cert {cert_index} in {cert_path}: {e}")
-            self.metrics.cert_analysis_errors.labels(error_type='extraction_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=self.metrics._node_name).inc()
             return None
 
         # Use the UTC-aware property where available, fall back to the naive
@@ -711,7 +711,7 @@ class CertificateAnalyzer:
                 not_after = not_after.replace(tzinfo=None)
         except Exception as e:
             logger.warning(f"Could not extract validity dates from cert {cert_index} in {cert_path}: {e}")
-            self.metrics.cert_analysis_errors.labels(error_type='extraction_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=self.metrics._node_name).inc()
             return None
 
         try:
@@ -1004,7 +1004,7 @@ class CertificateAnalyzer:
         except Exception as e:
             logger.error(f"Unexpected error parsing certificates from {cert_path}: {e}",
                          exc_info=True)
-            self.metrics.cert_analysis_errors.labels(error_type='parse_error').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='parse_error', node_name=self.metrics._node_name).inc()
             return []
 
         if not certs:
@@ -1021,11 +1021,11 @@ class CertificateAnalyzer:
                     # the error metric — skip this cert and continue with others
                     continue
                 cert_infos.append(cert_info)
-                self.metrics.cert_events_total.labels(event_type='analysis', status='success').inc()
+                self.metrics.cert_events_total.labels(event_type='analysis', status='success', node_name=self.metrics._node_name).inc()
             except Exception as e:
                 logger.error(f"Error extracting certificate info from {cert_path} (cert {idx}): {e}")
-                self.metrics.cert_events_total.labels(event_type='analysis', status='failed').inc()
-                self.metrics.cert_analysis_errors.labels(error_type='extraction_error').inc()
+                self.metrics.cert_events_total.labels(event_type='analysis', status='failed', node_name=self.metrics._node_name).inc()
+                self.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=self.metrics._node_name).inc()
 
         self.processed_paths.add(cert_path)
         self._update_cache_metrics()
@@ -1086,9 +1086,9 @@ class CertificateAnalyzer:
                     f"{cert_info.path}: {e}", exc_info=True
                 )
                 self.metrics.cert_events_total.labels(
-                    event_type='processing', status='error'
+                    event_type='processing', status='error', node_name=self.metrics._node_name
                 ).inc()
-                self.metrics.cert_analysis_errors.labels(error_type='finish_error').inc()
+                self.metrics.cert_analysis_errors.labels(error_type='finish_error', node_name=self.metrics._node_name).inc()
 
         if is_bundle:
             remaining = len(cert_infos) - metrics_cap
@@ -1165,7 +1165,7 @@ class CertificateAnalyzer:
             return cert_infos
 
         self._log_rate_limited_new_cert(cert_path)
-        self.metrics.cert_analysis_errors.labels(error_type='rate_limited').inc()
+        self.metrics.cert_analysis_errors.labels(error_type='rate_limited', node_name=self.metrics._node_name).inc()
         self._enqueue_rate_limited_retry(
             cert_path, process_name, pid, namespace,
             tetragon_pod, parent_process, parent_pid, node_name,
@@ -1198,7 +1198,7 @@ class CertificateAnalyzer:
             if len(self._retry_queue) >= self._retry_queue_max_size:
                 dropped = self._retry_queue.popleft()
                 self._retry_queue_paths.discard(dropped.cert_path)
-                self.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped').inc()
+                self.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped', node_name=self.metrics._node_name).inc()
                 logger.warning(
                     f"Rate-limit retry queue full ({self._retry_queue_max_size}) -- "
                     f"dropped oldest queued file {dropped.cert_path} to make room for {cert_path}"
@@ -1348,7 +1348,7 @@ class CertificateAnalyzer:
                     logger.error(f"Error processing large certificate file {cert_path}: {e}",
                                  exc_info=True)
                     self.metrics.cert_events_total.labels(
-                        event_type='processing', status='error'
+                        event_type='processing', status='error', node_name=self.metrics._node_name
                     ).inc()
             finally:
                 with self._new_path_lock:
@@ -1360,7 +1360,7 @@ class CertificateAnalyzer:
             # the file will be retried on its next qualifying event.
             with self._new_path_lock:
                 self._large_file_in_flight.discard(cert_path)
-            self.metrics.cert_analysis_errors.labels(error_type='background_thread_cap_reached').inc()
+            self.metrics.cert_analysis_errors.labels(error_type='background_thread_cap_reached', node_name=self.metrics._node_name).inc()
 
     def _apply_pod_context(self, cert_info: CertificateInfo, tetragon_pod):
         """Populate all Tetragon Pod proto fields onto cert_info."""
@@ -2003,7 +2003,7 @@ class CertificateAnalyzer:
 
         if endpoint_key in self._probed_endpoints:
             logger.debug("TLS probe: already probed %s", synthetic_path)
-            self.metrics.tls_port_probes_total.labels(status='skipped').inc()
+            self.metrics.tls_port_probes_total.labels(status='skipped', node_name=self.metrics._node_name).inc()
             return
 
         ctx = ssl.create_default_context()
@@ -2023,26 +2023,26 @@ class CertificateAnalyzer:
                 cipher_name = cipher[0] if cipher else None
         except Exception as e:
             logger.debug(f"TLS probe failed {host}:{port}: {e}")
-            self.metrics.tls_port_probes_total.labels(status='failed').inc()
+            self.metrics.tls_port_probes_total.labels(status='failed', node_name=self.metrics._node_name).inc()
             return
         finally:
             if raw_sock is not None:
                 raw_sock.close()
 
         if not der_bytes:
-            self.metrics.tls_port_probes_total.labels(status='failed').inc()
+            self.metrics.tls_port_probes_total.labels(status='failed', node_name=self.metrics._node_name).inc()
             return
 
         try:
             cert = x509.load_der_x509_certificate(der_bytes, default_backend())
         except Exception as e:
             logger.debug(f"TLS probe: DER parse failed for {host}:{port}: {e}")
-            self.metrics.tls_port_probes_total.labels(status='failed').inc()
+            self.metrics.tls_port_probes_total.labels(status='failed', node_name=self.metrics._node_name).inc()
             return
 
         cert_info = self.extract_certificate_info(cert, synthetic_path, process_name, pid)
         if cert_info is None:
-            self.metrics.tls_port_probes_total.labels(status='failed').inc()
+            self.metrics.tls_port_probes_total.labels(status='failed', node_name=self.metrics._node_name).inc()
             return
 
         if tetragon_pod is not None:
@@ -2061,7 +2061,7 @@ class CertificateAnalyzer:
         if self.kafka_publisher is not None:
             self.kafka_publisher.publish(cert_info)
 
-        self.metrics.tls_port_probes_total.labels(status='success').inc()
+        self.metrics.tls_port_probes_total.labels(status='success', node_name=self.metrics._node_name).inc()
         logger.info(
             f"TLS probe: discovered cert at {host}:{port} "
             f"CN={cert_info.common_name} process={process_name} "
@@ -2151,7 +2151,7 @@ class CertificateAnalyzer:
             # this endpoint will be retried on its next qualifying event.
             with self._probe_in_flight_lock:
                 self._probe_in_flight.discard(endpoint_key)
-            self.metrics.tls_port_probes_total.labels(status='skipped').inc()
+            self.metrics.tls_port_probes_total.labels(status='skipped', node_name=self.metrics._node_name).inc()
             return
         logger.debug(f"Scheduled TLS probe {host}:{port} delay={delay}s pid={pid} process={process_name}")
 
@@ -2223,7 +2223,7 @@ class CertificateAnalyzer:
             # this endpoint will be retried on its next qualifying event.
             with self._probe_in_flight_lock:
                 self._probe_in_flight.discard(endpoint_key)
-            self.metrics.tls_port_probes_total.labels(status='skipped').inc()
+            self.metrics.tls_port_probes_total.labels(status='skipped', node_name=self.metrics._node_name).inc()
             return
         logger.debug(
             f"Scheduled TLS outbound probe {daddr}:{dport} pid={pid} process={process_name}"
@@ -2667,7 +2667,7 @@ class CertificateAnalyzer:
                         except Exception as e:
                             logger.error(f"Error processing event: {e}", exc_info=True)
                             self.metrics.cert_events_total.labels(
-                                event_type='processing', status='error'
+                                event_type='processing', status='error', node_name=self.metrics._node_name
                             ).inc()
 
                     # Stream ended without error — Tetragon closed it cleanly

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -263,13 +263,13 @@ class PrometheusMetrics:
         self.cert_events_total = Counter(
             'tls_certificate_events_total',
             'Total number of certificate events detected',
-            ['event_type', 'status']
+            ['event_type', 'status', 'node_name']
         )
 
         self.cert_analysis_errors = Counter(
             'tls_certificate_analysis_errors_total',
             'Total number of certificate analysis errors',
-            ['error_type']
+            ['error_type', 'node_name']
         )
 
         # Certificate status
@@ -452,7 +452,7 @@ class PrometheusMetrics:
         self.tls_port_probes_total = Counter(
             'tls_port_probes_total',
             'Total number of TLS port probe attempts triggered by bind or outbound connect events',
-            ['status'],  # success, failed, skipped
+            ['status', 'node_name'],  # status: success, failed, skipped
         )
 
         self.tls_tcp_connect_events_total = Counter(

--- a/extras/examples/grafana-dashboard.json
+++ b/extras/examples/grafana-dashboard.json
@@ -2924,8 +2924,8 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "rate(tls_certificate_events_total[5m])",
-              "legendFormat": "{{event_type}} / {{status}}",
+              "expr": "rate(tls_certificate_events_total{node_name=~\"$node\"}[5m])",
+              "legendFormat": "{{event_type}} / {{status}} @ {{node_name}}",
               "refId": "A"
             }
           ],
@@ -2976,8 +2976,8 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "rate(tls_certificate_analysis_errors_total[5m])",
-              "legendFormat": "{{error_type}}",
+              "expr": "rate(tls_certificate_analysis_errors_total{node_name=~\"$node\"}[5m])",
+              "legendFormat": "{{error_type}} @ {{node_name}}",
               "refId": "A"
             }
           ],
@@ -3845,6 +3845,61 @@
                 "align": "auto",
                 "displayMode": "auto",
                 "filterable": true
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 52,
+          "title": "TLS Probe Outcome Rate",
+          "description": "Rate of TLS port probe attempts triggered by bind/connect events, by outcome and node.",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 137
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "rate(tls_port_probes_total{node_name=~\"$node\"}[5m])",
+              "legendFormat": "{{status}} @ {{node_name}}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "showPoints": "auto"
               }
             },
             "overrides": []

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -677,9 +677,7 @@ class TestLargeFileBackgroundProcessing:
 
         analyzer.metrics.update_certificate_metrics = flaky_update
 
-        errors_before = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='finish_error'
-        )._value.get()
+        errors_before = analyzer.metrics.cert_analysis_errors.labels(error_type='finish_error', node_name=analyzer.metrics._node_name)._value.get()
 
         analyzer.process_event(self._make_event(bundle_path))
 
@@ -687,9 +685,7 @@ class TestLargeFileBackgroundProcessing:
         # certs 0,1,3,4 must have landed in the cache; only cert 2 was lost.
         assert len(matching) == 4
 
-        errors_after = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='finish_error'
-        )._value.get()
+        errors_after = analyzer.metrics.cert_analysis_errors.labels(error_type='finish_error', node_name=analyzer.metrics._node_name)._value.get()
         assert errors_after == errors_before + 1
 
     def test_large_file_worker_exception_is_logged_and_counted(self, analyzer, temp_dir, caplog):
@@ -705,17 +701,13 @@ class TestLargeFileBackgroundProcessing:
 
         analyzer.analyze_certificate = boom
 
-        errors_before = analyzer.metrics.cert_events_total.labels(
-            event_type='processing', status='error'
-        )._value.get()
+        errors_before = analyzer.metrics.cert_events_total.labels(event_type='processing', status='error', node_name=analyzer.metrics._node_name)._value.get()
 
         with caplog.at_level(logging.ERROR, logger="agent.analyzer"):
             analyzer.process_event(self._make_event(bundle_path))
             self._wait_for_background_processing(analyzer, bundle_path)
 
-        errors_after = analyzer.metrics.cert_events_total.labels(
-            event_type='processing', status='error'
-        )._value.get()
+        errors_after = analyzer.metrics.cert_events_total.labels(event_type='processing', status='error', node_name=analyzer.metrics._node_name)._value.get()
         assert errors_after == errors_before + 1
         assert any("Error processing large certificate file" in r.message
                    for r in caplog.records)
@@ -1228,9 +1220,9 @@ class TestNewCertRateLimiting:
         path = os.path.join(temp_dir, "rl-metric.pem")
         TestCertificateGeneration.save_certificate_pem(cert, path)
 
-        before = analyzer.metrics.cert_analysis_errors.labels(error_type='rate_limited')._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='rate_limited', node_name=analyzer.metrics._node_name)._value.get()
         self._analyze_new(analyzer, path)
-        after = analyzer.metrics.cert_analysis_errors.labels(error_type='rate_limited')._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='rate_limited', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before + 1
 
     def test_zero_rate_disables_limiter_and_never_queues(self, analyzer, temp_dir):
@@ -1321,7 +1313,7 @@ class TestRateLimitRetryQueue:
         analyzer._new_cert_rate_limiter = bucket
         analyzer._retry_queue_max_size = 1
 
-        before = analyzer.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped')._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped', node_name=analyzer.metrics._node_name)._value.get()
 
         for i in range(3):
             cert, _ = TestCertificateGeneration.generate_certificate(f"drop{i}.example.com", 365)
@@ -1329,7 +1321,7 @@ class TestRateLimitRetryQueue:
             TestCertificateGeneration.save_certificate_pem(cert, path)
             self._analyze_new(analyzer, path)
 
-        after = analyzer.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped')._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='retry_queue_dropped', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before + 2  # first entry stays, next two each evict one
 
     def test_queue_depth_metric_tracks_size(self, analyzer, temp_dir):
@@ -1560,13 +1552,9 @@ class TestPKCS12Parsing:
 
         # Second call — should return immediately without attempting passwords
         # We verify by checking the error counter does not increment again
-        before = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='pkcs12_password_failed'
-        )._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='pkcs12_password_failed', node_name=analyzer.metrics._node_name)._value.get()
         analyzer.parse_pkcs12_certificates(p12_path)
-        after = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='pkcs12_password_failed'
-        )._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='pkcs12_password_failed', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before  # no additional error increment on second call
 
     def test_parse_p12_password_list_does_not_include_changeme_or_password(
@@ -2326,13 +2314,9 @@ class TestJKSParsing:
         assert jks_path in analyzer.password_failed_paths
 
         # Second call — error counter must not increment again
-        before = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='jks_password_failed'
-        )._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='jks_password_failed', node_name=analyzer.metrics._node_name)._value.get()
         analyzer.parse_jks_certificates(jks_path)
-        after = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='jks_password_failed'
-        )._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='jks_password_failed', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before
 
     def test_parse_jks_password_list_does_not_include_changeme_or_password(
@@ -3099,15 +3083,11 @@ class TestCertProcessInfoFanoutCap:
         analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
         cert_info = cert_infos[0]
 
-        before = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='process_fanout_cap_reached'
-        )._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='process_fanout_cap_reached', node_name=analyzer.metrics._node_name)._value.get()
 
         analyzer._record_cert_process_access(cert_info, "/usr/bin/other", "")
 
-        after = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='process_fanout_cap_reached'
-        )._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='process_fanout_cap_reached', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before + 1
 
 
@@ -5334,13 +5314,9 @@ class TestCertificateParsingExceptions:
     def test_extract_info_increments_error_metric_on_failure(self, analyzer):
         """extract_certificate_info increments extraction_error metric when it returns None."""
         cert = _BrokenCert(break_subject=True)
-        before = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='extraction_error'
-        )._value.get()
+        before = analyzer.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=analyzer.metrics._node_name)._value.get()
         analyzer.extract_certificate_info(cert, "/tmp/bad.pem", "test", 1)
-        after = analyzer.metrics.cert_analysis_errors.labels(
-            error_type='extraction_error'
-        )._value.get()
+        after = analyzer.metrics.cert_analysis_errors.labels(error_type='extraction_error', node_name=analyzer.metrics._node_name)._value.get()
         assert after == before + 1
 
     def test_analyze_certificate_skips_broken_cert_in_bundle(self, analyzer, temp_dir):
@@ -8125,7 +8101,7 @@ class TestPortProbe:
 
         synthetic_path = f'tls-bind-probe://127.0.0.1:{port}'
         assert any(k.startswith(synthetic_path + ':') for k in probe_analyzer.known_certs)
-        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='success')._value.get() == 1
+        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='success', node_name=probe_analyzer.metrics._node_name)._value.get() == 1
 
     def test_probe_records_negotiated_protocol_and_cipher(self, probe_analyzer, temp_dir):
         """A successful probe records the negotiated TLS protocol/cipher on tls_certificate_negotiated_protocol."""
@@ -8156,12 +8132,12 @@ class TestPortProbe:
         finally:
             stop.set()
 
-        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='skipped')._value.get() == 1
+        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='skipped', node_name=probe_analyzer.metrics._node_name)._value.get() == 1
 
     def test_probe_fails_on_connection_refused(self, probe_analyzer):
         """Connection to a closed port increments the failed counter."""
         probe_analyzer._probe_tls_endpoint('127.0.0.1', 1, '/usr/sbin/nginx', 1234, '', None)
-        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='failed')._value.get() == 1
+        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='failed', node_name=probe_analyzer.metrics._node_name)._value.get() == 1
 
     def test_probe_fails_on_plain_tcp_port(self, probe_analyzer):
         """Connecting to a non-TLS port (no TLS handshake) increments the failed counter."""
@@ -8182,7 +8158,7 @@ class TestPortProbe:
             threading.Thread(target=_accept, daemon=True).start()
             probe_analyzer._probe_tls_endpoint('127.0.0.1', port, '/usr/sbin/nginx', 1234, '', None)
 
-        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='failed')._value.get() == 1
+        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='failed', node_name=probe_analyzer.metrics._node_name)._value.get() == 1
 
     def test_probe_publishes_to_kafka_on_success(self, probe_analyzer, temp_dir):
         """Discovered cert is forwarded to the Kafka publisher when configured."""
@@ -8398,7 +8374,7 @@ class TestPortProbe:
         connect_path = f'tls-connect-probe://127.0.0.1:{port}'
         assert any(k.startswith(bind_path + ':') for k in probe_analyzer.known_certs)
         assert any(k.startswith(connect_path + ':') for k in probe_analyzer.known_certs)
-        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='success')._value.get() == 2
+        assert probe_analyzer.metrics.tls_port_probes_total.labels(status='success', node_name=probe_analyzer.metrics._node_name)._value.get() == 2
         assert mock_kafka.publish.call_count == 2
 
     def test_probe_in_flight_cleared_after_successful_probe(self, probe_analyzer, temp_dir):


### PR DESCRIPTION
tls_certificate_events_total, tls_certificate_analysis_errors_total, and tls_port_probes_total previously had no node_name label, making it impossible to diagnose per-node performance differences from these counters the way tls_socket_bind_events_total/tls_tcp_connect_events_total already allow. Also updates the dashboard's Operational Health panels to filter/group by $node and adds a per-node TLS Probe Outcome Rate panel.