### PR TITLE
Add optional system_test.py synthetic pipeline canary

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -132,6 +132,15 @@ class CertificateAnalyzer:
         9443,  # HTTPS alternate
     })
 
+    # Synthetic (non-file) path schemes used exclusively by this analyzer's own
+    # bind-probe/connect-probe/in-memory-uprobe discovery paths (see
+    # _handle_tls_bind_event/_handle_tls_connect_event and the uprobe handlers
+    # below) -- a real workload's certificate can never be discovered under one
+    # of these prefixes, so they're always synthetic regardless of config.
+    # Keep in sync with the synthetic_path values built at each of those call
+    # sites (f'uprobe://{symbol}/...', f'tls-{mechanism}-probe://...').
+    _SYNTHETIC_URI_SCHEMES = ('uprobe://', 'tls-bind-probe://', 'tls-connect-probe://')
+
     def __init__(self, tetragon_address: str, alert_threshold_days: int = 30,
                  filter_self_events: bool = True,
                  health_server: Optional['HealthServer'] = None,
@@ -156,7 +165,8 @@ class CertificateAnalyzer:
                  retry_queue_max_size: int = 2000,
                  scan_paths: Optional[list] = None,
                  scan_interval_seconds: int = 3600,
-                 metrics_port: int = 9090):
+                 metrics_port: int = 9090,
+                 synthetic_path_prefixes: Optional[list] = None):
         self.tetragon_address = tetragon_address
         self.alert_threshold_days = alert_threshold_days
         self.filter_self_events = filter_self_events
@@ -223,6 +233,11 @@ class CertificateAnalyzer:
         self._retry_queue_lock = threading.Lock()
         self._scan_paths = list(scan_paths) if scan_paths else []
         self._scan_interval_seconds = scan_interval_seconds
