### PR TITLE
Add spki-key-reuse use case demonstrating fleet blast radius's new badge

### DIFF
--- a/extras/test-server/fleet_blast_radius.py
+++ b/extras/test-server/fleet_blast_radius.py
@@ -348,7 +348,21 @@ def _render_group_detail(dimension, value, group, ns_color, idx, node_count):
 
 def _render_dimension_section(dimension, groups, excluded, ns_color, display):
     if groups:
-        ordered = sorted(groups.items(), key=lambda kv: (kv[1]["days_left"], -len(kv[1]["leaves"])))
+        # SPKI mode: key-reuse groups (the checksum-badge condition) sort
+        # first, ahead of expiry urgency -- otherwise they're scattered
+        # across the grid by days-left like any other group, and the badge
+        # is easy to miss unless you scan every card. Checksum mode is
+        # unaffected (distinct_checksums is always 1 there, so this key is
+        # always 1 and falls through to the existing order).
+        if dimension == "spki_hash":
+            sort_key = lambda kv: (
+                0 if kv[1]["distinct_checksums"] > 1 else 1,
+                kv[1]["days_left"],
+                -len(kv[1]["leaves"]),
+            )
+        else:
+            sort_key = lambda kv: (kv[1]["days_left"], -len(kv[1]["leaves"]))
+        ordered = sorted(groups.items(), key=sort_key)
         cards = []
         details = []
         for idx, (value, group) in enumerate(ordered):

--- a/extras/test-server/fleet_blast_radius.py
+++ b/extras/test-server/fleet_blast_radius.py
@@ -441,6 +441,7 @@ def _render_page(all_certs, coverage):
   <button class="mode-btn" id="mode-btn-spki_hash" onclick="setMode('spki_hash')">{blast_radius._esc(spki_label)}</button>
   <button class="mode-btn" id="mode-btn-checksum" onclick="setMode('checksum')">{blast_radius._esc(checksum_label)}</button>
 </div>
+<p class="note">&#128161; Looking for key reuse (one private key backing multiple certificates)? Click <strong>SPKI hash</strong> above -- this page opens on <strong>Checksum</strong> by default, which groups by whole-cert identity and never shows it. In SPKI mode, a group whose members carry more than one distinct checksum gets a badge and sorts to the front.</p>
 <div id="lookup">
   <input type="text" id="lookup-input" placeholder="Paste a checksum or spki_hash to jump to it">
   <button onclick="lookup()">Find</button>

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -452,6 +452,64 @@ def _generate_chain_across_multiple_files(params: dict) -> UseCaseResult:
     )
 
 
+def _generate_key_reused_certs(params: dict) -> UseCaseResult:
+    token = _resolve_token(params)
+    cn_a = f"certsight-test-keyreuse-svc-a-{token}.local"
+    cn_b = f"certsight-test-keyreuse-svc-b-{token}.local"
+
+    # One key, two otherwise-unrelated certs -- the interesting case for
+    # SPKI-based grouping isn't a same-CN renewal (expected, low-risk: an op
+    # keeping a key across rotation), it's the same private key backing two
+    # certs that look unrelated at a glance. That's what the fleet blast
+    # radius explorer's SPKI mode + distinct-checksums badge is for.
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+
+    def _build(cn: str):
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+        return (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
+            .sign(private_key, hashes.SHA256())
+        )
+
+    _GENERATED_CERT_DIR.mkdir(parents=True, exist_ok=True)
+    _GENERATED_CERT_DIR.chmod(0o755)
+
+    written_paths = []
+    for name, cn in (("svc-a", cn_a), ("svc-b", cn_b)):
+        cert = _build(cn)
+        path = _GENERATED_CERT_DIR / f"keyreuse-{name}-{token}.crt"
+        path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+        path.chmod(0o644)
+        try:
+            proc = subprocess.run(["cat", str(path)], capture_output=True, text=True, timeout=10)
+        except subprocess.TimeoutExpired:
+            return UseCaseResult(ok=False, detail=f"cat {path} timed out")
+        if proc.returncode != 0:
+            return UseCaseResult(ok=False, detail=f"cat {path} exited {proc.returncode}: {proc.stderr.strip()}")
+        written_paths.append(path)
+
+    return UseCaseResult(
+        ok=True,
+        detail=(
+            f"generated two certificates (CN={cn_a}, CN={cn_b}) from the same 2048-bit RSA "
+            f"key and cat'd each from its own path -- same SPKI hash, different subjects and "
+            f"checksums, simulating the same private key backing two unrelated-looking "
+            f"services. Open the [fleet blast radius explorer](/fleet-blast-radius), switch "
+            f"to SPKI mode, and look for a shared-key group carrying a '2 checksums' badge -- "
+            f"its detail table should list both certs above under different common names"
+        ),
+        token=token,
+    )
+
+
 # tls_probe_helper.py runs as its own OS process (not a thread here) so that
 # Tetragon's security_socket_bind hook attributes the bind() call to a PID
 # that's independently visible and verifiable, rather than this test
