### PR TITLE
Add optional Kafka Connect JSON envelope for certificate_discovered events

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ sudo systemctl enable --now cert-analyzer
 | `access_topic` | `cert-analyzer-access-events` | Topic to publish `certificate_accessed` events to |
 | `connect_enabled` | `false` | Additionally publish each `certificate_discovered` event wrapped in a Kafka-Connect-compatible JSON envelope (`{"schema": {...}, "payload": {...}}`) to `connect_topic`, suitable for a stock Kafka Connect JDBC Sink connector with no custom consumer code. Independent of `enabled`/`access_enabled`; off by default |
 | `connect_topic` | `cert-analyzer-events-connect` | Topic to publish the Kafka-Connect-enveloped `certificate_discovered` events to |
+| `access_connect_enabled` | `false` | Additionally publish each `certificate_accessed` event wrapped in the same kind of Kafka-Connect JSON envelope to `access_connect_topic`. Independent of `access_enabled`/`enabled`/`connect_enabled`; off by default |
+| `access_connect_topic` | `cert-analyzer-access-events-connect` | Topic to publish the Kafka-Connect-enveloped `certificate_accessed` events to |
 | `security_protocol` | `PLAINTEXT` | `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, `SASL_SSL` |
 | `sasl_mechanism` | _(unset)_ | SASL mechanism — required for `SASL_*` protocols |
 | `sasl_username` | _(unset)_ | SASL username |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ sudo systemctl enable --now cert-analyzer
 | `enabled` | `false` | Publish certificate discovery events to Kafka |
 | `bootstrap_servers` | `localhost:9092` | Comma-separated broker addresses |
 | `topic` | `cert-analyzer-events` | Topic to publish `certificate_discovered` events to |
+| `plain_enabled` | `true` | Publish `certificate_discovered` events to the plain-JSON `topic` above. Set to `false` to stop — e.g. once every consumer has migrated to `connect_topic` below. Independent of `access_enabled`/`connect_enabled` |
 | `access_enabled` | `false` | Additionally publish `certificate_accessed` events — one per distinct process/pod that re-accesses an already-known certificate (capped by `max_processes_per_cert` above). Independent of `enabled`; off by default since this can be materially higher volume than discovery events on a busy node |
 | `access_topic` | `cert-analyzer-access-events` | Topic to publish `certificate_accessed` events to |
 | `connect_enabled` | `false` | Additionally publish each `certificate_discovered` event wrapped in a Kafka-Connect-compatible JSON envelope (`{"schema": {...}, "payload": {...}}`) to `connect_topic`, suitable for a stock Kafka Connect JDBC Sink connector with no custom consumer code. Independent of `enabled`/`access_enabled`; off by default |

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ sudo systemctl enable --now cert-analyzer
 | `topic` | `cert-analyzer-events` | Topic to publish `certificate_discovered` events to |
 | `access_enabled` | `false` | Additionally publish `certificate_accessed` events — one per distinct process/pod that re-accesses an already-known certificate (capped by `max_processes_per_cert` above). Independent of `enabled`; off by default since this can be materially higher volume than discovery events on a busy node |
 | `access_topic` | `cert-analyzer-access-events` | Topic to publish `certificate_accessed` events to |
+| `connect_enabled` | `false` | Additionally publish each `certificate_discovered` event wrapped in a Kafka-Connect-compatible JSON envelope (`{"schema": {...}, "payload": {...}}`) to `connect_topic`, suitable for a stock Kafka Connect JDBC Sink connector with no custom consumer code. Independent of `enabled`/`access_enabled`; off by default |
+| `connect_topic` | `cert-analyzer-events-connect` | Topic to publish the Kafka-Connect-enveloped `certificate_discovered` events to |
 | `security_protocol` | `PLAINTEXT` | `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, `SASL_SSL` |
 | `sasl_mechanism` | _(unset)_ | SASL mechanism — required for `SASL_*` protocols |
 | `sasl_username` | _(unset)_ | SASL username |

--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -2357,7 +2357,9 @@ class CertificateAnalyzer:
             # *accessing* pod/container for this specific event, independent of
             # each cert_info's own (sticky, discoverer-attributed) pod fields.
             app_label, container_name = self._derive_app_label_and_container_name(tetragon_pod)
-            publish_access = self.kafka_publisher is not None and self.kafka_publisher.access_enabled
+            publish_access = self.kafka_publisher is not None and (
+                self.kafka_publisher.access_enabled or self.kafka_publisher.access_connect_enabled
+            )
             if publish_access:
                 pod_uid = tetragon_pod.uid if tetragon_pod is not None else ""
                 container_id = tetragon_pod.container.id if tetragon_pod is not None else ""

--- a/agent/config.py
+++ b/agent/config.py
@@ -236,6 +236,7 @@ def main():
     kafka_enabled          = cfg(cp, 'kafka', 'enabled',           'KAFKA_ENABLED',           'false').lower() == 'true'
     kafka_bootstrap        = cfg(cp, 'kafka', 'bootstrap_servers', 'KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')
     kafka_topic            = cfg(cp, 'kafka', 'topic',             'KAFKA_TOPIC',             'cert-analyzer-events')
+    kafka_plain_enabled    = cfg(cp, 'kafka', 'plain_enabled',     'KAFKA_PLAIN_ENABLED',     'true').lower() == 'true'
     kafka_access_enabled   = cfg(cp, 'kafka', 'access_enabled',    'KAFKA_ACCESS_ENABLED',    'false').lower() == 'true'
     kafka_access_topic     = cfg(cp, 'kafka', 'access_topic',      'KAFKA_ACCESS_TOPIC',      'cert-analyzer-access-events')
     kafka_connect_enabled  = cfg(cp, 'kafka', 'connect_enabled',   'KAFKA_CONNECT_ENABLED',   'false').lower() == 'true'
@@ -274,7 +275,7 @@ def main():
     logger.info(f"Kafka enabled:     {kafka_enabled}")
     if kafka_enabled:
         logger.info(f"Kafka brokers:     {kafka_bootstrap}")
-        logger.info(f"Kafka topic:       {kafka_topic}")
+        logger.info(f"Kafka topic:       {kafka_topic} ({'enabled' if kafka_plain_enabled else 'disabled'})")
         logger.info(f"Kafka access events: {'enabled — topic: ' + kafka_access_topic if kafka_access_enabled else 'disabled'}")
         logger.info(f"Kafka Connect envelope: {'enabled — topic: ' + kafka_connect_topic if kafka_connect_enabled else 'disabled'}")
         logger.info(f"Kafka security:    {kafka_security}")