+        # Real filesystem path prefixes (e.g. a test-server's generated-cert
+        # directory) that should also be treated as synthetic, in addition to
+        # the always-synthetic _SYNTHETIC_URI_SCHEMES above. Tuple so
+        # str.startswith() can check both in one call.
+        self._synthetic_path_prefixes = tuple(synthetic_path_prefixes) if synthetic_path_prefixes else ()
         self.metrics = PrometheusMetrics(node_name=_NODE_NAME)
         self.metrics.config_info.labels(node_name=_NODE_NAME).info({
             'checksum_enabled':                  str(checksum_enabled).lower(),
@@ -245,6 +260,7 @@ class CertificateAnalyzer:
             'max_processes_per_cert':              str(max_processes_per_cert),
             'alert_threshold_days':                str(alert_threshold_days),
             'scan_paths':                          ','.join(self._scan_paths),
+            'synthetic_path_prefixes':              ','.join(self._synthetic_path_prefixes),
             'kafka_enabled':                       str(kafka_publisher is not None).lower(),
             'kafka_bootstrap_servers':              kafka_publisher.bootstrap_servers if kafka_publisher is not None else '',
             'kafka_plain_enabled':                  str(kafka_publisher.plain_enabled).lower() if kafka_publisher is not None else 'false',
@@ -670,6 +686,18 @@ class CertificateAnalyzer:
             self.metrics.cert_analysis_errors.labels(error_type='read_error', node_name=self.metrics._node_name).inc()
             return []
 
+    def _is_synthetic_path(self, cert_path: str) -> bool:
+        """
+        True if cert_path came from this analyzer's own synthetic discovery
+        mechanisms (bind/connect-probe, in-memory uprobe) or from a configured
+        test-server generated-cert directory -- i.e. it's demo/system-test
+        traffic, not a real workload certificate. See CertificateInfo.synthetic.
+        """
+        return (
+            cert_path.startswith(self._SYNTHETIC_URI_SCHEMES)
+            or cert_path.startswith(self._synthetic_path_prefixes)
+        )
+
     def extract_certificate_info(
         self,
         cert: x509.Certificate,
@@ -933,6 +961,7 @@ class CertificateAnalyzer:
             is_ca=is_ca,
             basic_constraints_path_length=basic_constraints_path_length,
             is_self_signed=is_self_signed,
+            synthetic=self._is_synthetic_path(cert_path),
         )
 
     def _count_pem_certs(self, cert_path: str) -> int:

--- a/agent/config.py
+++ b/agent/config.py
@@ -15,6 +15,7 @@ from .analyzer import CertificateAnalyzer
 from .health import HealthServer
 from .kafka import KafkaPublisher
 from .metrics import start_metrics_server
+from .system_test import SystemTestRunner
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +169,14 @@ def main():
     staleness       = cfg_int(cp, 'health',    'readiness_staleness_seconds',    'READINESS_STALENESS_SECONDS',    '300')
     filter_self     = cfg(cp, 'certificates', 'filter_self_events',       'FILTER_SELF_EVENTS',              'true').lower() != 'false'
     host_prefix     = cfg(cp, 'certificates', 'host_prefix',              'HOST_PREFIX',                     '')
+    # Real filesystem path prefixes treated as synthetic (demo/system-test)
+    # traffic, in addition to the analyzer's own always-synthetic bind-probe/
+    # connect-probe/uprobe schemes -- see CertificateAnalyzer._is_synthetic_path.
+    # Defaults to extras/test-server's own default generated-cert directory
+    # (TEST_SERVER_CERT_DIR there) so a stock test-server deployment is
+    # recognized with no extra config on either side.
+    synthetic_path_prefixes_str = cfg(cp, 'certificates', 'synthetic_path_prefixes', 'SYNTHETIC_PATH_PREFIXES', '/dev/shm/certsight-test-server')
+    synthetic_path_prefixes = [p.strip() for p in synthetic_path_prefixes_str.split(',') if p.strip()]
     checksum_enabled        = cfg(cp, 'certificates', 'checksum_enabled',        'CERT_CHECKSUM_ENABLED',        'false').lower() == 'true'
     spki_hash_enabled       = cfg(cp, 'certificates', 'spki_hash_enabled',       'SPKI_HASH_ENABLED',            'true').lower() != 'false'
     demo_mode               = cfg(cp, 'certificates', 'demo_mode',               'DEMO_MODE',                    'false').lower() == 'true'
@@ -248,6 +257,17 @@ def main():
     kafka_sasl_username    = cfg(cp, 'kafka', 'sasl_username',     'KAFKA_SASL_USERNAME',     '')
     kafka_sasl_password    = cfg(cp, 'kafka', 'sasl_password',     'KAFKA_SASL_PASSWORD',     '')
 
+    # Synthetic end-to-end canary against an external test-server's use cases
+    # (see agent/system_test.py). Enabled by default, but only actually starts
+    # when test_server_url is set -- most deployments (real customer clusters)
+    # have no test-server, and this must degrade silently there rather than
+    # log connection failures forever.
+    system_test_enabled          = cfg(cp, 'system_test', 'enabled',          'SYSTEM_TEST_ENABLED',          'true').lower() != 'false'
+    system_test_url              = cfg(cp, 'system_test', 'test_server_url',  'SYSTEM_TEST_SERVER_URL',       '')
+    system_test_interval_seconds = cfg_int(cp, 'system_test', 'interval_seconds', 'SYSTEM_TEST_INTERVAL_SECONDS', '300')
+    _system_test_use_cases_str   = cfg(cp, 'system_test', 'use_cases',        'SYSTEM_TEST_USE_CASES',        '')
+    system_test_use_cases = [u.strip() for u in _system_test_use_cases_str.split(',') if u.strip()] or None
+
     logger.info("="*60)
     logger.info("TLS Certificate Expiry Monitor (Multi-Cert + K8s Enrichment)")
     logger.info("="*60)
@@ -274,6 +294,7 @@ def main():
     logger.info(f"Scan interval:     {scan_interval} seconds")
     logger.info(f"Filter self events: {filter_self}")
     logger.info(f"Host prefix:       '{host_prefix}' (empty = standalone mode)")
+    logger.info(f"Synthetic path prefixes: {synthetic_path_prefixes}")
     logger.info(f"Kafka enabled:     {kafka_enabled}")
     if kafka_enabled:
         logger.info(f"Kafka brokers:     {kafka_bootstrap}")
@@ -292,6 +313,12 @@ def main():
     if connect_probe_enabled:
         _effective_ports = tls_outbound_ports if tls_outbound_ports is not None else CertificateAnalyzer.TLS_OUTBOUND_PORTS
         logger.info(f"TLS outbound ports:        {sorted(_effective_ports)}")
+    if system_test_enabled and system_test_url:
+        logger.info(f"System test:       enabled — server: {system_test_url}, interval: {system_test_interval_seconds}s, use cases: {system_test_use_cases or 'all'}")
+    elif system_test_enabled:
+        logger.info("System test:       enabled but no [system_test] test_server_url configured — not started")
+    else:
+        logger.info("System test:       disabled")
     logger.info("="*60)
 
     logger.info(f"Starting Prometheus metrics server on port {metrics_port}")
@@ -342,7 +369,8 @@ def main():
                                    retry_queue_max_size=retry_queue_max_size,
                                    scan_paths=scan_paths,
                                    scan_interval_seconds=scan_interval,
-                                   metrics_port=metrics_port)
+                                   metrics_port=metrics_port,
+                                   synthetic_path_prefixes=synthetic_path_prefixes)
 
     health = HealthServer(
         analyzer=analyzer,
@@ -366,6 +394,15 @@ def main():
         scanner_thread = threading.Thread(target=periodic_scanner, daemon=True)
         scanner_thread.start()
         logger.info(f"Started periodic scanner (interval: {scan_interval}s)")
+
+    if system_test_enabled and system_test_url:
+        system_test_runner = SystemTestRunner(
+            base_url=system_test_url,
+            interval_seconds=system_test_interval_seconds,
+            use_case_allowlist=system_test_use_cases,
+        )
+        system_test_runner.start()
+        logger.info(f"Started system-test runner against {system_test_url} (interval: {system_test_interval_seconds}s)")
 
     try:
         analyzer.start()

--- a/agent/kafka.py
+++ b/agent/kafka.py
@@ -521,6 +521,7 @@ class KafkaPublisher:
             'is_ca':                         cert_info.is_ca,
             'basic_constraints_path_length': cert_info.basic_constraints_path_length,
             'is_self_signed':                cert_info.is_self_signed,
+            'synthetic':                     cert_info.synthetic,
         }
 
         # Use unique_key (path:cert_index:serial) as the partition key.
