### PR TITLE
Upgrade cryptography 41.0.7 -> 50.0.1, fixing all deferred CVEs

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -7,113 +7,29 @@
 # blanket exemption: each entry has a specific, checked reason, and an expiry
 # date that forces a re-review rather than letting an ignore go stale forever.
 #
-# cryptography==41.0.7, protobuf==4.25.3, and kafka-python==2.0.3 are all
-# several versions behind their patched releases (cryptography needs
-# 42.0-46.x depending on the CVE; protobuf needs 4.25.8+ or 5.29.6+;
-# kafka-python needs 2.3.2+). Upgrading is the real fix and is tracked as
-# separate follow-up work, since protobuf 5.x has known generated-code
-# breaking changes and all three are security-sensitive parsing/protocol
-# libraries that deserve a dedicated, tested upgrade rather than a
-# drive-by version bump here.
+# cryptography was upgraded 41.0.7 -> 50.0.1 on 2026-09-04, clearing every
+# cryptography CVE that was previously deferred here (including
+# CVE-2026-69247, a Bleichenbacher-oracle finding only fixed in >=50.0.0 --
+# 46.x, this policy's first target, still had it).
+#
+# protobuf==4.25.3 and kafka-python==2.0.3 remain several versions behind
+# their patched releases (protobuf needs 4.25.8+ or 5.29.6+; kafka-python
+# needs 2.3.2+). Upgrading is the real fix and is tracked as separate
+# follow-up work, since protobuf 5.x has known generated-code breaking
+# changes and both are security-sensitive parsing/protocol libraries that
+# deserve a dedicated, tested upgrade rather than a drive-by version bump
+# here.
 security:
     ignore-unpinned-requirements: True  # psutil and kubernetes are deliberately unpinned
     ignore-cvss-severity-below: 0
     ignore-cvss-unknown-severity: False
     ignore-vulnerabilities:
-        # -- cryptography 41.0.7 --------------------------------------------
-        65647: # CVE PVE-2024-65647 -- DoS via unbounded name-constraint checks during X.509 path validation
-            reason: >-
-                Real exposure: the analyzer does perform self-signed/chain checks
-                (verify_directly_issued_by, chain-length/missing-intermediate
-                detection) against certs read from arbitrary host paths. Prioritize
-                the cryptography upgrade over other entries in this list.
-            expires: '2026-10-04'
-        65212: # CVE-2023-6129 -- POLY1305 MAC flaw on PowerPC CPUs
-            reason: "Not applicable: x86_64 target only, and this app performs no MAC operations."
-            expires: '2026-10-04'
-        71681: # CVE-2024-4603 -- DSA key-check DoS via direct EVP_PKEY_param_check/EVP_PKEY_public_check calls
-            reason: "Not applicable: this app never calls these DSA check functions directly."
-            expires: '2026-10-04'
-        65510: # CVE-2023-5678 -- DH key generation/verification DoS with overly long parameters
-            reason: "Not applicable: this app never generates or verifies DH keys."
-            expires: '2026-10-04'
-        SFTY-20240205-03700: # CVE-2023-50782 -- RSA decrypt timing oracle (Marvin attack) in TLS servers
-            reason: "Not applicable: this app is not a TLS server and never performs RSA decryption."
-            expires: '2026-10-04'
-        71684: # CVE-2024-2511 -- unbounded memory growth in TLSv1.3 sessions on TLS servers
-            reason: "Not applicable: advisory explicitly states TLS clients are not affected, and this app never runs as a TLS server."
-            expires: '2026-10-04'
-        66777: # CVE-2023-6237 -- slow validation of excessively long RSA public keys (DoS)
-            reason: >-
-                Low relevance: this app does parse RSA keys from untrusted host
-                files/probed endpoints, so an oversized key could cause a slow
-                validation, but this is a much smaller-scale DoS surface (bounded
-                by per-file/per-endpoint processing) than the cryptography-upgrade
-                work already tracked via #65647 above.
-            expires: '2026-10-04'
-        SFTY-20260327-04621: # CVE-2026-34073 -- incomplete DNS name-constraint enforcement on peer names
-            reason: >-
-                Not applicable: this app never uses hostname/name-constraint
-                verification for access-control decisions -- TLS probes run with
-                check_hostname=False (inventory only, not authentication), and
-                file-based cert inventory doesn't gate access on hostname matching.
-            expires: '2026-10-04'
-        86217: # CVE-2026-26007 -- missing prime-order subgroup validation for SECT elliptic-curve public keys
-            reason: >-
-                Real exposure: the analyzer does call load_der_x509_certificate/
-                load_pem_x509_certificate on arbitrary, potentially attacker-
-                influenced certs (host filesystem, TLS probes). Prioritize the
-                cryptography upgrade over other entries in this list.
-            expires: '2026-10-04'
-        66704: # CVE-2024-26130 -- NULL pointer deref in pkcs12.serialize_key_and_certificates
-            reason: "Not applicable: this app only ever loads/reads PKCS12 files, never serializes/writes them."
-            expires: '2026-10-04'
-        SFTY-20260615-96125: # GHSA-537c-gmf6-5ccf / CVE-2026-34180 -- vendored OpenSSL ASN.1 integer-truncation OOB read in d2i_X509-style DER decoding
-            reason: >-
-                Real exposure: cryptography's PyPI wheels vendor a statically
-                linked OpenSSL affected by CVE-2026-34180, an integer-truncation
-                out-of-bounds read in ASN.1 content-length handling reachable via
-                d2i_X509/d2i_PKCS7-style DER decoding -- the exact path
-                load_der_x509_certificate/load_pem_x509_certificate take when
-                parsing certs from arbitrary host paths and TLS probes. Tracked as
-                part of the same cryptography upgrade as the other entries in this
-                list.
-            expires: '2026-10-04'
-        73711: # PVE-2024-73711 -- generic advisory covering cryptography's vendored OpenSSL CVEs
-            reason: >-
-                Broad/generic catch-all advisory rather than a specific exploit
-                path against this app's usage; tracked as part of the same
-                cryptography upgrade as the other entries in this list.
-            expires: '2026-10-04'
-        71680: # CVE-2024-0727 -- NULL pointer dereference (process crash) loading a malformed PKCS12 file
-            reason: >-
-                Real exposure -- the highest-priority entry in this list. The
-                analyzer calls load_pkcs12() directly on untrusted PKCS12/.p12/.pfx
-                files found on the host filesystem, and a NULL pointer
-                dereference is a native crash that no Python try/except can catch.
-                Prioritize the cryptography upgrade.
-            expires: '2026-10-04'
-        SFTY-20260803-29229: # CVE-2026-69249 -- DoS via exponential path-building on duplicate self-signed intermediates in build_chain_inner
-            reason: >-
-                Not applicable: the vulnerable path is cryptography's
-                PolicyBuilder/build_chain multi-candidate path-validation API
-                (cryptography.x509.verification), never called by this codebase.
-                The only path-validation-adjacent call is the single-cert
-                self-signed check at analyzer.py:857
-                (cert.verify_directly_issued_by(cert), one candidate checked
-                against itself, not a multi-certificate chain build), which
-                can't exhibit the reported exponential blowup across duplicate
-                self-signed intermediates.
-            expires: '2026-10-04'
-        SFTY-20260803-89041: # CVE-2026-69248 -- improper certificate validation via wildcard DNS SAN bypass in DNSConstraint.matches
-            reason: >-
-                Not applicable: same PolicyBuilder-based path-validation API as
-                SFTY-20260803-29229 above, specifically its
-                DNSConstraint/NameConstraints enforcement -- this app never
-                calls that verifier, and TLS probes run with
-                check_hostname=False (inventory only, not authentication; same
-                reasoning as SFTY-20260327-04621 above).
-            expires: '2026-10-04'
+        # cryptography's 41.0.7-era entries (65647, 65212, 71681, 65510,
+        # SFTY-20240205-03700, 71684, 66777, SFTY-20260327-04621, 86217,
+        # 66704, SFTY-20260615-96125, 73711, 71680, SFTY-20260803-29229,
+        # SFTY-20260803-89041, and SFTY-20260803-51569) were removed
+        # 2026-09-04: fixed by the 41.0.7 -> 50.0.1 upgrade, confirmed via a
+        # clean `safety check` run against the new pin.
         # -- protobuf 4.25.3 --------------------------------------------------
         85151: # CVE-2026-0994 -- DoS via missing recursion-depth accounting when parsing protobuf messages
             reason: >-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ grpcio==1.60.1
 grpcio-tools==1.60.1
 protobuf==4.25.3
 prometheus-client==0.19.0
-cryptography==41.0.7      # also provides PKCS12 (.p12/.pfx) support
+cryptography==50.0.1      # also provides PKCS12 (.p12/.pfx) support
 pyyaml==6.0.1
 kubernetes>=28.1.0
 pyjks==20.0.0             # JKS (.jks/.keystore/.truststore) support


### PR DESCRIPTION
Actually fixes rather than defers the cryptography vulnerabilities tracked in .safety-policy.yml: bumped past 46.x (this policy's original target) all the way to 50.0.1 after discovering CVE-2026-69247 (a Bleichenbacher-oracle finding, affected range >=44.0.0,<50.0.0) is only patched at 50.0.0+, and 46.x would have traded the old CVEs for a new unpatched one. Verified the full test suite (552 tests) and pyjks import cleanly against the new pin with no deprecation warnings from production code, then confirmed `safety check -r requirements.txt --policy-file .safety-policy.yml` now exits 0 with zero cryptography findings. Trimmed the now-resolved cryptography entries out of the policy file; protobuf and kafka-python stay deferred as separate follow-up work.