@@ -1684,6 +1742,54 @@ USE_CASES: List[UseCase] = [
             "even with intermediates dropped here, this use case only ever "
             "demonstrates the FOUND ELSEWHERE state, not MISSING -- use the "
             "single-bundle use case above for that.",
+        ],
+    ),
+    UseCase(
+        id="spki-key-reuse",
+        label="reuse one key across two unrelated certs",
+        description=(
+            "Generates two certificates from the same RSA key but with "
+            "different subjects, simulating the same private key backing "
+            "two unrelated-looking services -- unlike a same-CN renewal "
+            "(expected, low-risk key preservation across rotation), this is "
+            "the SPKI-reuse shape that's actually worth flagging. Check the "
+            "fleet blast radius explorer's SPKI mode for the resulting "
+            "shared-key group and its distinct-checksums badge."
+        ),
+        run=_generate_key_reused_certs,
+        pipeline=[
+            "This server generates one 2048-bit RSA key, then builds two "
+            "independent self-signed X.509 certificates from it -- same "
+            "public key both times, different subject/SAN and serial "
+            "number -- and writes each to its own brand-new path under "
+            f"{_GENERATED_CERT_DIR}/.",
+
+            "This server runs 'cat <path>' against each file individually "
+            "-- two real open()/read() calls, same as the multi-file chain "
+            "use case above.",
+
+            "Tetragon's kprobe on fd_install fires once per file via the "
+            "certificate-file-access.yaml TracingPolicy, and CertSight "
+            "discovers each as its own independent cert_path.",
+
+            "CertSight parses both certs and computes each one's SPKI hash "
+            "(SHA-256 of the DER-encoded public key) and checksum (SHA-256 "
+            "of the whole DER cert). The public key bytes are identical "
+            "between the two, so their spki_hash values match even though "
+            "every other field -- subject, serial, checksum -- differs.",
+
+            "CertSight records each cert as its own first-time discovery "
+            "(unique path + serial) and -- since [kafka] enabled = true -- "
+            "publishes a 'certificate_discovered' event per file to the "
+            "cert-analyzer-events Kafka topic, pushed to the browser the "
+            "same way as every other use case here.",
+
+            "Open the [fleet blast radius explorer](/fleet-blast-radius) "
+            "afterwards and switch to SPKI mode: both certs group under "
+            "the one spki_hash value, and since they carry two distinct "
+            "checksums the overview card shows a '2 checksums' badge -- "
+            "the at-a-glance signal that this key backs more than one "
+            "logically distinct certificate.",
         ],
     ),
 ]

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -502,9 +502,11 @@ def _generate_key_reused_certs(params: dict) -> UseCaseResult:
             f"generated two certificates (CN={cn_a}, CN={cn_b}) from the same 2048-bit RSA "
             f"key and cat'd each from its own path -- same SPKI hash, different subjects and "
             f"checksums, simulating the same private key backing two unrelated-looking "
-            f"services. Open the [fleet blast radius explorer](/fleet-blast-radius), switch "
-            f"to SPKI mode, and look for a shared-key group carrying a '2 checksums' badge -- "
-            f"its detail table should list both certs above under different common names"
+            f"services. Open the [fleet blast radius explorer](/fleet-blast-radius) and click "
+            f"the 'SPKI hash' button near the top -- it opens on 'Checksum' by default, which "
+            f"won't show this. In SPKI mode, badged groups (key reuse) now sort first, so the "
+            f"one from this run should be at or near the top of the grid; its detail table "
+            f"lists both certs above under different common names"
         ),
         token=token,
     )
@@ -1752,9 +1754,10 @@ USE_CASES: List[UseCase] = [
             "different subjects, simulating the same private key backing "
             "two unrelated-looking services -- unlike a same-CN renewal "
             "(expected, low-risk key preservation across rotation), this is "
-            "the SPKI-reuse shape that's actually worth flagging. Check the "
-            "fleet blast radius explorer's SPKI mode for the resulting "
-            "shared-key group and its distinct-checksums badge."
+            "the SPKI-reuse shape that's actually worth flagging. Afterwards, "
+            "open the fleet blast radius explorer and click the 'SPKI hash' "
+            "button near the top (it opens on 'Checksum' by default) to see "
+            "the resulting shared-key group and its distinct-checksums badge."
         ),
         run=_generate_key_reused_certs,
         pipeline=[
@@ -1785,11 +1788,14 @@ USE_CASES: List[UseCase] = [
             "same way as every other use case here.",
 
             "Open the [fleet blast radius explorer](/fleet-blast-radius) "
-            "afterwards and switch to SPKI mode: both certs group under "
-            "the one spki_hash value, and since they carry two distinct "
-            "checksums the overview card shows a '2 checksums' badge -- "
-            "the at-a-glance signal that this key backs more than one "
-            "logically distinct certificate.",
+            "afterwards and click 'SPKI hash' near the top -- it opens on "
+            "'Checksum' by default, which groups by whole-cert identity and "
+            "won't show this. In SPKI mode both certs group under the one "
+            "spki_hash value, and since they carry two distinct checksums "
+            "the overview card shows a '2 checksums' badge -- the at-a-"
+            "glance signal that this key backs more than one logically "
+            "distinct certificate. Badged groups sort first in SPKI mode, "
+            "so this one should be near the top of the grid.",
         ],
     ),
 ]


### PR DESCRIPTION
Generates two certificates from one RSA key but with different subjects/serials -- same SPKI hash, different checksums -- simulating the same private key backing two unrelated-looking services, as opposed to a same-CN renewal (expected, low-risk key preservation across rotation). Makes the distinct-checksums badge added to the fleet blast radius overview (ddbb922) demoable without hand-crafting certs.

No new helper file needed -- unlike every other use case with a dedicated process/socket step, cert generation + cat happens directly in use_cases.py (same pattern as fresh-test-cert and the chain-explorer use cases), so this doesn't touch the RPM spec/build-rpm.sh/Containerfile glob-based packaging fixed earlier this session.

Verified locally: ran _generate_key_reused_certs() directly and confirmed both certs' DER-encoded SubjectPublicKeyInfo bytes are identical (same SPKI hash) while their full DER encodings differ (different checksum) -- the exact condition the badge fires on.