@@ -659,6 +660,12 @@ class KafkaPublisher:
         (no nested/dict fields), so it calls _wrap_connect_envelope directly.
         """
         envelope = self._wrap_connect_envelope(self._connect_schema, message)
+        # 'synthetic' is deliberately not in _CONNECT_SCHEMA_FIELDS -- adding a
+        # field there is schema drift the module docstring says Connect sinks
+        # don't tolerate on an existing topic (a new connect_topic name would
+        # be needed). It stays in the plain-JSON message (schema-tolerant per
+        # KAFKA_SCHEMA_VERSION) and is stripped here so payload matches schema.
+        envelope['payload'].pop('synthetic', None)
         envelope['payload']['pod_annotations'] = json.dumps(envelope['payload'].get('pod_annotations') or {})
         return envelope
 

--- a/agent/models.py
+++ b/agent/models.py
@@ -86,6 +86,11 @@ class CertificateInfo:
     # verifies against its own public key). Root CA certificates are legitimately
     # self-signed; self-signed leaf certificates are typically a configuration risk.
     is_self_signed: bool = False
+    # True when this cert's path/synthetic-URI matched a known test-server
+    # generation pattern (see CertificateAnalyzer._is_synthetic_path) --
+    # i.e. it came from a demo click or system_test.py, not real workload
+    # traffic. Lets downstream fleet/inventory dashboards filter it out.
+    synthetic: bool = False
     # Distinct (process, parent_process, pod_name, namespace, app_label,
     # container_name) tuples already given their own tls_certificate_process_info
     # series for this cert, capped at max_processes_per_cert (see

--- a/agent/system_test.py
+++ b/agent/system_test.py
@@ -1,0 +1,188 @@
+"""
+Optional synthetic end-to-end canary: periodically drives every (or an
+allow-listed subset of) use case exposed by an external test-server's HTTP
+API, and exposes pass/fail as Prometheus gauges.
+
+Unlike periodic_scan (which only re-discovers certs already on disk), this
+proves the *whole* pipeline is alive end-to-end: Tetragon kprobe/uprobe ->
+this analyzer's gRPC consumer -> cert parsing -> (optionally) Kafka -- on a
+schedule, independent of whether any real workload happens to be touching
+certificates right now.
+
+Degrades silently (never started) when [system_test] test_server_url is
+unset -- most deployments (real customer clusters) have no test-server, and
+this feature must never be the thing that makes those installs noisy. See
+[[project_system_test_design]] in memory for the design discussion.
+"""
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from prometheus_client import Counter, Gauge
+
+from .constants import _NODE_NAME
+
+logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT_SECONDS = 15
+# Spread requests out across a poll pass rather than firing all use cases at
+# once -- each one already generates real Tetragon events and (if enabled) a
+# real Kafka publish, so a synchronized burst is exactly the kind of load
+# spike this canary shouldn't itself be causing.
+_USE_CASE_STAGGER_SECONDS = 1.0
+
+systemtest_usecase_up = Gauge(
+    'systemtest_usecase_up',
+    '1 if the last system-test run of this use case succeeded, 0 if it failed',
+    ['node_name', 'usecase'],
+)
+
+systemtest_usecase_last_run_timestamp_seconds = Gauge(
+    'systemtest_usecase_last_run_timestamp_seconds',
+    'Unix timestamp of the last system-test run of this use case',
+    ['node_name', 'usecase'],
+)
+
+systemtest_usecase_duration_seconds = Gauge(
+    'systemtest_usecase_duration_seconds',
+    'Duration of the last system-test run of this use case, in seconds',
+    ['node_name', 'usecase'],
+)
+
+systemtest_usecase_run_total = Counter(
+    'systemtest_usecase_run_total',
+    'Total number of system-test runs of this use case, by result',
+    ['node_name', 'usecase', 'result'],
+)
+
+systemtest_all_passing = Gauge(
+    'systemtest_all_passing',
+    '1 if every use case passed its last run, 0 if any failed -- pipeline-health summary',
+    ['node_name'],
+)
+
+systemtest_available = Gauge(
+    'systemtest_available',
+    '1 if the configured test-server was reachable on the last poll, 0 otherwise',
+    ['node_name'],
+)
+
+
+def _fetch_use_case_ids(base_url: str, timeout: float) -> list:
+    with urllib.request.urlopen(f"{base_url}/api/use-cases", timeout=timeout) as resp:
+        payload = json.loads(resp.read())
+    return [uc["id"] for uc in payload]
+
+
+def _call_run_use_case(base_url: str, use_case_id: str, timeout: float):
+    """
+    POSTs an empty params body (every use case runs with its documented
+    defaults) to /api/run/<id>. Returns (ok, detail) -- never raises, since
+    the caller needs a result either way to update the Prometheus gauges.
+    """
+    req = urllib.request.Request(
+        f"{base_url}/api/run/{use_case_id}",
+        data=b"{}",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read())
+            return bool(body.get("ok")), body.get("detail", "")
+    except urllib.error.HTTPError as e:
+        # The test-server always sends a JSON body on its 500s too (see
+        # server.py's _run_use_case) -- prefer that over the bare HTTP status.
+        try:
+            body = json.loads(e.read())
+            return False, body.get("detail", str(e))
+        except Exception:
+            return False, str(e)
+    except Exception as e:
+        return False, str(e)
+
+
+class SystemTestRunner:
+    """Background poller -- one instance per analyzer process. See start()."""
+
+    def __init__(
+        self,
+        base_url: str,
+        interval_seconds: int = 300,
+        use_case_allowlist: Optional[list] = None,
+        request_timeout: float = _REQUEST_TIMEOUT_SECONDS,
+    ):
+        self._base_url = base_url.rstrip('/')
+        self._interval_seconds = interval_seconds
+        self._allowlist = set(use_case_allowlist) if use_case_allowlist else None
+        self._timeout = request_timeout
+        # use_case_id -> bool, last known result. Read back to compute
+        # systemtest_all_passing and to log only on state transitions rather
+        # than spamming the same failure every poll.
+        self._last_result: dict = {}
+        self._was_available: Optional[bool] = None
+
+    def start(self) -> threading.Thread:
+        thread = threading.Thread(target=self._loop, name='system-test', daemon=True)
+        thread.start()
+        return thread
+
+    def _loop(self) -> None:
+        while True:
+            try:
+                self._run_once()
+            except Exception as e:
+                # Must never take the whole daemon thread down -- a single
+                # bad poll (e.g. a malformed /api/use-cases response) should
+                # cost one interval, not silently end system testing for the
+                # rest of the process's life with nothing in the logs to
+                # explain why the gauges stopped moving.
+                logger.error(f"system_test: unexpected error in poll loop: {e}", exc_info=True)
+            time.sleep(self._interval_seconds)
+
+    def _run_once(self) -> None:
+        try:
+            ids = _fetch_use_case_ids(self._base_url, self._timeout)
+        except Exception as e:
+            if self._was_available is not False:
+                logger.warning(f"system_test: test-server at {self._base_url} unreachable: {e}")
+            self._was_available = False
+            systemtest_available.labels(node_name=_NODE_NAME).set(0)
+            return
+
+        if self._was_available is not True:
+            logger.info(f"system_test: test-server at {self._base_url} reachable, {len(ids)} use case(s) registered")
+        self._was_available = True
+        systemtest_available.labels(node_name=_NODE_NAME).set(1)
+
+        if self._allowlist:
+            ids = [i for i in ids if i in self._allowlist]
+
+        for use_case_id in ids:
+            self._run_and_record(use_case_id)
+            time.sleep(_USE_CASE_STAGGER_SECONDS)
+
+        if ids:
+            systemtest_all_passing.labels(node_name=_NODE_NAME).set(
+                1 if all(self._last_result.get(i) for i in ids) else 0
+            )
+
+    def _run_and_record(self, use_case_id: str) -> None:
+        started_at = time.time()
+        ok, detail = _call_run_use_case(self._base_url, use_case_id, self._timeout)
+        duration = time.time() - started_at
+
+        if self._last_result.get(use_case_id) != ok:
+            log = logger.info if ok else logger.warning
+            log(f"system_test '{use_case_id}': {'ok' if ok else 'FAILED'} — {detail}")
+        self._last_result[use_case_id] = ok
+
+        labels = dict(node_name=_NODE_NAME, usecase=use_case_id)
+        systemtest_usecase_up.labels(**labels).set(1 if ok else 0)
+        systemtest_usecase_last_run_timestamp_seconds.labels(**labels).set(time.time())
+        systemtest_usecase_duration_seconds.labels(**labels).set(duration)
+        systemtest_usecase_run_total.labels(**labels, result='success' if ok else 'failure').inc()

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -6761,7 +6761,11 @@ class TestKafkaPublisher:
             for key, value in plain_msg.items():
                 if key == 'pod_annotations':
                     continue  # JSON-encoded in the envelope, checked separately below
+                if key == 'synthetic':
+                    continue  # deliberately absent from the Connect envelope, checked below
                 assert connect_payload[key] == value, f"Mismatch on {key}"
+
+            assert 'synthetic' not in connect_payload
 
     def test_publish_connect_schema_is_stable_across_calls(self, monkeypatch, sample_cert_info):
         """The Connect schema is built once and reused, not rebuilt per message."""


### PR DESCRIPTION
Polls an external test-server's use cases over HTTP on an interval and exposes pass/fail as systemtest_* Prometheus metrics, feeding pipeline health. Degrades silently (never starts) when no test_server_url is configured, since most deployments have no test-server.

Also tags certificate_discovered events as synthetic when they come from the test-server's known generated-cert paths or the analyzer's own bind/connect-probe and uprobe schemes, so fleet/inventory dashboards can filter them out. Left out of the Kafka Connect envelope schema, which doesn't tolerate in-place field additions on an existing topic.


Claude-Session: https://claude.ai/code/session_012vBfgfpQH8HKJbtRQa65V2