### PR TITLE
Document SNI blind spot in bind/connect-probe cert verification

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -2099,6 +2099,16 @@ class CertificateAnalyzer:
         cipher_name = None
         try:
             raw_sock = socket.create_connection((host, port), timeout=self._port_probe_timeout)
+            # KNOWN LIMITATION: server_hostname=host is the raw destination IP,
+            # not the real hostname the original process's TLS ClientHello sent
+            # -- Tetragon's kprobe only sees L3/L4 (connect()/bind()), fired
+            # before any TLS bytes including SNI exist, so there's no real
+            # hostname available here to send. Harmless against a single-tenant
+            # server, but against an SNI-multiplexed CDN edge (Fastly,
+            # Cloudflare, CloudFront, ...) an IP-string SNI matches no real
+            # customer vhost, so the edge falls back to its own generic
+            # default cert instead of the one the real process negotiated.
+            # See extras/PRESENTATION-QA.md's "Scale & Performance" section.
             with ctx.wrap_socket(raw_sock, server_hostname=host) as ssock:
                 raw_sock = None  # SSL socket owns it now; closed by the with-block
                 der_bytes = ssock.getpeercert(binary_form=True)

--- a/extras/PRESENTATION-QA.md
+++ b/extras/PRESENTATION-QA.md
@@ -81,6 +81,9 @@ It's O(1) dedup with no TTL — each unique `host:port` is probed at most once p
 **On a node with thousands of outbound TLS connections, what's the per-event overhead from the eBPF hooks?**
 The `perf_tests/` directory contains `cert_agent_hook_overhead.py` and a companion Java perf test (`CertAgentPerfTest`) that measure hook overhead. Refer to `perf_tests/README.md` for benchmark methodology and results.
 
+**Bind/connect probe against an SNI-multiplexed CDN edge (Fastly, Cloudflare, CloudFront, ...) — does it capture the real certificate?**
+This is a known limitation. The kprobe on `tcp_connect`/`security_socket_bind` only gives Tetragon the destination IP:port (L3/L4) — it fires before any TLS bytes, including the ClientHello's SNI extension, are sent, so cert-analyzer has no way to know what hostname the real process's handshake actually used. `agent/analyzer.py`'s `_probe_and_ingest_tls_cert` (`server_hostname=host`, ~line 2131) has no better option than passing the raw destination IP as SNI on its own verification handshake. Against a single-tenant server this is harmless — but a CDN edge that multiplexes many customer certs by SNI won't match an IP-string SNI to any real vhost, so it falls back to serving its own generic "no SNI match" default certificate instead of the real one the process negotiated. Confirmed live on the AWS demo box (2026-09-01): `dnf`'s outbound package-mirror traffic, fronted by Fastly, probed back as three different destination IPs all resolving to the identical `*.sni-<n>-default.ssl.fastly.net` fallback cert (same SPKI hash *and* same checksum) rather than the mirror's actual certificate. This is a data-fidelity gap in the probe mechanism itself, not a bug in the per-endpoint dedup (see the connect-probe dedup entry above) — dedup is correctly keeping each `host:port` distinct, it's just that some of those "certificates" are the CDN's fallback, not the real one.
+
 ---
 
 ## Security & Compliance


### PR DESCRIPTION
Tetragon's kprobe fires before any TLS bytes (including SNI) exist, so the probe's own verification handshake sends the raw destination IP as server_hostname. Against an SNI-multiplexed CDN edge that returns the edge's generic fallback cert instead of the real one, rather than the certificate the original process actually negotiated.

Confirmed live on the AWS demo box: dnf's Fastly-fronted mirror traffic probed back as several destination IPs all resolving to the identical *.sni-<n>-default.ssl.fastly.net fallback cert. Documented as a known limitation only -- no clean fix exists since the kprobe can't recover the real SNI.