@@ -305,6 +306,7 @@ def main():
         kafka_publisher = KafkaPublisher(
             bootstrap_servers=kafka_bootstrap,
             topic=kafka_topic,
+            plain_enabled=kafka_plain_enabled,
             access_topic=kafka_access_topic if kafka_access_enabled else '',
             connect_topic=kafka_connect_topic if kafka_connect_enabled else '',
             security_protocol=kafka_security,

--- a/agent/config.py
+++ b/agent/config.py
@@ -238,6 +238,8 @@ def main():
     kafka_topic            = cfg(cp, 'kafka', 'topic',             'KAFKA_TOPIC',             'cert-analyzer-events')
     kafka_access_enabled   = cfg(cp, 'kafka', 'access_enabled',    'KAFKA_ACCESS_ENABLED',    'false').lower() == 'true'
     kafka_access_topic     = cfg(cp, 'kafka', 'access_topic',      'KAFKA_ACCESS_TOPIC',      'cert-analyzer-access-events')
+    kafka_connect_enabled  = cfg(cp, 'kafka', 'connect_enabled',   'KAFKA_CONNECT_ENABLED',   'false').lower() == 'true'
+    kafka_connect_topic    = cfg(cp, 'kafka', 'connect_topic',     'KAFKA_CONNECT_TOPIC',     'cert-analyzer-events-connect')
     kafka_security         = cfg(cp, 'kafka', 'security_protocol', 'KAFKA_SECURITY_PROTOCOL', 'PLAINTEXT')
     kafka_sasl_mechanism   = cfg(cp, 'kafka', 'sasl_mechanism',    'KAFKA_SASL_MECHANISM',    '')
     kafka_sasl_username    = cfg(cp, 'kafka', 'sasl_username',     'KAFKA_SASL_USERNAME',     '')
@@ -274,6 +276,7 @@ def main():
         logger.info(f"Kafka brokers:     {kafka_bootstrap}")
         logger.info(f"Kafka topic:       {kafka_topic}")
         logger.info(f"Kafka access events: {'enabled — topic: ' + kafka_access_topic if kafka_access_enabled else 'disabled'}")
+        logger.info(f"Kafka Connect envelope: {'enabled — topic: ' + kafka_connect_topic if kafka_connect_enabled else 'disabled'}")
         logger.info(f"Kafka security:    {kafka_security}")
     logger.info(f"Event rate metrics: {'enabled' if event_rate_metrics_enabled else 'disabled'}")
     logger.info(f"Bind probe:        {'enabled' if bind_probe_enabled else 'disabled'}")
@@ -303,6 +306,7 @@ def main():
             bootstrap_servers=kafka_bootstrap,
             topic=kafka_topic,
             access_topic=kafka_access_topic if kafka_access_enabled else '',
+            connect_topic=kafka_connect_topic if kafka_connect_enabled else '',
             security_protocol=kafka_security,
             sasl_mechanism=kafka_sasl_mechanism,
             sasl_username=kafka_sasl_username,

--- a/agent/config.py
+++ b/agent/config.py
@@ -241,6 +241,8 @@ def main():
     kafka_access_topic     = cfg(cp, 'kafka', 'access_topic',      'KAFKA_ACCESS_TOPIC',      'cert-analyzer-access-events')
     kafka_connect_enabled  = cfg(cp, 'kafka', 'connect_enabled',   'KAFKA_CONNECT_ENABLED',   'false').lower() == 'true'
     kafka_connect_topic    = cfg(cp, 'kafka', 'connect_topic',     'KAFKA_CONNECT_TOPIC',     'cert-analyzer-events-connect')
+    kafka_access_connect_enabled = cfg(cp, 'kafka', 'access_connect_enabled', 'KAFKA_ACCESS_CONNECT_ENABLED', 'false').lower() == 'true'
+    kafka_access_connect_topic   = cfg(cp, 'kafka', 'access_connect_topic',   'KAFKA_ACCESS_CONNECT_TOPIC',   'cert-analyzer-access-events-connect')
     kafka_security         = cfg(cp, 'kafka', 'security_protocol', 'KAFKA_SECURITY_PROTOCOL', 'PLAINTEXT')
     kafka_sasl_mechanism   = cfg(cp, 'kafka', 'sasl_mechanism',    'KAFKA_SASL_MECHANISM',    '')
     kafka_sasl_username    = cfg(cp, 'kafka', 'sasl_username',     'KAFKA_SASL_USERNAME',     '')
@@ -278,6 +280,7 @@ def main():
         logger.info(f"Kafka topic:       {kafka_topic} ({'enabled' if kafka_plain_enabled else 'disabled'})")
         logger.info(f"Kafka access events: {'enabled — topic: ' + kafka_access_topic if kafka_access_enabled else 'disabled'}")
         logger.info(f"Kafka Connect envelope: {'enabled — topic: ' + kafka_connect_topic if kafka_connect_enabled else 'disabled'}")
+        logger.info(f"Kafka access Connect envelope: {'enabled — topic: ' + kafka_access_connect_topic if kafka_access_connect_enabled else 'disabled'}")
         logger.info(f"Kafka security:    {kafka_security}")
     logger.info(f"Event rate metrics: {'enabled' if event_rate_metrics_enabled else 'disabled'}")
     logger.info(f"Bind probe:        {'enabled' if bind_probe_enabled else 'disabled'}")
@@ -309,6 +312,7 @@ def main():
             plain_enabled=kafka_plain_enabled,
             access_topic=kafka_access_topic if kafka_access_enabled else '',
             connect_topic=kafka_connect_topic if kafka_connect_enabled else '',
+            access_connect_topic=kafka_access_connect_topic if kafka_access_connect_enabled else '',
             security_protocol=kafka_security,
             sasl_mechanism=kafka_sasl_mechanism,
             sasl_username=kafka_sasl_username,

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -125,34 +125,75 @@ _CONNECT_SCHEMA_FIELDS = [
 ]
 
 
-def _build_connect_schema() -> dict:
+# Static field -> (Kafka Connect JSON Schema type, optional) map for the
+# certificate_accessed message, used to build the Connect envelope published
+# to [kafka] access_connect_topic when access_connect_enabled=true. Same
+# hand-maintained, built-once rationale as _CONNECT_SCHEMA_FIELDS above --
+# keep in sync with the message dict built in publish_access(). No nested/
+# dict fields here, unlike the discovery message (no pod_annotations
+# equivalent), so no per-field transform is needed when wrapping.
+_ACCESS_CONNECT_SCHEMA_FIELDS = [
+    ('schema_version',   'int32',  False),
+    ('event_type',       'string', False),
+    ('accessed_at',      'string', False),
+    ('cert_unique_key',  'string', False),
+    ('path',              'string', False),
+    ('cert_index',        'int32',  False),
+    ('serial_number',     'string', False),
+    ('process',           'string', False),
+    ('pid',                'int32',  False),
+    ('parent_process',     'string', False),
+    ('parent_pid',         'int32',  False),
+    ('namespace',          'string', False),
+    ('pod_name',           'string', False),
+    ('pod_uid',            'string', False),
+    ('node_name',          'string', False),
+    ('app_label',          'string', False),
+    ('container_name',     'string', False),
+    ('container_id',       'string', False),
+    ('container_image',    'string', False),
+]
+
+
+def _build_struct_schema(name: str, schema_fields: list) -> dict:
     """
-    Build the Kafka Connect JSON Schema "schema" struct for the
-    certificate_discovered Connect envelope, from _CONNECT_SCHEMA_FIELDS.
-    Called once per KafkaPublisher instance (when connect_enabled) and
-    cached -- never rebuilt per message.
+    Build a Kafka Connect JSON Schema "schema" struct from a
+    (field_name, connect_type, optional) list -- shared by
+    _build_connect_schema() and _build_access_connect_schema(). Called once
+    per KafkaPublisher instance (per envelope, when its *_connect_enabled
+    flag is set) and cached -- never rebuilt per message.
     """
     fields = []
-    for name, connect_type, optional in _CONNECT_SCHEMA_FIELDS:
+    for field_name, connect_type, optional in schema_fields:
         if connect_type == 'array_string':
             fields.append({
-                'field': name,
+                'field': field_name,
                 'type': 'array',
                 'items': {'type': 'string', 'optional': False},
                 'optional': optional,
             })
         else:
             fields.append({
-                'field': name,
+                'field': field_name,
                 'type': connect_type,
                 'optional': optional,
             })
     return {
         'type': 'struct',
-        'name': 'io.certanalyzer.CertificateDiscovered',
+        'name': name,
         'optional': False,
         'fields': fields,
     }
+
+
+def _build_connect_schema() -> dict:
+    """Connect envelope schema for certificate_discovered (connect_topic)."""
+    return _build_struct_schema('io.certanalyzer.CertificateDiscovered', _CONNECT_SCHEMA_FIELDS)
+
+
+def _build_access_connect_schema() -> dict:
+    """Connect envelope schema for certificate_accessed (access_connect_topic)."""
+    return _build_struct_schema('io.certanalyzer.CertificateAccessed', _ACCESS_CONNECT_SCHEMA_FIELDS)
 
 
 class KafkaPublisher:
@@ -247,6 +288,17 @@ class KafkaPublisher:
     connect_topic, without ever running mutually-exclusive-only -- plain-only,
     both (a migration window), and connect-only are all just combinations of
     plain_enabled/connect_enabled, not a single mode switch.
+
+    certificate_accessed has the same optional Connect envelope, independently
+    gated by access_connect_enabled/access_connect_topic -- NOT tied to
+    access_enabled, same reasoning as plain_enabled/connect_enabled above (you
+    can run the Connect-envelope access stream without the plain one, or vice
+    versa). Keyed on node_name:path:cert_index:<accessor identity>, not just
+    cert identity -- the whole point of certificate_accessed is capturing
+    multiple distinct accessors per cert, so the upsert key must include the
+    accessor or every accessor but the last-published would silently collapse
+    into one row. See _ACCESS_CONNECT_SCHEMA_FIELDS and
+    extras/kafka/INTEGRATION-BRIEF.md.
     """
 
     def __init__(
@@ -255,6 +307,7 @@ class KafkaPublisher:
         topic: str,
         access_topic: str = '',
         connect_topic: str = '',
+        access_connect_topic: str = '',
         plain_enabled: bool = True,
         security_protocol: str = 'PLAINTEXT',
         sasl_mechanism: str = '',
@@ -276,6 +329,11 @@ class KafkaPublisher:
         # no need for a second KafkaProducer/TCP connection per topic.
         self._access_topic = access_topic
         self.access_enabled = bool(access_topic)
+        # Same empty-string-means-disabled convention, and deliberately
+        # independent of access_enabled above -- see class docstring.
+        self._access_connect_topic = access_connect_topic
+        self.access_connect_enabled = bool(access_connect_topic)
+        self._access_connect_schema = _build_access_connect_schema() if self.access_connect_enabled else None
         # Same empty-string-means-disabled convention as access_topic above.
         # Schema is built once here (not per message) since it's static --
         # see _build_connect_schema().
@@ -382,6 +440,8 @@ class KafkaPublisher:
                 label_topic = f"{label_topic}, {self._access_topic}" if label_topic else self._access_topic
             if self._connect_topic:
                 label_topic = f"{label_topic}, {self._connect_topic}" if label_topic else self._connect_topic
+            if self._access_connect_topic:
+                label_topic = f"{label_topic}, {self._access_connect_topic}" if label_topic else self._access_connect_topic
             logger.info(
                 f"Kafka producer connected — "
                 f"brokers: {label}, topics: {label_topic}"
@@ -496,8 +556,10 @@ class KafkaPublisher:
         Publish a certificate_accessed event for a distinct process/pod
         re-accessing an already-known certificate.
 
-        No-op unless access_topic was configured (access_enabled is False by
-        default — see [kafka] access_enabled in cert-analyzer.conf). Callers
+        No-op unless access_enabled and/or access_connect_enabled is set (both
+        default False — see [kafka] access_enabled/access_connect_enabled in
+        cert-analyzer.conf); each independently gates its own topic, same as
+        plain_enabled/connect_enabled do for certificate_discovered. Callers
         are expected to have already deduplicated per (process, parent_process,
         pod_name, namespace, app_label, container_name) — see
         CertificateAnalyzer._record_cert_process_access — so this fires once
@@ -530,7 +592,7 @@ class KafkaPublisher:
             "container_image": "my-app:1.0"
         }
         """
-        if not KAFKA_AVAILABLE or not self.access_enabled:
+        if not KAFKA_AVAILABLE or not (self.access_enabled or self.access_connect_enabled):
             return
 
         message = {
@@ -555,18 +617,43 @@ class KafkaPublisher:
             'container_image':  container_image,
         }
 
-        self._send(self._access_topic, cert_info.unique_key, message, cert_info.path)
+        if self.access_enabled:
+            self._send(self._access_topic, cert_info.unique_key, message, cert_info.path)
+
+        if self.access_connect_enabled:
+            envelope = self._wrap_connect_envelope(self._access_connect_schema, message)
+            # node_name:path:cert_index:<accessor identity> -- unlike the
+            # discovery-connect key, cert identity alone isn't enough here:
+            # the whole point of certificate_accessed is capturing multiple
+            # distinct accessors per cert, so the accessor fields must be
+            # part of the key or every accessor but the last-published would
+            # silently collapse into one row on upsert. See class docstring
+            # and extras/kafka/INTEGRATION-BRIEF.md.
+            connect_key = (
+                f"{node_name}:{cert_info.path}:{cert_info.cert_index}:"
+                f"{process}:{parent_process}:{pod_name}:{namespace}:{app_label}:{container_name}"
+            )
+            self._send(self._access_connect_topic, connect_key, envelope, cert_info.path)
+
+    def _wrap_connect_envelope(self, schema: dict, message: dict) -> dict:
+        """
+        Generic {"schema": ..., "payload": dict(message)} wrap, shared by the
+        certificate_discovered and certificate_accessed Connect envelopes.
+        Returns a new dict -- never mutates `message`, which the caller also
+        sends unwrapped to its plain-JSON topic.
+        """
+        return {'schema': schema, 'payload': dict(message)}
 
     def _to_connect_envelope(self, message: dict) -> dict:
         """
         Wrap a certificate_discovered message dict in the Kafka Connect JSON
-        envelope ({"schema": self._connect_schema, "payload": ...}). Returns
-        a new dict -- never mutates `message`, which the caller also sends
-        unwrapped to the plain-JSON topic.
+        envelope ({"schema": self._connect_schema, "payload": ...}).
+        certificate_accessed has no equivalent per-field transform needed
+        (no nested/dict fields), so it calls _wrap_connect_envelope directly.
         """
-        payload = dict(message)
-        payload['pod_annotations'] = json.dumps(payload.get('pod_annotations') or {})
-        return {'schema': self._connect_schema, 'payload': payload}
+        envelope = self._wrap_connect_envelope(self._connect_schema, message)
+        envelope['payload']['pod_annotations'] = json.dumps(envelope['payload'].get('pod_annotations') or {})
+        return envelope
 
     def _send(self, topic: str, key: str, message: dict, log_label: str) -> None:
         """

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -240,6 +240,13 @@ class KafkaPublisher:
     and extras/kafka/CONSUMER-README.md for the envelope's field types and
     the Kafka-message-key convention (node_name:path:cert_index, chosen for
     upsert correctness -- see extras/kafka/INTEGRATION-BRIEF.md).
+
+    plain_enabled (default true) independently gates publishing the plain-JSON
+    message to `topic`. It exists so a fleet can eventually turn the raw topic
+    off (plain_enabled=false) once every consumer has migrated to
+    connect_topic, without ever running mutually-exclusive-only -- plain-only,
+    both (a migration window), and connect-only are all just combinations of
+    plain_enabled/connect_enabled, not a single mode switch.
     """
 
     def __init__(
@@ -248,6 +255,7 @@ class KafkaPublisher:
         topic: str,
         access_topic: str = '',
         connect_topic: str = '',
+        plain_enabled: bool = True,
         security_protocol: str = 'PLAINTEXT',
         sasl_mechanism: str = '',
         sasl_username: str = '',
@@ -255,6 +263,14 @@ class KafkaPublisher:
     ):
         self.bootstrap_servers = bootstrap_servers
         self._topic = topic
+        # Defaults true (unchanged behavior) -- set false to stop publishing
+        # certificate_discovered to the plain-JSON topic, e.g. once every
+        # consumer has migrated to connect_topic below. Unlike access_topic/
+        # connect_topic, `topic` has no natural "empty means disabled" signal
+        # (it's a required constructor arg with a real default in config), so
+        # this needs its own explicit flag rather than the empty-string
+        # convention used below.
+        self.plain_enabled = plain_enabled
         # Empty string means certificate_accessed publishing is disabled --
         # see access_enabled below. One producer serves both topics; there's
         # no need for a second KafkaProducer/TCP connection per topic.
@@ -361,11 +377,11 @@ class KafkaPublisher:
                 return False
 
             label = bootstrap_servers or str(self._producer_kwargs.get('bootstrap_servers', ''))
-            label_topic = topic or self._topic
+            label_topic = (topic or self._topic) if self.plain_enabled else ''
             if self._access_topic:
-                label_topic = f"{label_topic}, {self._access_topic}"
+                label_topic = f"{label_topic}, {self._access_topic}" if label_topic else self._access_topic
             if self._connect_topic:
-                label_topic = f"{label_topic}, {self._connect_topic}"
+                label_topic = f"{label_topic}, {self._connect_topic}" if label_topic else self._connect_topic
             logger.info(
                 f"Kafka producer connected — "
                 f"brokers: {label}, topics: {label_topic}"
@@ -441,7 +457,8 @@ class KafkaPublisher:
         }
 
         # Use unique_key (path:cert_index:serial) as the partition key.
-        self._send(self._topic, cert_info.unique_key, message, cert_info.path)
+        if self.plain_enabled:
+            self._send(self._topic, cert_info.unique_key, message, cert_info.path)
 
         if self.connect_enabled:
             envelope = self._to_connect_envelope(message)

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -49,6 +49,111 @@ _kafka_last_published_timestamp = Gauge(
 # or not the payload shape changed; consumers should gate on this instead.
 KAFKA_SCHEMA_VERSION = 1
 
+# Static field -> (Kafka Connect JSON Schema type, optional) map for the
+# certificate_discovered message, used to build the Connect envelope
+# ({"schema": ..., "payload": ...}) published to [kafka] connect_topic when
+# connect_enabled=true. Deliberately hand-maintained and built once (not
+# inferred per-message from a live dict): several fields below are legitimately
+# None on some messages (container_pid, container_start_time, key_usage,
+# extended_key_usage, is_ca, basic_constraints_path_length), and a None value
+# carries no type information to infer from. Kafka Connect's JSON converter
+# also expects every record's "schema" to be structurally identical on a
+# topic, so a schema built fresh per message would be actively wrong, not
+# just wasteful. 'array_string' is a local sentinel expanded by
+# _build_connect_schema() into a Connect "array" of "string" -- not a real
+# Connect type name. Keep in sync with the message dict built in publish().
+#
+# A breaking change to this field set (rename/remove/retype) must ship as a
+# new [kafka] connect_topic value (e.g. cert-analyzer-events-connect-v2), not
+# an in-place change -- Kafka Connect sink connectors don't tolerate schema
+# drift on a topic the way KAFKA_SCHEMA_VERSION lets plain-JSON consumers
+# tolerate new fields. See extras/kafka/CONSUMER-README.md.
+_CONNECT_SCHEMA_FIELDS = [
+    ('schema_version',    'int32',  False),
+    ('event_type',        'string', False),
+    ('detected_at',       'string', False),
+    ('path',               'string', False),
+    ('cert_index',         'int32',  False),
+    ('subject',             'string', False),
+    ('issuer',              'string', False),
+    ('serial_number',       'string', False),
+    ('common_name',         'string', False),
+    ('san_dns_names',       'array_string', False),
+    ('san_ip_addresses',    'array_string', False),
+    ('not_before',          'string', False),
+    ('not_after',           'string', False),
+    ('days_until_expiry',   'float64', False),
+    ('is_expired',          'boolean', False),
+    ('process',             'string', False),
+    ('pid',                 'int32',  False),
+    ('parent_process',      'string', False),
+    ('parent_pid',          'int32',  False),
+    ('namespace',                  'string', False),
+    ('pod_name',                   'string', False),
+    ('pod_uid',                    'string', False),
+    ('node_name',                  'string', False),
+    # JSON-encoded string in the Connect envelope -- Connect's JSON schema has
+    # no map type a stock JDBC sink can flatten into columns without a custom
+    # SMT. Decode client-side. See extras/kafka/CONSUMER-README.md.
+    ('pod_annotations',            'string', False),
+    ('workload_kind',              'string', False),
+    ('workload_name',              'string', False),
+    ('app_label',                  'string', False),
+    ('container_id',               'string', False),
+    ('container_name',             'string', False),
+    ('container_image',            'string', False),
+    ('container_image_id',         'string', False),
+    ('container_privileged',       'boolean', False),
+    ('container_pid',              'int32',  True),
+    ('container_start_time',       'string', True),
+    ('container_maybe_exec_probe', 'boolean', False),
+    ('checksum',          'string', False),
+    ('spki_hash',         'string', False),
+    ('key_algorithm',     'string', False),
+    ('key_size',          'int32',  False),
+    ('signature_hash',    'string', False),
+    ('curve_name',        'string', False),
+    ('fips_compliant',    'boolean', False),
+    ('fips_violations',   'array_string', False),
+    ('spki_algorithm_oid',      'string', False),
+    ('signature_algorithm_oid', 'string', False),
+    ('key_usage',                     'array_string', True),
+    ('extended_key_usage',            'array_string', True),
+    ('is_ca',                         'boolean', True),
+    ('basic_constraints_path_length', 'int32',  True),
+    ('is_self_signed',                'boolean', False),
+]
+
+
+def _build_connect_schema() -> dict:
+    """
+    Build the Kafka Connect JSON Schema "schema" struct for the
+    certificate_discovered Connect envelope, from _CONNECT_SCHEMA_FIELDS.
+    Called once per KafkaPublisher instance (when connect_enabled) and
+    cached -- never rebuilt per message.
+    """
+    fields = []
+    for name, connect_type, optional in _CONNECT_SCHEMA_FIELDS:
+        if connect_type == 'array_string':
+            fields.append({
+                'field': name,
+                'type': 'array',
+                'items': {'type': 'string', 'optional': False},
+                'optional': optional,
+            })
+        else:
+            fields.append({
+                'field': name,
+                'type': connect_type,
+                'optional': optional,
+            })
+    return {
+        'type': 'struct',
+        'name': 'io.certanalyzer.CertificateDiscovered',
+        'optional': False,
+        'fields': fields,
+    }
+
 
 class KafkaPublisher:
     """
@@ -124,6 +229,17 @@ class KafkaPublisher:
         "basic_constraints_path_length": null,
         "is_self_signed":                false
     }
+
+    Optionally, when connect_enabled=true, every certificate_discovered event
+    above is additionally published to connect_topic wrapped in a Kafka
+    Connect JSON envelope ({"schema": {...}, "payload": {...}}, the shape
+    org.apache.kafka.connect.json.JsonConverter with schemas.enable=true
+    expects) so a stock Kafka Connect JDBC Sink connector can consume it with
+    no custom code. Off by default; purely additive -- the plain-JSON message
+    above and its topic are unaffected either way. See _CONNECT_SCHEMA_FIELDS
+    and extras/kafka/CONSUMER-README.md for the envelope's field types and
+    the Kafka-message-key convention (node_name:path:cert_index, chosen for
+    upsert correctness -- see extras/kafka/INTEGRATION-BRIEF.md).
     """
 
     def __init__(
@@ -131,6 +247,7 @@ class KafkaPublisher:
         bootstrap_servers: str,
         topic: str,
         access_topic: str = '',
+        connect_topic: str = '',
         security_protocol: str = 'PLAINTEXT',
         sasl_mechanism: str = '',
         sasl_username: str = '',
@@ -143,6 +260,12 @@ class KafkaPublisher:
         # no need for a second KafkaProducer/TCP connection per topic.
         self._access_topic = access_topic
         self.access_enabled = bool(access_topic)
+        # Same empty-string-means-disabled convention as access_topic above.
+        # Schema is built once here (not per message) since it's static --
+        # see _build_connect_schema().
+        self._connect_topic = connect_topic
+        self.connect_enabled = bool(connect_topic)
+        self._connect_schema = _build_connect_schema() if self.connect_enabled else None
         self._producer: Optional['KafkaProducer'] = None
         self._producer_kwargs: dict = {}
         self._last_connect_attempt: float = 0.0
@@ -241,6 +364,8 @@ class KafkaPublisher:
             label_topic = topic or self._topic
             if self._access_topic:
                 label_topic = f"{label_topic}, {self._access_topic}"
+            if self._connect_topic:
+                label_topic = f"{label_topic}, {self._connect_topic}"
             logger.info(
                 f"Kafka producer connected — "
                 f"brokers: {label}, topics: {label_topic}"
@@ -317,6 +442,22 @@ class KafkaPublisher:
 
         # Use unique_key (path:cert_index:serial) as the partition key.
         self._send(self._topic, cert_info.unique_key, message, cert_info.path)
+
+        if self.connect_enabled:
+            envelope = self._to_connect_envelope(message)
+            # node_name:path:cert_index, NOT unique_key -- this key drives an
+            # upsert on the consumer side (typically a JDBC sink's
+            # pk.mode=record_key), so it must uniquely identify "one row",
+            # not just group related events. unique_key includes serial_number,
+            # which would make every renewal a new row instead of updating the
+            # existing one -- the opposite of what an expiry table wants. And
+            # path:cert_index alone (the brief's own recommended *grouping*
+            # key for this use case) would collide across every node running
+            # an identical cert at the same path, silently collapsing a
+            # fleet's worth of rows down to whichever node's event landed
+            # last. See extras/kafka/INTEGRATION-BRIEF.md.
+            connect_key = f"{cert_info.node_name}:{cert_info.path}:{cert_info.cert_index}"
+            self._send(self._connect_topic, connect_key, envelope, cert_info.path)
 
     def publish_access(
         self,
@@ -398,6 +539,17 @@ class KafkaPublisher:
         }
 
         self._send(self._access_topic, cert_info.unique_key, message, cert_info.path)
+
+    def _to_connect_envelope(self, message: dict) -> dict:
+        """
+        Wrap a certificate_discovered message dict in the Kafka Connect JSON
+        envelope ({"schema": self._connect_schema, "payload": ...}). Returns
+        a new dict -- never mutates `message`, which the caller also sends
+        unwrapped to the plain-JSON topic.
+        """
+        payload = dict(message)
+        payload['pod_annotations'] = json.dumps(payload.get('pod_annotations') or {})
+        return {'schema': self._connect_schema, 'payload': payload}
 
     def _send(self, topic: str, key: str, message: dict, log_label: str) -> None:
         """

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -221,6 +221,17 @@ connect_enabled = false
 # Topic to publish the Kafka-Connect-enveloped certificate_discovered events to
 connect_topic = cert-analyzer-events-connect
 
+# Set access_connect_enabled = true to additionally publish each certificate_accessed
+# event wrapped in a Kafka-Connect-compatible JSON envelope
+# ({"schema": {...}, "payload": {...}}) to access_connect_topic, suitable for a
+# stock Kafka Connect JDBC Sink connector to consume with no custom code.
+# Independently gated from `access_enabled` above (and from `enabled`/
+# `connect_enabled`); off by default.
+access_connect_enabled = false
+
+# Topic to publish the Kafka-Connect-enveloped certificate_accessed events to
+access_connect_topic = cert-analyzer-access-events-connect
+
 # Security protocol: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 security_protocol = PLAINTEXT
 

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -195,6 +195,12 @@ bootstrap_servers = localhost:9092
 # Topic to publish certificate discovery events to
 topic = cert-analyzer-events
 
+# Set plain_enabled = false to stop publishing certificate_discovered events
+# to the plain-JSON topic above — e.g. once every consumer has migrated to
+# connect_topic below. Defaults to true (unchanged behavior); independent of
+# access_enabled/connect_enabled.
+plain_enabled = true
+
 # Set access_enabled = true to additionally publish certificate_accessed
 # events — one per distinct process/pod that re-accesses an already-known
 # certificate (capped by [certificates] max_processes_per_cert). Independently

--- a/cert-analyzer.conf
+++ b/cert-analyzer.conf
@@ -205,6 +205,16 @@ access_enabled = false
 # Topic to publish certificate_accessed events to
 access_topic = cert-analyzer-access-events
 
+# Set connect_enabled = true to additionally publish each certificate_discovered
+# event wrapped in a Kafka-Connect-compatible JSON envelope
+# ({"schema": {...}, "payload": {...}}) to connect_topic, suitable for a stock
+# Kafka Connect JDBC Sink connector to consume with no custom code.
+# Independently gated from `enabled`/`access_enabled` above; off by default.
+connect_enabled = false
+
+# Topic to publish the Kafka-Connect-enveloped certificate_discovered events to
+connect_topic = cert-analyzer-events-connect
+
 # Security protocol: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 security_protocol = PLAINTEXT
 

--- a/cert-analyzer.spec
+++ b/cert-analyzer.spec
@@ -282,6 +282,29 @@ if [ -f "$_CONF" ] && grep -q '^large_file_cert_threshold[ \t]*=' "$_CONF" 2>/de
     && chmod 0640 "$_CONF" \
     || echo "WARNING: failed to insert large_file_metrics_cap into $_CONF" >&2
 fi
+# Hosts upgraded from a release predating [kafka] plain_enabled: insert it
+# right after topic (which every prior release with [kafka] has). Same
+# end-of-file-append hazard as the large_file_metrics_cap case above.
+if [ -f "$_CONF" ] && grep -q '^topic[ \t]*=' "$_CONF" 2>/dev/null \
+        && ! grep -q '^plain_enabled[ \t]*=' "$_CONF" 2>/dev/null; then
+    awk '
+    /^topic[ \t]*=/ {
+        print
+        print ""
+        print "# Set plain_enabled = false to stop publishing certificate_discovered events"
+        print "# to the plain-JSON topic above -- e.g. once every consumer has migrated to"
+        print "# connect_topic below. Defaults to true (unchanged behavior); independent of"
+        print "# access_enabled/connect_enabled."
+        print "plain_enabled = true"
+        next
+    }
+    { print }
+    ' "$_CONF" > "$_CONF.new" \
+    && mv "$_CONF.new" "$_CONF" \
+    && chown root:%{ana_group} "$_CONF" \
+    && chmod 0640 "$_CONF" \
+    || echo "WARNING: failed to insert plain_enabled into $_CONF" >&2
+fi
 # Hosts upgraded from a release predating [kafka] connect_enabled: insert it
 # right after access_topic (which every prior release with [kafka] has).
 # Plain end-of-file append would land it after whatever section happens to be

--- a/cert-analyzer.spec
+++ b/cert-analyzer.spec
@@ -282,6 +282,35 @@ if [ -f "$_CONF" ] && grep -q '^large_file_cert_threshold[ \t]*=' "$_CONF" 2>/de
     && chmod 0640 "$_CONF" \
     || echo "WARNING: failed to insert large_file_metrics_cap into $_CONF" >&2
 fi
+# Hosts upgraded from a release predating [kafka] connect_enabled: insert it
+# right after access_topic (which every prior release with [kafka] has).
+# Plain end-of-file append would land it after whatever section happens to be
+# last in the operator's file instead of under [kafka] -- same reasoning as
+# the large_file_metrics_cap case above.
+if [ -f "$_CONF" ] && grep -q '^access_topic[ \t]*=' "$_CONF" 2>/dev/null \
+        && ! grep -q '^connect_enabled[ \t]*=' "$_CONF" 2>/dev/null; then
+    awk '
+    /^access_topic[ \t]*=/ {
+        print
+        print ""
+        print "# Set connect_enabled = true to additionally publish each certificate_discovered"
+        print "# event wrapped in a Kafka-Connect-compatible JSON envelope"
+        print "# ({\"schema\": {...}, \"payload\": {...}}) to connect_topic, suitable for a stock"
+        print "# Kafka Connect JDBC Sink connector to consume with no custom code."
+        print "# Independently gated from `enabled`/`access_enabled` above; off by default."
+        print "connect_enabled = false"
+        print ""
+        print "# Topic to publish the Kafka-Connect-enveloped certificate_discovered events to"
+        print "connect_topic = cert-analyzer-events-connect"
+        next
+    }
+    { print }
+    ' "$_CONF" > "$_CONF.new" \
+    && mv "$_CONF.new" "$_CONF" \
+    && chown root:%{ana_group} "$_CONF" \
+    && chmod 0640 "$_CONF" \
+    || echo "WARNING: failed to insert connect_enabled/connect_topic into $_CONF" >&2
+fi
 unset _CONF
 
 # Reload systemd to pick up the Tetragon drop-in

--- a/cert-analyzer.spec
+++ b/cert-analyzer.spec
@@ -334,6 +334,36 @@ if [ -f "$_CONF" ] && grep -q '^access_topic[ \t]*=' "$_CONF" 2>/dev/null \
     && chmod 0640 "$_CONF" \
     || echo "WARNING: failed to insert connect_enabled/connect_topic into $_CONF" >&2
 fi
+# Hosts upgraded from a release predating [kafka] access_connect_enabled:
+# insert it right after connect_topic (present on every host by this point --
+# either from a prior release, or just inserted by the block above on this
+# same upgrade). Same end-of-file-append hazard as the large_file_metrics_cap
+# case above.
+if [ -f "$_CONF" ] && grep -q '^connect_topic[ \t]*=' "$_CONF" 2>/dev/null \
+        && ! grep -q '^access_connect_enabled[ \t]*=' "$_CONF" 2>/dev/null; then
+    awk '
+    /^connect_topic[ \t]*=/ {
+        print
+        print ""
+        print "# Set access_connect_enabled = true to additionally publish each certificate_accessed"
+        print "# event wrapped in a Kafka-Connect-compatible JSON envelope"
+        print "# ({\"schema\": {...}, \"payload\": {...}}) to access_connect_topic, suitable for a"
+        print "# stock Kafka Connect JDBC Sink connector to consume with no custom code."
+        print "# Independently gated from `access_enabled` above (and from `enabled`/"
+        print "# `connect_enabled`); off by default."
+        print "access_connect_enabled = false"
+        print ""
+        print "# Topic to publish the Kafka-Connect-enveloped certificate_accessed events to"
+        print "access_connect_topic = cert-analyzer-access-events-connect"
+        next
+    }
+    { print }
+    ' "$_CONF" > "$_CONF.new" \
+    && mv "$_CONF.new" "$_CONF" \
+    && chown root:%{ana_group} "$_CONF" \
+    && chmod 0640 "$_CONF" \
+    || echo "WARNING: failed to insert access_connect_enabled/access_connect_topic into $_CONF" >&2
+fi
 unset _CONF
 
 # Reload systemd to pick up the Tetragon drop-in

--- a/extras/FIELDS-README.md
+++ b/extras/FIELDS-README.md
@@ -5,7 +5,10 @@ The cert-analyzer surfaces certificate data through two independent channels:
 **Kafka event streams** — `certificate_discovered` (one message per
 newly-discovered certificate) and `certificate_accessed` (one message per
 distinct process/pod that subsequently re-accesses an already-known
-certificate).
+certificate). Each stream can also, independently and optionally, be
+additionally published wrapped in a [Kafka Connect JSON
+envelope](#kafka-connect-envelope-optional) to its own topic, for
+consumption by a stock Kafka Connect JDBC Sink connector.
 
 This document is a reference for engineers writing dashboards, alert rules,
 or consuming either Kafka topic.
@@ -160,6 +163,10 @@ Prometheus handles ongoing state; Kafka handles the stream of new discoveries.
 
 The partition key is `path:cert_index:serial_number` — stable across restarts,
 unique per certificate, and rotated when the cert at a path changes.
+
+This is the plain-JSON topic. There's also an optional [Kafka Connect
+envelope](#kafka-connect-envelope-optional) variant of this same event,
+carrying the same fields shown below.
 
 ```json
 {
@@ -361,6 +368,10 @@ consumers should join the two streams on `cert_unique_key` (equivalent to
 The partition key is the same `cert_unique_key`, so all accesses for a given
 certificate land on the same partition.
 
+This is the plain-JSON topic. There's also an optional [Kafka Connect
+envelope](#kafka-connect-envelope-optional) variant of this same event,
+carrying the same fields shown below.
+
 ```json
 {
   "schema_version":   1,
@@ -416,3 +427,90 @@ certificate land on the same partition.
 > can differ from the pod/container fields on the certificate's own
 > `certificate_discovered` event, which stay sticky to whichever pod first
 > discovered the certificate.
+
+---
+
+## Kafka Connect envelope (optional)
+
+Both event streams above have an optional second output: the same event,
+wrapped in a Kafka Connect JSON envelope
+(`{"schema": {...}, "payload": {...}}`, the shape
+`org.apache.kafka.connect.json.JsonConverter` with `schemas.enable=true`
+expects), published to its own dedicated topic. This exists so a stock
+Kafka Connect JDBC Sink connector (Confluent's, or Aiven's open-source fork)
+can consume it directly — no custom consumer code, `auto.create`/
+`auto.evolve` build the DB table from the schema, `insert.mode=upsert`
+handles the write.
+
+Off by default, purely additive — enabling either envelope changes nothing
+about the plain-JSON topics documented above.
+
+| Event | Plain topic | Envelope topic | Config keys |
+|---|---|---|---|
+| `certificate_discovered` | `cert-analyzer-events` | `cert-analyzer-events-connect` | `connect_enabled` / `connect_topic` |
+| `certificate_accessed` | `cert-analyzer-access-events` | `cert-analyzer-access-events-connect` | `access_connect_enabled` / `access_connect_topic` |
+
+Each envelope flag is independently gated from its plain-topic counterpart
+(`connect_enabled` from `plain_enabled`; `access_connect_enabled` from
+`access_enabled`) — any combination of plain-only, both, or envelope-only is
+valid config, not a single mode switch.
+
+### Payload
+
+`payload` carries the **same fields** documented in the field reference
+tables above, for the matching event type — nothing added or removed,
+except:
+
+- `pod_annotations` (`certificate_discovered` only) is **JSON-encoded as a
+  string**, not a nested object as shown in the plain-topic example above —
+  Kafka Connect's JSON schema has no map type a stock JDBC sink can flatten
+  into columns without a custom SMT. Decode it client-side.
+
+`schema` declares each payload field's Kafka Connect type, built once per
+`KafkaPublisher` and identical on every message (not re-derived per event —
+Connect's JSON converter expects a structurally identical schema on every
+message on a topic). Types map from the field reference tables above as:
+`int` → `int32`, `float` → `float64`, `bool` → `boolean`, `string`/ISO 8601
+timestamp → `string` (timestamps are plain text, not a native Connect
+timestamp logical type), and a `string[]` list → a Connect `array` of
+`string`.
+
+### Message key
+
+Unlike the plain topics (keyed on cert identity alone, so same-partition
+in-order delivery between a `certificate_discovered` event and its
+`certificate_accessed` events — see
+[INTEGRATION-BRIEF.md](kafka/INTEGRATION-BRIEF.md)), the envelope
+topics are keyed for **upsert correctness** on the JDBC sink side
+(`pk.mode=record_key`, no `pk.fields` needed — the whole key is one opaque
+string):
+
+| Envelope topic | Key |
+|---|---|
+| `cert-analyzer-events-connect` | `node_name:path:cert_index` |
+| `cert-analyzer-access-events-connect` | `node_name:path:cert_index:process:parent_process:pod_name:namespace:app_label:container_name` |
+
+The access-connect key includes the accessor fields, not just cert
+identity, because the whole point of `certificate_accessed` is capturing
+every distinct accessor of a cert — keying on cert identity alone would
+collapse every accessor down to whichever one published last. See
+[extras/kafka/INTEGRATION-BRIEF.md](kafka/INTEGRATION-BRIEF.md#kafka-connect--jdbc-sink-publishing)
+for the full key-design rationale (including why this deliberately
+diverges from `path:cert_index`, the key recommended for consumer-side
+*grouping* elsewhere in that document).
+
+### Schema evolution
+
+A Connect schema is rigid by construction — every message on a topic must
+match the declared `"schema"` exactly, unlike `schema_version` above, which
+tolerates new fields at the same version. A breaking change to either
+envelope (field renamed, removed, or retyped) ships as a **new topic name**
+(a new `connect_topic`/`access_connect_topic` config value), not an
+in-place schema change.
+
+### Further reading
+
+- [extras/kafka/CONSUMER-README.md](kafka/CONSUMER-README.md#consuming-via-kafka-connect-jdbc-sink) —
+  example JDBC sink connector config.
+- [extras/kafka/INTEGRATION-BRIEF.md](kafka/INTEGRATION-BRIEF.md#kafka-connect--jdbc-sink-publishing) —
+  design rationale, key choices, migration path off the plain topics.

--- a/extras/kafka/CONSUMER-README.md
+++ b/extras/kafka/CONSUMER-README.md
@@ -171,6 +171,76 @@ so:
 
 ---
 
+## Consuming via Kafka Connect (JDBC Sink)
+
+`cert-analyzer-events-connect` (`[kafka] connect_enabled` / `connect_topic`,
+off by default) is a **separate, opt-in topic** — enabling it changes
+nothing about the two topics documented above, and everything in this
+document up to here still applies to them unmodified.
+
+Each message is a Kafka Connect JSON envelope,
+`{"schema": {...}, "payload": {...}}` (the shape
+`org.apache.kafka.connect.json.JsonConverter` with `schemas.enable=true`
+expects), wrapping the same fields as a `certificate_discovered` event on
+the main topic. It exists so a stock Kafka Connect JDBC Sink connector
+(Confluent's or Aiven's open-source fork) can upsert rows into a DB with
+**no custom consumer code** — you're not expected to write a Python
+consumer against this topic the way the rest of this document covers.
+
+**Important — the `schema_version` forward-compatibility guarantee above
+does *not* extend to this topic.** A Kafka Connect JSON schema is rigid by
+construction: every message must match the declared `"schema"` exactly. Any
+breaking change to this envelope ships as a new topic name (e.g.
+`cert-analyzer-events-connect-v2`), not a silent in-place change — see
+[INTEGRATION-BRIEF.md](INTEGRATION-BRIEF.md#kafka-connect--jdbc-sink-publishing)
+for why.
+
+`pod_annotations` is JSON-encoded as a plain string field in this envelope
+(Connect's schema has no map type a stock JDBC sink can flatten into
+columns) — decode it client-side if you need it.
+
+Example JDBC sink connector config, POSTed to a Connect worker's REST API:
+
+```json
+{
+  "name": "cert-analyzer-expiry-sink",
+  "config": {
+    "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+    "tasks.max": "1",
+    "topics": "cert-analyzer-events-connect",
+    "connection.url": "jdbc:postgresql://db-host:5432/certs",
+    "connection.user": "cert_sink",
+    "connection.password": "${env:DB_PASSWORD}",
+    "insert.mode": "upsert",
+    "pk.mode": "record_key",
+    "auto.create": "true",
+    "auto.evolve": "true",
+    "table.name.format": "cert_discoveries"
+  }
+}
+```
+
+`pk.mode=record_key` with no `pk.fields` works because the Kafka message key
+on this topic is a single opaque string, `node_name:path:cert_index` — see
+[INTEGRATION-BRIEF.md](INTEGRATION-BRIEF.md#kafka-connect--jdbc-sink-publishing)
+for why that key (not `cert_unique_key`, and not `path:cert_index` alone) is
+what makes the upsert correct across a fleet.
+
+One more thing to know before relying on `auto.create`: `not_before`,
+`not_after`, and `detected_at` are Connect `string` fields (ISO 8601 text),
+not a native Connect timestamp logical type — `auto.create` will give you
+`VARCHAR`/`TEXT` columns for these, not `TIMESTAMP`. If you want real
+timestamp columns, add your own `TimestampConverter` single message
+transform to the connector config; that's outside what cert-analyzer
+provides.
+
+Standing up the Connect worker itself, installing the JDBC connector plugin,
+and the DB/table this ends up in are all outside this repo's scope — this
+section only covers what the topic looks like and how to point a stock
+connector at it.
+
+---
+
 ## Connecting to a secured broker
 
 If `[kafka] security_protocol` is set to anything other than `PLAINTEXT` on

--- a/extras/kafka/CONSUMER-README.md
+++ b/extras/kafka/CONSUMER-README.md
@@ -234,6 +234,37 @@ timestamp columns, add your own `TimestampConverter` single message
 transform to the connector config; that's outside what cert-analyzer
 provides.
 
+### `certificate_accessed` has the same envelope
+
+`cert-analyzer-access-events-connect` (`[kafka] access_connect_enabled` /
+`access_connect_topic`, off by default) is the same idea applied to
+`certificate_accessed` — a Kafka Connect JSON envelope wrapping the same
+fields as an access event on `cert-analyzer-access-events`. Everything
+above applies equally: separate opt-in topic, no `schema_version`
+forward-compatibility, breaking changes get a new topic name. There's no
+`pod_annotations`-equivalent field to JSON-encode here (the access message
+has no nested/dict fields).
+
+**Independently gated from `access_enabled`, not tied to it** — you can run
+the Connect-envelope access stream without the plain one, or vice versa,
+same as `plain_enabled`/`connect_enabled` for the discovery topic.
+
+**Key is different, and matters more here than on the discovery topic:**
+`node_name:path:cert_index:<process>:<parent_process>:<pod_name>:<namespace>:<app_label>:<container_name>`
+— cert identity alone (`node_name:path:cert_index`, what the discovery-connect
+topic uses) is *not* enough, because the entire point of `certificate_accessed`
+is capturing every distinct accessor for a cert, not one row per cert. An
+upsert keyed only on cert identity would collapse every accessor down to
+whichever one published last. With the accessor folded into the key, an
+`insert.mode=upsert` JDBC sink naturally maintains a live "who has this
+cert loaded, and when did each last touch it" table — a new access from an
+already-seen accessor updates that accessor's row in place (fresh
+`accessed_at`) rather than growing the table unboundedly, while a genuinely
+new accessor gets its own row. Still `pk.mode=record_key` with no
+`pk.fields` needed, same as the discovery topic — just point `topics` at
+`cert-analyzer-access-events-connect` and `table.name.format` at a
+different table name in the example config above.
+
 Standing up the Connect worker itself, installing the JDBC connector plugin,
 and the DB/table this ends up in are all outside this repo's scope — this
 section only covers what the topic looks like and how to point a stock

--- a/extras/kafka/INTEGRATION-BRIEF.md
+++ b/extras/kafka/INTEGRATION-BRIEF.md
@@ -183,6 +183,21 @@ orphaned old column behind a new one rather than a clean transition.
 See [CONSUMER-README.md](CONSUMER-README.md#consuming-via-kafka-connect-jdbc-sink)
 for an example JDBC sink connector config.
 
+**Migration path off the plain topic:** `[kafka] plain_enabled` (default
+`true`) independently gates the plain-JSON `topic` publish, separately from
+`connect_enabled`. This isn't a mode switch — plain-only (today),
+both-at-once (a migration window, to validate the new consumer before
+committing), and connect-only (`plain_enabled=false`, once every consumer
+has migrated) are just combinations of the two flags. There's no rush to
+flip `plain_enabled=false`: running both costs one extra `producer.send()`
+per discovery event (already a low-volume, discovery-only stream), plus
+proportionally more broker-side bytes on the connect topic than the plain
+one — Connect's inline `schemas.enable=true` format re-sends the full
+`"schema"` block on every message (no registry to dedupe it), so each
+enveloped message runs a few times larger than its plain-topic equivalent.
+Neither cost compounds with fleet size beyond the normal per-node discovery
+rate.
+
 ---
 
 ## Open questions for the platform team

--- a/extras/kafka/INTEGRATION-BRIEF.md
+++ b/extras/kafka/INTEGRATION-BRIEF.md
@@ -20,6 +20,7 @@ below for reference).
 | `cert-analyzer-events` | `[kafka] topic` / `KAFKA_TOPIC` | once per certificate, the first time it's seen — subject, issuer, SANs, key/crypto detail, FIPS status, K8s enrichment |
 | `cert-analyzer-access-events` | `[kafka] access_topic` / `KAFKA_ACCESS_TOPIC` | once per distinct process/pod that subsequently re-accesses an already-known certificate (opt-in, off by default) |
 | `cert-analyzer-events-connect` | `[kafka] connect_topic` / `KAFKA_CONNECT_TOPIC` | same trigger as `cert-analyzer-events`, wrapped in a Kafka-Connect JSON envelope (`{"schema": {...}, "payload": {...}}`) for a stock Kafka Connect JDBC Sink connector (opt-in, off by default — see below) |
+| `cert-analyzer-access-events-connect` | `[kafka] access_connect_topic` / `KAFKA_ACCESS_CONNECT_TOPIC` | same trigger as `cert-analyzer-access-events`, wrapped the same way (opt-in, off by default, independent of `access_enabled` — see below) |
 
 Topic names are set via config file / env var only today — the Helm chart
 doesn't expose them as values, so pointing at a differently-namespaced topic
@@ -198,6 +199,25 @@ enveloped message runs a few times larger than its plain-topic equivalent.
 Neither cost compounds with fleet size beyond the normal per-node discovery
 rate.
 
+**`certificate_accessed` gets the same envelope**, on
+`cert-analyzer-access-events-connect` (`access_connect_enabled` /
+`access_connect_topic`) — independently gated from `access_enabled`, same
+reasoning as `plain_enabled`/`connect_enabled` above (you can run the
+Connect-envelope access stream without the plain one, or vice versa).
+
+Its key is **not** just cert identity, unlike the discovery topic:
+`node_name:path:cert_index:<process>:<parent_process>:<pod_name>:<namespace>:<app_label>:<container_name>`.
+Cert identity alone would be wrong here — the entire point of
+`certificate_accessed` is capturing every distinct accessor of a cert, so an
+upsert keyed only on `node_name:path:cert_index` would collapse every
+accessor down to whichever one published last, the opposite of what the
+event exists to record. Folding the accessor fields into the key instead
+gives a JDBC sink a natural "who has this cert loaded, and when did each
+last touch it" table: a repeat access from an already-seen accessor updates
+that one row in place, a genuinely new accessor gets its own row, and the
+table doesn't grow unboundedly on repeat access from the same processes.
+Still `pk.mode=record_key`, zero extra connector config either way.
+
 ---
 
 ## Open questions for the platform team
@@ -216,11 +236,11 @@ rate.
    them with your own sizing, or should we rely on auto-create?
 5. **Schema expectations:** plain JSON + an in-payload `schema_version`
    remains the format on the two raw topics. If you need Connect/JDBC-sink
-   compatibility for a specific consumer, `cert-analyzer-events-connect` is
-   now available as an opt-in third topic carrying a Kafka Connect JSON
-   envelope (see "Kafka Connect / JDBC Sink publishing" above) — raise it if
-   that covers your need, or if you still require full registry-managed
-   schemas (Avro/Protobuf) beyond that.
+   compatibility for a specific consumer, `cert-analyzer-events-connect` and
+   `cert-analyzer-access-events-connect` are now available as opt-in topics
+   carrying a Kafka Connect JSON envelope (see "Kafka Connect / JDBC Sink
+   publishing" above) — raise it if that covers your need, or if you still
+   require full registry-managed schemas (Avro/Protobuf) beyond that.
 6. **Partition affinity by node/pod:** the key is cert-identity only — node
    and pod are payload fields, not part of the key. If you need per-node
    routing or sharded consumers, that's a key-strategy change on our side,

--- a/extras/kafka/INTEGRATION-BRIEF.md
+++ b/extras/kafka/INTEGRATION-BRIEF.md
@@ -19,6 +19,7 @@ below for reference).
 |---|---|---|
 | `cert-analyzer-events` | `[kafka] topic` / `KAFKA_TOPIC` | once per certificate, the first time it's seen — subject, issuer, SANs, key/crypto detail, FIPS status, K8s enrichment |
 | `cert-analyzer-access-events` | `[kafka] access_topic` / `KAFKA_ACCESS_TOPIC` | once per distinct process/pod that subsequently re-accesses an already-known certificate (opt-in, off by default) |
+| `cert-analyzer-events-connect` | `[kafka] connect_topic` / `KAFKA_CONNECT_TOPIC` | same trigger as `cert-analyzer-events`, wrapped in a Kafka-Connect JSON envelope (`{"schema": {...}, "payload": {...}}`) for a stock Kafka Connect JDBC Sink connector (opt-in, off by default — see below) |
 
 Topic names are set via config file / env var only today — the Helm chart
 doesn't expose them as values, so pointing at a differently-namespaced topic
@@ -27,7 +28,8 @@ just a config toggle.
 
 ## Key & ordering
 
-The partition key on both topics is `cert_unique_key`
+The partition key on the two raw topics (`cert-analyzer-events`,
+`cert-analyzer-access-events`) is `cert_unique_key`
 (`path:cert_index:serial_number`, spelled `cert_info.unique_key` in code) —
 it identifies the **certificate**, not its source. Node and pod ride along
 in the *payload* (the schema includes both) but aren't in the key: there's
@@ -40,6 +42,10 @@ append-only log, so a shared key never causes events to be lost or
 overwritten, only co-located in publish order — but it does mean
 partitioning won't give you per-node consumer sharding or even load spread
 by host.
+
+`cert-analyzer-events-connect` (see "Kafka Connect / JDBC Sink publishing"
+below) uses a different key for a different reason — it's built for a
+sink connector's *upsert*, not the raw log's grouping.
 
 ## Message format
 
@@ -134,6 +140,51 @@ spread load evenly across whatever partition count they provision.
 
 ---
 
+## Kafka Connect / JDBC Sink publishing
+
+`cert-analyzer-events-connect` (`[kafka] connect_enabled` / `connect_topic`,
+off by default) sidesteps the registry-vs-plain-JSON question above for one
+specific consumer shape: a stock Kafka Connect JDBC Sink connector upserting
+`certificate_discovered` events into a DB table for efficient expiry
+querying, with no custom consumer code. Each message is a Kafka Connect JSON
+envelope (`{"schema": {...}, "payload": {...}}`, the shape
+`org.apache.kafka.connect.json.JsonConverter` with `schemas.enable=true`
+expects) — a static schema, built once, covering the same fields as the
+plain topic's message.
+
+**Key: `node_name:path:cert_index`** — deliberately *not*
+`path:cert_index` (the Expiry row's recommended grouping key above). That
+recommendation was for a consumer-side *grouping* key, where cross-node
+correctness is handled at query time. This key drives a JDBC sink's
+*upsert* (`pk.mode=record_key`) — whichever record last writes a given key
+becomes the only surviving row. A cert deployed at the same path across
+hundreds of nodes (the common case this project exists to observe) would,
+under `path:cert_index` alone, collapse every node's row down to whichever
+one last upserted — hiding per-node expiry status, the opposite of what the
+table is for. Including `node_name` keeps one row per node+deployment-slot,
+still with zero extra connector config (`pk.mode=record_key`, no
+`pk.fields` needed since the whole key is one opaque string).
+
+`pod_annotations` (the one nested/dict field in the payload) is
+JSON-encoded as a plain string in this envelope — Connect's JSON schema has
+no map type a stock JDBC sink can flatten into columns without a custom
+SMT. Decode client-side.
+
+**Schema evolution:** a Connect schema is rigid by construction — every
+message on a topic must match it exactly, unlike the plain topics' `schema_
+version`-gated forward-compatibility (new fields tolerated at the same
+version). A breaking change to this envelope (field renamed, removed, or
+retyped) ships as a **new topic name** (e.g.
+`cert-analyzer-events-connect-v2`, a new `connect_topic` config value), not
+an in-place schema change — `auto.evolve` on the sink side only ever adds
+columns, never drops/renames, so an in-place breaking change would leave an
+orphaned old column behind a new one rather than a clean transition.
+
+See [CONSUMER-README.md](CONSUMER-README.md#consuming-via-kafka-connect-jdbc-sink)
+for an example JDBC sink connector config.
+
+---
+
 ## Open questions for the platform team
 
 1. **Bootstrap address:** our DaemonSet runs with `hostNetwork: true`, so it
@@ -148,9 +199,13 @@ spread load evenly across whatever partition count they provision.
    come from?
 4. **Partitions / RF / who creates the topics:** do you want to pre-create
    them with your own sizing, or should we rely on auto-create?
-5. **Schema expectations:** is plain JSON + an in-payload `schema_version`
-   workable, or does your org require registry-managed schemas
-   (Avro/Protobuf)?
+5. **Schema expectations:** plain JSON + an in-payload `schema_version`
+   remains the format on the two raw topics. If you need Connect/JDBC-sink
+   compatibility for a specific consumer, `cert-analyzer-events-connect` is
+   now available as an opt-in third topic carrying a Kafka Connect JSON
+   envelope (see "Kafka Connect / JDBC Sink publishing" above) — raise it if
+   that covers your need, or if you still require full registry-managed
+   schemas (Avro/Protobuf) beyond that.
 6. **Partition affinity by node/pod:** the key is cert-identity only — node
    and pod are payload fields, not part of the key. If you need per-node
    routing or sharded consumers, that's a key-strategy change on our side,

--- a/extras/kafka/KAFKA-README.md
+++ b/extras/kafka/KAFKA-README.md
@@ -4,9 +4,10 @@ cert-analyzer can optionally publish a JSON event to Kafka each time a
 certificate is discovered for the first time (`KAFKA_ENABLED=true` /
 `[kafka] enabled = true`), and optionally a further event each time an
 already-known certificate is re-accessed by a new process/pod
-(`[kafka] access_enabled = true`). A discovery event can also, optionally,
-be additionally published wrapped in a Kafka-Connect-compatible JSON
-envelope to a third topic (`[kafka] connect_enabled = true`), for a stock
+(`[kafka] access_enabled = true`). Either event can also, independently and
+optionally, be additionally published wrapped in a Kafka-Connect-compatible
+JSON envelope to its own dedicated topic (`[kafka] connect_enabled = true`
+for discovery, `access_connect_enabled = true` for access), for a stock
 Kafka Connect JDBC Sink connector to consume with no custom code. This
 document covers standing up a throwaway, single-node Kafka broker on RHEL 9
 to test that path locally, and how to verify and view the data it produces.
@@ -45,11 +46,12 @@ ZooKeeper) as a native systemd service:
 - Formats KRaft storage under `/var/lib/kafka/data` (once, on first install)
 - Installs and starts `kafka.service`
 - Waits for the broker to actually accept Kafka-protocol connections (not just for the process to start — see [Troubleshooting](#troubleshooting))
-- Creates the `cert-analyzer-events`, `cert-analyzer-access-events`, and
-  `cert-analyzer-events-connect` topics (the latter two created
-  unconditionally, even though `[kafka] access_enabled`/`connect_enabled`
+- Creates the `cert-analyzer-events`, `cert-analyzer-access-events`,
+  `cert-analyzer-events-connect`, and `cert-analyzer-access-events-connect`
+  topics (the latter three created unconditionally, even though
+  `[kafka] access_enabled`/`connect_enabled`/`access_connect_enabled` all
   default to `false` — cheap to have them exist and idle rather than fail
-  later if you turn either on after already running this script)
+  later if you turn any of them on after already running this script)
 
 It's plaintext/unauthenticated by design — matches cert-analyzer's own
 `PLAINTEXT` default `security_protocol`, and is not meant for anything
@@ -62,7 +64,7 @@ broker and both topics.
 To use different topic names:
 
 ```bash
-CERT_ANALYZER_TOPIC=my-test-topic CERT_ANALYZER_ACCESS_TOPIC=my-test-access-topic CERT_ANALYZER_CONNECT_TOPIC=my-test-connect-topic ./extras/kafka/install-kafka.sh
+CERT_ANALYZER_TOPIC=my-test-topic CERT_ANALYZER_ACCESS_TOPIC=my-test-access-topic CERT_ANALYZER_CONNECT_TOPIC=my-test-connect-topic CERT_ANALYZER_ACCESS_CONNECT_TOPIC=my-test-access-connect-topic ./extras/kafka/install-kafka.sh
 ```
 
 ---
@@ -88,6 +90,11 @@ access_topic = cert-analyzer-access-events
 # a stock Kafka Connect JDBC Sink connector.
 connect_enabled = true
 connect_topic = cert-analyzer-events-connect
+
+# Optional -- off by default, and independent of access_enabled above.
+# Same Kafka Connect envelope, for certificate_accessed instead.
+access_connect_enabled = true
+access_connect_topic = cert-analyzer-access-events-connect
 ```
 
 Then restart cert-analyzer for the config to take effect.

--- a/extras/kafka/KAFKA-README.md
+++ b/extras/kafka/KAFKA-README.md
@@ -76,6 +76,8 @@ Add to `/etc/cert-analyzer/cert-analyzer.conf` (or set the equivalent env vars):
 enabled = true
 bootstrap_servers = localhost:9092
 topic = cert-analyzer-events
+# plain_enabled = true is the default -- set false to stop publishing this
+# topic once every consumer has migrated to connect_topic below.
 
 # Optional -- off by default. See CONSUMER-README.md for the
 # certificate_accessed schema.

--- a/extras/kafka/KAFKA-README.md
+++ b/extras/kafka/KAFKA-README.md
@@ -4,9 +4,12 @@ cert-analyzer can optionally publish a JSON event to Kafka each time a
 certificate is discovered for the first time (`KAFKA_ENABLED=true` /
 `[kafka] enabled = true`), and optionally a further event each time an
 already-known certificate is re-accessed by a new process/pod
-(`[kafka] access_enabled = true`). This document covers standing up a
-throwaway, single-node Kafka broker on RHEL 9 to test that path locally, and
-how to verify and view the data it produces.
+(`[kafka] access_enabled = true`). A discovery event can also, optionally,
+be additionally published wrapped in a Kafka-Connect-compatible JSON
+envelope to a third topic (`[kafka] connect_enabled = true`), for a stock
+Kafka Connect JDBC Sink connector to consume with no custom code. This
+document covers standing up a throwaway, single-node Kafka broker on RHEL 9
+to test that path locally, and how to verify and view the data it produces.
 
 Writing an actual consumer against these topics? See
 [CONSUMER-README.md](CONSUMER-README.md) for client code examples and links
@@ -42,10 +45,11 @@ ZooKeeper) as a native systemd service:
 - Formats KRaft storage under `/var/lib/kafka/data` (once, on first install)
 - Installs and starts `kafka.service`
 - Waits for the broker to actually accept Kafka-protocol connections (not just for the process to start — see [Troubleshooting](#troubleshooting))
-- Creates the `cert-analyzer-events` and `cert-analyzer-access-events` topics
-  (the latter created unconditionally, even though `[kafka] access_enabled`
-  defaults to `false` — cheap to have it exist and idle rather than fail
-  later if you turn access events on after already running this script)
+- Creates the `cert-analyzer-events`, `cert-analyzer-access-events`, and
+  `cert-analyzer-events-connect` topics (the latter two created
+  unconditionally, even though `[kafka] access_enabled`/`connect_enabled`
+  default to `false` — cheap to have them exist and idle rather than fail
+  later if you turn either on after already running this script)
 
 It's plaintext/unauthenticated by design — matches cert-analyzer's own
 `PLAINTEXT` default `security_protocol`, and is not meant for anything
@@ -58,7 +62,7 @@ broker and both topics.
 To use different topic names:
 
 ```bash
-CERT_ANALYZER_TOPIC=my-test-topic CERT_ANALYZER_ACCESS_TOPIC=my-test-access-topic ./extras/kafka/install-kafka.sh
+CERT_ANALYZER_TOPIC=my-test-topic CERT_ANALYZER_ACCESS_TOPIC=my-test-access-topic CERT_ANALYZER_CONNECT_TOPIC=my-test-connect-topic ./extras/kafka/install-kafka.sh
 ```
 
 ---
@@ -77,6 +81,11 @@ topic = cert-analyzer-events
 # certificate_accessed schema.
 access_enabled = true
 access_topic = cert-analyzer-access-events
+
+# Optional -- off by default. See CONSUMER-README.md for consuming this via
+# a stock Kafka Connect JDBC Sink connector.
+connect_enabled = true
+connect_topic = cert-analyzer-events-connect
 ```
 
 Then restart cert-analyzer for the config to take effect.

--- a/extras/kafka/install-kafka.sh
+++ b/extras/kafka/install-kafka.sh
@@ -19,6 +19,7 @@ SERVICE_FILE="/etc/systemd/system/kafka.service"
 CERT_ANALYZER_TOPIC="${CERT_ANALYZER_TOPIC:-cert-analyzer-events}"
 CERT_ANALYZER_ACCESS_TOPIC="${CERT_ANALYZER_ACCESS_TOPIC:-cert-analyzer-access-events}"
 CERT_ANALYZER_CONNECT_TOPIC="${CERT_ANALYZER_CONNECT_TOPIC:-cert-analyzer-events-connect}"
+CERT_ANALYZER_ACCESS_CONNECT_TOPIC="${CERT_ANALYZER_ACCESS_CONNECT_TOPIC:-cert-analyzer-access-events-connect}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -211,10 +212,18 @@ echo "Ensuring topic '${CERT_ANALYZER_CONNECT_TOPIC}' exists..."
     --partitions 1 --replication-factor 1 > /dev/null
 echo "    Topic ready."
 
+# Same rationale again -- access_connect_enabled defaults to false too.
+echo "Ensuring topic '${CERT_ANALYZER_ACCESS_CONNECT_TOPIC}' exists..."
+"${INSTALL_DIR}/bin/kafka-topics.sh" --create --if-not-exists \
+    --topic "${CERT_ANALYZER_ACCESS_CONNECT_TOPIC}" \
+    --bootstrap-server "localhost:${KAFKA_PORT}" \
+    --partitions 1 --replication-factor 1 > /dev/null
+echo "    Topic ready."
+
 echo ""
 echo "============================================"
 echo " Kafka is running on localhost:${KAFKA_PORT}"
-echo " Topics: ${CERT_ANALYZER_TOPIC}, ${CERT_ANALYZER_ACCESS_TOPIC}, ${CERT_ANALYZER_CONNECT_TOPIC}"
+echo " Topics: ${CERT_ANALYZER_TOPIC}, ${CERT_ANALYZER_ACCESS_TOPIC}, ${CERT_ANALYZER_CONNECT_TOPIC}, ${CERT_ANALYZER_ACCESS_CONNECT_TOPIC}"
 echo ""
 echo " Point cert-analyzer at it:"
 echo "   [kafka]"
@@ -225,11 +234,13 @@ echo "   access_enabled = true   # optional -- off by default"
 echo "   access_topic = ${CERT_ANALYZER_ACCESS_TOPIC}"
 echo "   connect_enabled = true   # optional -- off by default"
 echo "   connect_topic = ${CERT_ANALYZER_CONNECT_TOPIC}"
+echo "   access_connect_enabled = true   # optional -- off by default"
+echo "   access_connect_topic = ${CERT_ANALYZER_ACCESS_CONNECT_TOPIC}"
 echo ""
 echo " Tail messages:"
 echo "   ${INSTALL_DIR}/bin/kafka-console-consumer.sh \\"
 echo "     --bootstrap-server localhost:${KAFKA_PORT} --topic ${CERT_ANALYZER_TOPIC} --from-beginning"
 echo ""
 echo " Override the topic names if needed:"
-echo "   CERT_ANALYZER_TOPIC=<name> CERT_ANALYZER_ACCESS_TOPIC=<name> CERT_ANALYZER_CONNECT_TOPIC=<name> bash $0"
+echo "   CERT_ANALYZER_TOPIC=<name> CERT_ANALYZER_ACCESS_TOPIC=<name> CERT_ANALYZER_CONNECT_TOPIC=<name> CERT_ANALYZER_ACCESS_CONNECT_TOPIC=<name> bash $0"
 echo "============================================"

--- a/extras/kafka/install-kafka.sh
+++ b/extras/kafka/install-kafka.sh
@@ -18,6 +18,7 @@ DATA_DIR="/var/lib/kafka/data"
 SERVICE_FILE="/etc/systemd/system/kafka.service"
 CERT_ANALYZER_TOPIC="${CERT_ANALYZER_TOPIC:-cert-analyzer-events}"
 CERT_ANALYZER_ACCESS_TOPIC="${CERT_ANALYZER_ACCESS_TOPIC:-cert-analyzer-access-events}"
+CERT_ANALYZER_CONNECT_TOPIC="${CERT_ANALYZER_CONNECT_TOPIC:-cert-analyzer-events-connect}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -200,10 +201,20 @@ echo "Ensuring topic '${CERT_ANALYZER_ACCESS_TOPIC}' exists..."
     --partitions 1 --replication-factor 1 > /dev/null
 echo "    Topic ready."
 
+# Same rationale as the access topic above -- connect_enabled defaults to
+# false, but the topic is created unconditionally so flipping it on later
+# doesn't need a re-run of this script.
+echo "Ensuring topic '${CERT_ANALYZER_CONNECT_TOPIC}' exists..."
+"${INSTALL_DIR}/bin/kafka-topics.sh" --create --if-not-exists \
+    --topic "${CERT_ANALYZER_CONNECT_TOPIC}" \
+    --bootstrap-server "localhost:${KAFKA_PORT}" \
+    --partitions 1 --replication-factor 1 > /dev/null
+echo "    Topic ready."
+
 echo ""
 echo "============================================"
 echo " Kafka is running on localhost:${KAFKA_PORT}"
-echo " Topics: ${CERT_ANALYZER_TOPIC}, ${CERT_ANALYZER_ACCESS_TOPIC}"
+echo " Topics: ${CERT_ANALYZER_TOPIC}, ${CERT_ANALYZER_ACCESS_TOPIC}, ${CERT_ANALYZER_CONNECT_TOPIC}"
 echo ""
 echo " Point cert-analyzer at it:"
 echo "   [kafka]"
@@ -212,11 +223,13 @@ echo "   bootstrap_servers = localhost:${KAFKA_PORT}"
 echo "   topic = ${CERT_ANALYZER_TOPIC}"
 echo "   access_enabled = true   # optional -- off by default"
 echo "   access_topic = ${CERT_ANALYZER_ACCESS_TOPIC}"
+echo "   connect_enabled = true   # optional -- off by default"
+echo "   connect_topic = ${CERT_ANALYZER_CONNECT_TOPIC}"
 echo ""
 echo " Tail messages:"
 echo "   ${INSTALL_DIR}/bin/kafka-console-consumer.sh \\"
 echo "     --bootstrap-server localhost:${KAFKA_PORT} --topic ${CERT_ANALYZER_TOPIC} --from-beginning"
 echo ""
 echo " Override the topic names if needed:"
-echo "   CERT_ANALYZER_TOPIC=<name> CERT_ANALYZER_ACCESS_TOPIC=<name> bash $0"
+echo "   CERT_ANALYZER_TOPIC=<name> CERT_ANALYZER_ACCESS_TOPIC=<name> CERT_ANALYZER_CONNECT_TOPIC=<name> bash $0"
 echo "============================================"

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -6203,6 +6203,65 @@ class TestKafkaPublisher:
             assert str(sample_cert_info.cert_index) in expected_key
             assert sample_cert_info.serial_number in expected_key
 
+    # ── plain_enabled gating ───────────────────────────────────────────────────
+
+    def test_plain_enabled_defaults_true(self, monkeypatch, sample_cert_info):
+        """plain_enabled defaults to True -- unchanged behavior for existing installs."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            assert publisher.plain_enabled is True
+
+            publisher.publish(sample_cert_info)
+            mock_producer.send.assert_called_once()
+            send_args, _ = mock_producer.send.call_args
+            assert send_args[0] == 't'
+
+    def test_publish_plain_disabled_skips_plain_topic_send(self, monkeypatch, sample_cert_info):
+        """plain_enabled=False stops the plain-topic send but connect_topic still fires -- independent gates."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t',
+                plain_enabled=False, connect_topic='t-connect',
+            )
+            publisher.publish(sample_cert_info)
+
+            mock_producer.send.assert_called_once()
+            send_args, _ = mock_producer.send.call_args
+            assert send_args[0] == 't-connect'
+
+    def test_publish_plain_and_connect_both_disabled_sends_nothing(self, monkeypatch, sample_cert_info):
+        """plain_enabled=False with no connect_topic configured is a silent no-op, never raises."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', plain_enabled=False,
+            )
+            publisher.publish(sample_cert_info)
+            mock_producer.send.assert_not_called()
+
     # ── publish_access (certificate_accessed) ─────────────────────────────────
 
     def test_publish_access_noop_when_access_topic_not_configured(self, monkeypatch, sample_cert_info):

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -6325,6 +6325,124 @@ class TestKafkaPublisher:
             assert 'subject' not in msg
             assert 'fips_compliant' not in msg
 
+    # ── publish_access() Kafka Connect envelope (access_connect_topic) ────────
+
+    def test_publish_access_connect_noop_when_neither_flag_set(self, monkeypatch, sample_cert_info):
+        """publish_access() sends nothing when both access_enabled and access_connect_enabled are unset (defaults)."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            assert publisher.access_connect_enabled is False
+
+            publisher.publish_access(
+                sample_cert_info, process='/usr/bin/git', pid=555,
+                parent_process='/usr/bin/bash', parent_pid=1,
+            )
+            mock_producer.send.assert_not_called()
+
+    def test_publish_access_connect_sends_independent_of_access_enabled(self, monkeypatch, sample_cert_info):
+        """access_connect_enabled alone (access_enabled left False) still sends an envelope to access_connect_topic."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', access_connect_topic='t-access-connect',
+            )
+            assert publisher.access_enabled is False
+            assert publisher.access_connect_enabled is True
+
+            publisher.publish_access(
+                sample_cert_info, process='/usr/bin/git', pid=555,
+                parent_process='/usr/bin/bash', parent_pid=1,
+                namespace='default', pod_name='my-pod', pod_uid='uid-1',
+                node_name='worker-node-1', app_label='my-app',
+                container_name='main', container_id='c1', container_image='my-app:1.0',
+            )
+
+            mock_producer.send.assert_called_once()
+            send_args, send_kwargs = mock_producer.send.call_args
+            assert send_args[0] == 't-access-connect'
+            envelope = send_kwargs['value']
+            assert set(envelope.keys()) == {'schema', 'payload'}
+            assert envelope['schema']['name'] == 'io.certanalyzer.CertificateAccessed'
+            assert envelope['payload']['event_type'] == 'certificate_accessed'
+            assert envelope['payload']['process']    == '/usr/bin/git'
+
+    def test_publish_access_connect_key_includes_accessor_identity(self, monkeypatch, sample_cert_info):
+        """access_connect_topic key includes the accessor, not just cert identity -- distinct accessors mustn't collide on upsert."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', access_connect_topic='t-access-connect',
+            )
+
+            publisher.publish_access(
+                sample_cert_info, process='/usr/bin/git', pid=555,
+                parent_process='/usr/bin/bash', parent_pid=1,
+                namespace='default', pod_name='pod-a', node_name='worker-node-1',
+                app_label='my-app', container_name='main',
+            )
+            key_a = mock_producer.send.call_args[1]['key']
+
+            mock_producer.reset_mock()
+            publisher.publish_access(
+                sample_cert_info, process='/usr/bin/curl', pid=556,
+                parent_process='/usr/bin/bash', parent_pid=1,
+                namespace='default', pod_name='pod-a', node_name='worker-node-1',
+                app_label='my-app', container_name='main',
+            )
+            key_b = mock_producer.send.call_args[1]['key']
+
+            assert key_a != key_b
+            expected_a = (
+                f"worker-node-1:{sample_cert_info.path}:{sample_cert_info.cert_index}:"
+                f"/usr/bin/git:/usr/bin/bash:pod-a:default:my-app:main"
+            )
+            assert key_a == expected_a
+
+    def test_publish_access_connect_and_plain_both_enabled(self, monkeypatch, sample_cert_info):
+        """Both access_enabled and access_connect_enabled together send to both topics."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t',
+                access_topic='t-access', access_connect_topic='t-access-connect',
+            )
+            publisher.publish_access(
+                sample_cert_info, process='/usr/bin/git', pid=555,
+                parent_process='/usr/bin/bash', parent_pid=1,
+            )
+            assert mock_producer.send.call_count == 2
+            topics_sent = {c[0][0] for c in mock_producer.send.call_args_list}
+            assert topics_sent == {'t-access', 't-access-connect'}
+
     # ── publish() Kafka Connect envelope (connect_topic) ──────────────────────
 
     def test_publish_connect_noop_when_connect_topic_not_configured(self, monkeypatch, sample_cert_info):
@@ -6814,6 +6932,7 @@ class TestKafkaPublisher:
 
         mock_publisher = MagicMock()
         mock_publisher.access_enabled = True
+        mock_publisher.access_connect_enabled = False
         analyzer.kafka_publisher = mock_publisher
 
         cert, _ = TestCertificateGeneration.generate_certificate('access.example.com', 365)
@@ -6860,6 +6979,7 @@ class TestKafkaPublisher:
 
         mock_publisher = MagicMock()
         mock_publisher.access_enabled = False
+        mock_publisher.access_connect_enabled = False
         analyzer.kafka_publisher = mock_publisher
 
         cert, _ = TestCertificateGeneration.generate_certificate('access-disabled.example.com', 365)
@@ -6884,6 +7004,40 @@ class TestKafkaPublisher:
         analyzer.process_event(make_event(path, '/usr/bin/curl', 99))
         analyzer.process_event(make_event(path, '/usr/bin/git', 100))
         mock_publisher.publish_access.assert_not_called()
+
+    def test_analyzer_publishes_access_event_when_only_access_connect_enabled(
+        self, analyzer, temp_dir
+    ):
+        """A re-access still publishes certificate_accessed when only access_connect_enabled is set -- independent of access_enabled."""
+        from unittest.mock import MagicMock
+
+        mock_publisher = MagicMock()
+        mock_publisher.access_enabled = False
+        mock_publisher.access_connect_enabled = True
+        analyzer.kafka_publisher = mock_publisher
+
+        cert, _ = TestCertificateGeneration.generate_certificate('access-connect-only.example.com', 365)
+        path = os.path.join(temp_dir, 'access-connect-only.pem')
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        def make_event(p, binary, pid):
+            mock_event = MagicMock()
+            mock_event.HasField.side_effect = lambda f: f == 'process_kprobe'
+            mock_kprobe = MagicMock()
+            mock_kprobe.process.binary = binary
+            mock_kprobe.process.pid.value = pid
+            mock_kprobe.process.HasField.side_effect = lambda f: f == 'pid'
+            mock_kprobe.HasField.return_value = False
+            mock_arg = MagicMock()
+            mock_arg.HasField.side_effect = lambda f: f == 'file_arg'
+            mock_arg.file_arg.path = p
+            mock_kprobe.args = [mock_arg]
+            mock_event.process_kprobe = mock_kprobe
+            return mock_event
+
+        analyzer.process_event(make_event(path, '/usr/bin/curl', 99))
+        analyzer.process_event(make_event(path, '/usr/bin/git', 100))
+        mock_publisher.publish_access.assert_called_once()
 
     def test_analyzer_without_kafka_publisher_works_normally(
         self, analyzer, temp_dir

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -6266,6 +6266,165 @@ class TestKafkaPublisher:
             assert 'subject' not in msg
             assert 'fips_compliant' not in msg
 
+    # ── publish() Kafka Connect envelope (connect_topic) ──────────────────────
+
+    def test_publish_connect_noop_when_connect_topic_not_configured(self, monkeypatch, sample_cert_info):
+        """publish() sends only the plain-topic message when connect_topic isn't set — purely additive, off by default."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(bootstrap_servers='b:9092', topic='t')
+            assert publisher.connect_enabled is False
+
+            publisher.publish(sample_cert_info)
+            mock_producer.send.assert_called_once()
+
+    def test_publish_connect_sends_envelope_when_connect_topic_configured(self, monkeypatch, sample_cert_info):
+        """publish() additionally sends a {schema, payload} envelope to connect_topic when configured."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            assert publisher.connect_enabled is True
+
+            publisher.publish(sample_cert_info)
+            assert mock_producer.send.call_count == 2
+
+            second_call_args, second_call_kwargs = mock_producer.send.call_args_list[1]
+            assert second_call_args[0] == 't-connect'
+            envelope = second_call_kwargs['value']
+            assert set(envelope.keys()) == {'schema', 'payload'}
+            assert envelope['schema']['type'] == 'struct'
+
+    def test_publish_connect_envelope_payload_matches_plain_message(self, monkeypatch, sample_cert_info):
+        """The connect envelope's payload carries the same field values as the plain-topic message."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            publisher.publish(sample_cert_info)
+
+            plain_msg = mock_producer.send.call_args_list[0][1]['value']
+            connect_payload = mock_producer.send.call_args_list[1][1]['value']['payload']
+
+            for key, value in plain_msg.items():
+                if key == 'pod_annotations':
+                    continue  # JSON-encoded in the envelope, checked separately below
+                assert connect_payload[key] == value, f"Mismatch on {key}"
+
+    def test_publish_connect_schema_is_stable_across_calls(self, monkeypatch, sample_cert_info):
+        """The Connect schema is built once and reused, not rebuilt per message."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            publisher.publish(sample_cert_info)
+            publisher.publish(sample_cert_info)
+
+            schema_1 = mock_producer.send.call_args_list[1][1]['value']['schema']
+            schema_2 = mock_producer.send.call_args_list[3][1]['value']['schema']
+            assert schema_1 is schema_2
+
+    def test_publish_connect_pod_annotations_json_encoded(self, monkeypatch, sample_cert_info):
+        """pod_annotations lands as a JSON-encoded string in the envelope, not a raw dict."""
+        import dataclasses
+        import json as _json
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        cert_info = dataclasses.replace(sample_cert_info, pod_annotations={'foo': 'bar'})
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            publisher.publish(cert_info)
+
+            connect_payload = mock_producer.send.call_args_list[1][1]['value']['payload']
+            assert isinstance(connect_payload['pod_annotations'], str)
+            assert _json.loads(connect_payload['pod_annotations']) == {'foo': 'bar'}
+
+    def test_publish_connect_key_is_node_path_cert_index(self, monkeypatch, sample_cert_info):
+        """connect_topic key is node_name:path:cert_index -- not unique_key, so an upsert stays correct per node+slot."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            publisher.publish(sample_cert_info)
+
+            second_call_kwargs = mock_producer.send.call_args_list[1][1]
+            expected_key = f"{sample_cert_info.node_name}:{sample_cert_info.path}:{sample_cert_info.cert_index}"
+            assert second_call_kwargs['key'] == expected_key
+            assert second_call_kwargs['key'] != sample_cert_info.unique_key
+
+    def test_publish_connect_schema_fields_optional_flags(self, monkeypatch, sample_cert_info):
+        """Spot-check known-nullable vs. always-present fields carry the correct 'optional' flag."""
+        import agent.kafka as _ca
+        monkeypatch.setattr(_ca, 'KAFKA_AVAILABLE', True)
+
+        from unittest.mock import patch, MagicMock
+        with patch('agent.kafka.KafkaProducer') as mock_cls:
+            mock_producer = MagicMock()
+            mock_cls.return_value = mock_producer
+
+            from cert_analyzer import KafkaPublisher
+            publisher = KafkaPublisher(
+                bootstrap_servers='b:9092', topic='t', connect_topic='t-connect',
+            )
+            publisher.publish(sample_cert_info)
+
+            schema_fields = {
+                f['field']: f for f in
+                mock_producer.send.call_args_list[1][1]['value']['schema']['fields']
+            }
+            assert schema_fields['container_pid']['optional'] is True
+            assert schema_fields['is_ca']['optional'] is True
+            assert schema_fields['path']['optional'] is False
+            assert schema_fields['event_type']['optional'] is False
+
     def test_publish_sends_to_configured_topic(self, monkeypatch, sample_cert_info):
         """Message is sent to the topic specified in configuration."""
         import agent.kafka as _ca


### PR DESCRIPTION
Publishes an additional, config-gated ({connect_enabled}/{connect_topic}, off by default) copy of each discovery event wrapped in a Kafka Connect JSON envelope to a separate topic, so a stock Kafka Connect JDBC Sink connector can upsert straight into a DB for efficient expiry querying with no custom consumer code. The existing plain-JSON topics and every current consumer are untouched.

Keyed on node_name:path:cert_index rather than the raw topics' cert-identity key, so an upsert doesn't collapse one node's history into another's for a cert deployed identically across a fleet.