### PR TITLE
Fix uprobe-cert DoS gap and LRUCache index staleness from security re…

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -145,6 +145,7 @@ class CertificateAnalyzer(
                  max_concurrent_background_threads: int = 20,
                  max_processes_per_cert: int = 20,
                  new_cert_events_per_second: float = 50.0,
+                 uprobe_cert_events_per_second: float = 50.0,
                  retry_queue_max_size: int = 2000,
                  scan_paths: Optional[list] = None,
                  scan_interval_seconds: int = 3600,
@@ -200,6 +201,22 @@ class CertificateAnalyzer(
         self._rate_limit_log_lock = threading.Lock()
         self._rate_limit_last_log_time = 0.0
         self._rate_limit_dropped_since_log = 0
+        # Separate token bucket for the PKCS11/NSS and in-memory-DER uprobe
+        # discovery paths (agent/java_fips.py): those bypass
+        # _new_cert_rate_limiter entirely (see the comment on
+        # _handle_nsc_create_object) and are deduped only on a synthetic
+        # pid+serial path, trivially defeated by a compromised/malicious
+        # process on the node varying the injected certificate's serial
+        # number on every call -- with no limiter of its own, that path had
+        # no ceiling on how much extract_certificate_info/logging/Kafka-
+        # publish work it could force per second. Kept as its own bucket
+        # rather than sharing _new_cert_rate_limiter's so a flood of forged
+        # uprobe captures can't also starve real file-based cert discovery
+        # of its budget.
+        self._uprobe_cert_rate_limiter = _TokenBucket(uprobe_cert_events_per_second)
+        self._uprobe_rate_limit_log_lock = threading.Lock()
+        self._uprobe_rate_limit_last_log_time = 0.0
+        self._uprobe_rate_limit_dropped_since_log = 0
         # A rate-limited file isn't dropped -- it's queued here and replayed
         # by the retry-queue drainer thread once capacity frees up, with its
         # *original* triggering process/pod context intact (unlike
@@ -237,6 +254,7 @@ class CertificateAnalyzer(
             'large_file_byte_cap':                 str(large_file_byte_cap),
             'max_concurrent_background_threads':   str(max_concurrent_background_threads),
             'new_cert_events_per_second':          str(new_cert_events_per_second),
+            'uprobe_cert_events_per_second':       str(uprobe_cert_events_per_second),
             'retry_queue_max_size':                str(retry_queue_max_size),
             'max_processes_per_cert':              str(max_processes_per_cert),
             'alert_threshold_days':                str(alert_threshold_days),
@@ -379,6 +397,37 @@ class CertificateAnalyzer(
             # thread that's mutating the cache (event consumer, periodic scan,
             # or a background parse worker).
             logger.debug(f"Could not remove Prometheus metrics for evicted cert {key}: {e}")
+
+    def _path_has_live_known_cert(self, cert_path: str) -> bool:
+        """
+        True if cert_path has at least one entry that's *actually* still
+        present in known_certs right now -- not just listed in the
+        _known_paths secondary index.
+
+        _known_paths is populated/depopulated by known_certs's on_set/
+        on_evict callbacks (_index_known_cert/_deindex_known_cert), which
+        LRUCache invokes *after* releasing its own internal lock (see
+        agent/cache.py's __setitem__) so it can't hold that lock across an
+        arbitrary caller-supplied callback. That means _known_paths can be
+        transiently stale relative to known_certs's real contents: a reader
+        checking _known_paths_lock alone can catch a path as "known" a
+        moment before it's actually inserted, or a moment after its last
+        entry was actually evicted -- two independently-locked pieces of
+        state that don't move together atomically.
+
+        process_event's own known-file loop already tolerates this per-key
+        (each iteration does its own known_certs.get() and skips a None
+        gracefully); this is the same defensive check for callers --
+        periodic_scan and the retry-queue drainer -- that only want a single
+        yes/no answer and, critically, treat "yes" as a reason to skip work
+        entirely. A false positive there would silently and *permanently*
+        drop legitimate work rather than just delay it, so it's worth the
+        extra known_certs lookups given neither caller is a per-event hot
+        path.
+        """
+        with self._known_paths_lock:
+            keys = list(self._known_paths.get(cert_path, ()))
+        return any(self.known_certs.get(k) is not None for k in keys)
 
     def _update_cache_metrics(self) -> None:
         """Update Prometheus gauges reflecting current LRU cache occupancy."""
@@ -624,10 +673,21 @@ class CertificateAnalyzer(
                 pod_uid = tetragon_pod.uid if tetragon_pod is not None else ""
                 container_id = tetragon_pod.container.id if tetragon_pod is not None else ""
                 container_image = tetragon_pod.container.image.name if tetragon_pod is not None else ""
+            # Tracks whether any candidate key actually resolved -- _known_paths
+            # (this loop's source of matching_keys) can be transiently stale
+            # relative to known_certs's real contents (see
+            # _path_has_live_known_cert's docstring), so it's possible for
+            # every single key here to have already been evicted. Without this,
+            # that edge case would still hit the unconditional `return` below,
+            # silently and permanently treating a now-untracked path as
+            # "already known, nothing to do" instead of falling through to
+            # rediscover it as new.
+            any_live = False
             for i, key in enumerate(matching_keys):
                 cert_info = self.known_certs.get(key)
                 if cert_info is None:  # evicted between snapshot and access
                     continue
+                any_live = True
                 # cert_info is already published/cached and may be read
                 # concurrently by probe threads, the retry drainer, or another
                 # event-consumer iteration -- pod_name/namespace/node_name/etc.
@@ -665,14 +725,24 @@ class CertificateAnalyzer(
                         container_image=container_image,
                     )
 
-            if is_bundle:
+            if is_bundle and any_live:
                 logger.info(
                     f"{cert_path}: re-access by {process_name} covers "
                     f"{len(matching_keys)} cached certs — tracked process-access "
                     f"for the first {metrics_cap}; {len(matching_keys) - metrics_cap} "
                     f"more skipped to bound cert_process_info cardinality"
                 )
-            return
+            if any_live:
+                return
+            # Every candidate key from _known_paths turned out to be already
+            # evicted from known_certs -- this path isn't actually known
+            # anymore (the secondary index was just stale), so fall through
+            # to the large-file/new-file handling below to rediscover it
+            # instead of silently dropping it here.
+            logger.debug(
+                "%s: _known_paths listed %d stale key(s) with no live known_certs "
+                "entry -- treating as a new file", cert_path, len(matching_keys),
+            )
 
         # Large multi-cert files (e.g. system CA bundles with hundreds of
         # certs, or an oversized JKS/PKCS12 keystore) are parsed on a
@@ -848,9 +918,13 @@ class CertificateAnalyzer(
                     # would re-publish "new discovery" Kafka messages for certs that
                     # aren't new. Genuinely new files fall through to the same
                     # threshold-routed / metrics-capped path Tetragon events use.
-                    with self._known_paths_lock:
-                        if cert_path in self._known_paths:
-                            continue
+                    # _path_has_live_known_cert (not a bare _known_paths check)
+                    # confirms against known_certs itself -- see its own
+                    # docstring for why a bare membership check here could
+                    # wrongly and permanently skip a file whose _known_paths
+                    # entry is transiently stale.
+                    if self._path_has_live_known_cert(cert_path):
+                        continue
 
                     if self._is_large_certificate_file(cert_path):
                         self._process_certificate_file_async(

--- a/agent/config.py
+++ b/agent/config.py
@@ -214,6 +214,15 @@ def main():
     # FIFO so this can't become a second unbounded memory sink for the same
     # abuse new_cert_events_per_second defends against.
     retry_queue_max_size = cfg_int(cp, 'certificates', 'retry_queue_max_size', 'RETRY_QUEUE_MAX_SIZE', '2000')
+    # Separate token bucket for the PKCS11/NSS and in-memory-DER uprobe
+    # discovery paths (agent/java_fips.py), which bypass
+    # new_cert_events_per_second entirely -- those paths are dedup'd only on
+    # a synthetic pid+serial path, trivially defeated by an attacker-
+    # controlled process varying the injected certificate's serial number on
+    # every call. Kept as its own bucket rather than sharing
+    # new_cert_events_per_second's so a flood of forged uprobe captures can't
+    # also starve legitimate file-based cert discovery of its own budget.
+    uprobe_cert_events_per_second = cfg_float(cp, 'certificates', 'uprobe_cert_events_per_second', 'UPROBE_CERT_EVENTS_PER_SECOND', '50')
 
     event_rate_metrics_enabled = cfg(cp, 'metrics', 'event_rate_metrics_enabled', 'EVENT_RATE_METRICS_ENABLED', 'false').lower() == 'true'
 
@@ -274,6 +283,7 @@ def main():
     logger.info(f"Max processes tracked per cert: {max_processes_per_cert}")
     logger.info(f"New-cert analysis rate limit: {new_cert_events_per_second}/sec" if new_cert_events_per_second > 0 else "New-cert analysis rate limit: disabled")
     logger.info(f"Rate-limit retry queue max size: {retry_queue_max_size}")
+    logger.info(f"Uprobe-cert analysis rate limit: {uprobe_cert_events_per_second}/sec" if uprobe_cert_events_per_second > 0 else "Uprobe-cert analysis rate limit: disabled")
     logger.info(f"Metrics port:      {metrics_port}")
     logger.info(f"Min scrape interval: {min_scrape_interval}s (too-frequent scrapes get a cached reply)" if min_scrape_interval > 0 else "Min scrape interval: disabled")
     logger.info(f"Health port:       {health_port}")
@@ -350,6 +360,7 @@ def main():
                                    max_concurrent_background_threads=max_concurrent_background_threads,
                                    max_processes_per_cert=max_processes_per_cert,
                                    new_cert_events_per_second=new_cert_events_per_second,
+                                   uprobe_cert_events_per_second=uprobe_cert_events_per_second,
                                    retry_queue_max_size=retry_queue_max_size,
                                    scan_paths=scan_paths,
                                    scan_interval_seconds=scan_interval,

--- a/agent/java_fips.py
+++ b/agent/java_fips.py
@@ -7,6 +7,8 @@ see that module's docstring for the full list of mixins CertificateAnalyzer
 composes. _JavaFipsMixin assumes the composing class provides the instance
 state set up in CertificateAnalyzer.__init__ (self.filter_self_events,
 self.known_certs, self._known_paths/_known_paths_lock, self._recent_client_sni,
+self._uprobe_cert_rate_limiter, self._uprobe_rate_limit_log_lock/
+_uprobe_rate_limit_last_log_time/_uprobe_rate_limit_dropped_since_log,
 self.metrics, self.kafka_publisher, self.last_event_time) and methods from its
 sibling mixins (self._resolve_process_binary, self._is_self_event,
 self.extract_certificate_info, self._apply_pod_context,
@@ -31,6 +33,30 @@ class _JavaFipsMixin:
     PKCS11/NSS helpers (Java FIPS mode) plus the generic in-memory-DER-bytes
     uprobe handler. Mixed into CertificateAnalyzer -- see module docstring.
     """
+
+    def _log_rate_limited_uprobe_cert(self, synthetic_path: str) -> None:
+        """
+        Log a uprobe-cert rate-limit hit at most once every 10 seconds, with
+        a count of how many were dropped in between -- mirrors
+        _log_rate_limited_new_cert's throttling in agent/retry_queue.py, kept
+        as a separate counter/lock here since these are a different trigger
+        (uprobe captures, not file discovery) and shouldn't share one
+        dropped-count with it.
+        """
+        with self._uprobe_rate_limit_log_lock:
+            self._uprobe_rate_limit_dropped_since_log += 1
+            now = time.monotonic()
+            if now - self._uprobe_rate_limit_last_log_time < 10.0:
+                return
+            dropped = self._uprobe_rate_limit_dropped_since_log
+            self._uprobe_rate_limit_dropped_since_log = 0
+            self._uprobe_rate_limit_last_log_time = now
+        logger.warning(
+            f"Uprobe-cert analysis rate limit reached (most recently for {synthetic_path}) -- "
+            f"{dropped} uprobe capture(s) skipped in the last ~10s. Tune via "
+            f"[certificates] uprobe_cert_events_per_second in cert-analyzer.conf or "
+            f"UPROBE_CERT_EVENTS_PER_SECOND."
+        )
 
     @staticmethod
     def _read_process_memory(pid: int, address: int, size: int) -> Optional[bytes]:
@@ -163,18 +189,27 @@ class _JavaFipsMixin:
             logger.info(f"Re-detected known Java FIPS certificate: {synthetic_path}")
             return True
 
+        # Bypasses _analyze_and_finish_new_certificate_file's file-oriented
+        # rate limiter/retry queue -- this isn't a file, and a throttled
+        # capture can't be usefully "replayed" later (the bytes only existed
+        # transiently in the discovering process's memory) -- but is gated by
+        # its own _uprobe_cert_rate_limiter instead. The _known_paths dedup
+        # above only catches an *identical* replay: a compromised or
+        # malicious process on the node can call NSC_CreateObject with a
+        # freshly forged certificate (a different serial every time) as fast
+        # as it likes, trivially defeating that dedup, so without a
+        # throughput ceiling here this path had no bound on how much
+        # extract_certificate_info/logging/Kafka-publish cost it could force
+        # per second.
+        if not self._uprobe_cert_rate_limiter.try_acquire():
+            self._log_rate_limited_uprobe_cert(synthetic_path)
+            self.metrics.cert_analysis_errors.labels(error_type='uprobe_rate_limited', node_name=self.metrics._node_name).inc()
+            return False
+
         cert_info = self.extract_certificate_info(cert, synthetic_path, process_name, pid, namespace)
         if cert_info is None:
             return False
 
-        # Deliberately bypasses _analyze_and_finish_new_certificate_file's
-        # rate limiter/retry queue: that machinery exists to protect against
-        # bulk-file floods (e.g. a directory of thousands of certs, or a scan
-        # sweeping many paths at once). A NSC_CreateObject uprobe fires once
-        # per PKCS11 object creation -- inherently low-volume and already
-        # deduped per pid+serial via the _known_paths check above -- so
-        # rate-limiting it would only drop real, rare captures with no
-        # cardinality benefit.
         self._apply_pod_context(cert_info, tetragon_pod)
         cert_info.node_name      = event.node_name
         cert_info.parent_process = parent_process
@@ -335,16 +370,22 @@ class _JavaFipsMixin:
             logger.info(f"Re-detected known in-memory certificate: {synthetic_path}")
             return True
 
+        # Bypasses _analyze_and_finish_new_certificate_file's file-oriented
+        # rate limiter/retry queue but is gated by its own
+        # _uprobe_cert_rate_limiter -- see the identical comment in
+        # _handle_nsc_create_object. In-memory DER captures (e.g. via
+        # SSL_CTX_use_certificate_ASN1) are dedup'd only by pid+serial, which
+        # a compromised/malicious process can trivially defeat by forging a
+        # different serial on every call.
+        if not self._uprobe_cert_rate_limiter.try_acquire():
+            self._log_rate_limited_uprobe_cert(synthetic_path)
+            self.metrics.cert_analysis_errors.labels(error_type='uprobe_rate_limited', node_name=self.metrics._node_name).inc()
+            return False
+
         cert_info = self.extract_certificate_info(cert, synthetic_path, process_name, pid, namespace)
         if cert_info is None:
             return False
 
-        # Deliberately bypasses _analyze_and_finish_new_certificate_file's
-        # rate limiter/retry queue -- see the identical comment in
-        # _handle_nsc_create_object. In-memory DER captures (e.g. via
-        # SSL_CTX_use_certificate_ASN1) are low-volume and already deduped
-        # per pid+serial via the _known_paths check above, so there's no
-        # flood scenario here for the rate limiter to guard against.
         self._apply_pod_context(cert_info, tetragon_pod)
         cert_info.node_name      = event.node_name
         cert_info.parent_process = parent_process

--- a/agent/retry_queue.py
+++ b/agent/retry_queue.py
@@ -8,11 +8,11 @@ instance state set up in CertificateAnalyzer.__init__ (self._rate_limit_log_lock
 self._rate_limit_dropped_since_log, self._rate_limit_last_log_time,
 self.processed_paths, self.known_certs, self.kafka_publisher, self.metrics,
 self._new_cert_rate_limiter, self._retry_queue/_retry_queue_lock/
-_retry_queue_paths/_retry_queue_max_size, self._known_paths/_known_paths_lock)
-and methods from its sibling mixins (self.parse_certificates,
-self.extract_certificate_info, self._apply_pod_context,
-self.log_certificate_status, self._snapshot_pod_context) and the core class
-(self._update_cache_metrics).
+_retry_queue_paths/_retry_queue_max_size) and methods from its sibling
+mixins (self.parse_certificates, self.extract_certificate_info,
+self._apply_pod_context, self.log_certificate_status,
+self._snapshot_pod_context) and the core class (self._update_cache_metrics,
+self._path_has_live_known_cert).
 """
 import logging
 import threading
@@ -362,10 +362,11 @@ class _RateLimitRetryQueueMixin:
                 # unrelated event (a fresh Tetragon re-access, or
                 # periodic_scan finding it under scan_paths) since it was
                 # queued -- drop it without spending a token on a no-op
-                # replay.
-                with self._known_paths_lock:
-                    already_known = entry.cert_path in self._known_paths
-                if already_known:
+                # replay. _path_has_live_known_cert (not a bare _known_paths
+                # check) confirms against known_certs itself -- see its own
+                # docstring for why a bare membership check here could
+                # wrongly and permanently drop a still-needed retry.
+                if self._path_has_live_known_cert(entry.cert_path):
                     with self._retry_queue_lock:
                         if self._retry_queue and self._retry_queue[0] == entry:
                             self._retry_queue.popleft()

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -2875,6 +2875,93 @@ class TestKnownCertsIndex:
         assert len(analyzer._known_paths) == 0
 
 
+class TestPathHasLiveKnownCert:
+    """
+    Tests for _path_has_live_known_cert (agent/analyzer.py) -- confirms a
+    _known_paths hit against known_certs itself before treating "known" as a
+    reason to skip work, since _known_paths is populated/depopulated by
+    on_set/on_evict callbacks LRUCache invokes *after* releasing its own
+    internal lock, so it can be transiently stale relative to known_certs's
+    real contents. Used by periodic_scan, the retry-queue drainer, and
+    process_event's known-file loop (see TestProcessEventFallsThroughOnStaleIndex).
+    """
+
+    def test_true_when_entry_present(self, analyzer, temp_dir):
+        """Sanity check: a real known_certs entry for the path reads as live."""
+        cert, _ = TestCertificateGeneration.generate_certificate("live-check.example.com", 365)
+        path = os.path.join(temp_dir, "live-check.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+        cert_infos = analyzer.analyze_certificate(path, "test", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+
+        assert analyzer._path_has_live_known_cert(path) is True
+
+    def test_false_for_unknown_path(self, analyzer):
+        assert analyzer._path_has_live_known_cert("/no/such/path.pem") is False
+
+    def test_false_when_known_paths_index_is_stale(self, analyzer):
+        """
+        A _known_paths entry with no matching known_certs entry -- exactly
+        the race window on_set/on_evict callbacks running outside
+        LRUCache's own lock can create -- must not read as live.
+        """
+        analyzer._known_paths["/stale/path.pem"] = {"/stale/path.pem:0:1"}
+        assert analyzer._path_has_live_known_cert("/stale/path.pem") is False
+
+    def test_true_when_at_least_one_of_several_keys_is_live(self, analyzer, temp_dir):
+        """A bundle path with some evicted and some live keys still reads as live."""
+        cert, _ = TestCertificateGeneration.generate_certificate("partial-bundle.example.com", 365)
+        path = os.path.join(temp_dir, "partial-bundle.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+        cert_infos = analyzer.analyze_certificate(path, "test", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+
+        # Add a second, stale key under the same path without a matching
+        # known_certs entry.
+        analyzer._known_paths[path].add(f"{path}:1:stale-serial")
+
+        assert analyzer._path_has_live_known_cert(path) is True
+
+
+class TestProcessEventFallsThroughOnStaleIndex:
+    """
+    process_event's known-file loop must not treat a path as "already known,
+    nothing to do" when every _known_paths-indexed key for it has actually
+    been evicted from known_certs -- see _path_has_live_known_cert's
+    docstring for why that index can be transiently stale. Before this fix,
+    that edge case hit the loop's unconditional `return`, permanently
+    dropping the file instead of falling through to rediscover it.
+    """
+
+    def test_rediscovers_file_when_known_paths_index_is_stale(self, analyzer, temp_dir):
+        cert, _ = TestCertificateGeneration.generate_certificate("stale-index.example.com", 365)
+        path = os.path.join(temp_dir, "stale-index.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+
+        # Simulate the stale-index race directly: _known_paths claims this
+        # path is known, but known_certs has nothing under that key.
+        analyzer._known_paths[path] = {f"{path}:0:999"}
+        assert len(analyzer.known_certs) == 0
+
+        analyzer.process_event(TestCacheHitReDetection._MockEvent(path, '/usr/bin/cat'))
+
+        assert any(k.startswith(path + ":") for k in analyzer.known_certs)
+
+    def test_does_not_rediscover_when_index_is_genuinely_live(self, analyzer, temp_dir):
+        """Control case: a real (non-stale) known entry is still treated as known."""
+        import unittest.mock as mock
+
+        cert, _ = TestCertificateGeneration.generate_certificate("genuinely-live.example.com", 365)
+        path = os.path.join(temp_dir, "genuinely-live.pem")
+        TestCertificateGeneration.save_certificate_pem(cert, path)
+        cert_infos = analyzer.analyze_certificate(path, "test", 1)
+        analyzer._finish_new_certificate_file(cert_infos, None, "", 0, "")
+
+        with mock.patch.object(analyzer, 'analyze_certificate') as mock_analyze:
+            analyzer.process_event(TestCacheHitReDetection._MockEvent(path, '/usr/bin/cat'))
+        mock_analyze.assert_not_called()
+
+
 class TestMetricsCleanupOnEviction:
     """
     Tests for PrometheusMetrics.remove_certificate_metrics, wired into
@@ -5694,8 +5781,12 @@ class TestRetryQueueDrainer:
         TestCertificateGeneration.save_certificate_pem(cert, path)
 
         # Simulate the path having already been successfully processed
-        # through some other route.
-        analyzer._known_paths[path] = {f"{path}:0:1"}
+        # through some other route -- a real known_certs entry (not just a
+        # _known_paths one) so _path_has_live_known_cert's confirming lookup
+        # (see its docstring) finds it too, matching what a genuine
+        # already-processed path looks like in production.
+        from types import SimpleNamespace
+        analyzer.known_certs[f"{path}:0:1"] = SimpleNamespace(path=path)
 
         # Directly queue a stale retry entry for that same path.
         analyzer._enqueue_rate_limited_retry(
@@ -7808,6 +7899,76 @@ class TestOpensslUprobeHooking:
         analyzer._handle_uprobe_in_memory_cert(event)
         assert len(analyzer.known_certs) == 1
 
+    def test_handle_bytes_rate_limited_when_bucket_exhausted(self, analyzer):
+        """
+        A distinct forged in-memory DER blob on every call bypasses the
+        pid+serial _known_paths dedup (a compromised/malicious process could
+        do exactly this), but the dedicated _uprobe_cert_rate_limiter still
+        caps it.
+        """
+        from agent.analyzer import _TokenBucket
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0  # force exhausted
+        analyzer._uprobe_cert_rate_limiter = bucket
+
+        _, der = self._cert_der(cn='throttled.example.com')
+        event = self._make_uprobe_event([self._make_bytes_arg(der)])
+        result = analyzer._handle_uprobe_in_memory_cert(event)
+        assert result is False
+        assert len(analyzer.known_certs) == 0
+
+    def test_handle_bytes_rate_limited_increments_error_metric(self, analyzer):
+        from agent.analyzer import _TokenBucket
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0
+        analyzer._uprobe_cert_rate_limiter = bucket
+
+        _, der = self._cert_der(cn='throttled-metric.example.com')
+        event = self._make_uprobe_event([self._make_bytes_arg(der)])
+        before = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='uprobe_rate_limited', node_name=analyzer.metrics._node_name)._value.get()
+        analyzer._handle_uprobe_in_memory_cert(event)
+        after = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='uprobe_rate_limited', node_name=analyzer.metrics._node_name)._value.get()
+        assert after == before + 1
+
+    def test_handle_bytes_repeated_forged_certs_bounded_by_rate_limiter(self, analyzer):
+        """
+        Varying the DER content (and thus the serial) on every call defeats
+        the pid+serial dedup, but the dedicated rate limiter still bounds
+        how many distinct forged certificates get fully processed per
+        second, regardless of how fast the uprobe fires.
+        """
+        from agent.analyzer import _TokenBucket
+        analyzer._uprobe_cert_rate_limiter = _TokenBucket(rate=2)
+
+        processed = 0
+        for i in range(5):
+            _, der = self._cert_der(cn=f'forged-mem{i}.example.com')
+            event = self._make_uprobe_event([self._make_bytes_arg(der)])
+            if analyzer._handle_uprobe_in_memory_cert(event):
+                processed += 1
+        assert processed == 2, "only the burst capacity (2 tokens) should be fully processed"
+        assert len(analyzer.known_certs) == 2
+
+    def test_handle_bytes_redetection_not_rate_limited(self, analyzer):
+        """
+        Re-detecting an already-known cert returns True even with the uprobe
+        rate limiter fully exhausted -- only *new* discoveries are gated.
+        """
+        from agent.analyzer import _TokenBucket
+        _, der = self._cert_der(cn='redetect.example.com')
+        event = self._make_uprobe_event([self._make_bytes_arg(der)])
+        analyzer._handle_uprobe_in_memory_cert(event)
+        assert len(analyzer.known_certs) == 1
+
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0
+        analyzer._uprobe_cert_rate_limiter = bucket
+        result = analyzer._handle_uprobe_in_memory_cert(event)
+        assert result is True
+        assert len(analyzer.known_certs) == 1
+
     def test_handle_bytes_two_distinct_certs_both_stored(self, analyzer):
         """Two different certs from separate bytes_arg events are both stored."""
         _, der1 = self._cert_der('a.example.com')
@@ -8174,6 +8335,94 @@ class TestJavaNSSFIPSHooking:
         with mock.patch.object(analyzer, '_read_process_memory',
                                side_effect=[tmpl, ck_cert, der]):
             analyzer._handle_nsc_create_object(event)
+        with mock.patch.object(analyzer, '_read_process_memory',
+                               side_effect=[tmpl, ck_cert, der]):
+            result = analyzer._handle_nsc_create_object(event)
+        assert result is True
+        assert len(analyzer.known_certs) == 1
+
+    def test_create_object_rate_limited_when_bucket_exhausted(self, analyzer):
+        """
+        A distinct forged certificate on every call bypasses the pid+serial
+        _known_paths dedup (a compromised/malicious process could do exactly
+        this), but the dedicated _uprobe_cert_rate_limiter still caps it.
+        """
+        import unittest.mock as mock
+        from agent.analyzer import _TokenBucket
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0  # force exhausted
+        analyzer._uprobe_cert_rate_limiter = bucket
+
+        _, der = self._cert_der(cn='fips-throttled.example.com')
+        tmpl, ck_cert, _ = self._cert_template(der)
+        event = self._make_event('NSC_CreateObject', [0, self.TMPL_ADDR, 2])
+        with mock.patch.object(analyzer, '_read_process_memory',
+                               side_effect=[tmpl, ck_cert, der]):
+            result = analyzer._handle_nsc_create_object(event)
+        assert result is False
+        assert len(analyzer.known_certs) == 0
+
+    def test_create_object_rate_limited_increments_error_metric(self, analyzer):
+        import unittest.mock as mock
+        from agent.analyzer import _TokenBucket
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0
+        analyzer._uprobe_cert_rate_limiter = bucket
+
+        _, der = self._cert_der(cn='fips-throttled-metric.example.com')
+        tmpl, ck_cert, _ = self._cert_template(der)
+        event = self._make_event('NSC_CreateObject', [0, self.TMPL_ADDR, 2])
+        before = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='uprobe_rate_limited', node_name=analyzer.metrics._node_name)._value.get()
+        with mock.patch.object(analyzer, '_read_process_memory',
+                               side_effect=[tmpl, ck_cert, der]):
+            analyzer._handle_nsc_create_object(event)
+        after = analyzer.metrics.cert_analysis_errors.labels(
+            error_type='uprobe_rate_limited', node_name=analyzer.metrics._node_name)._value.get()
+        assert after == before + 1
+
+    def test_create_object_repeated_forged_certs_bounded_by_rate_limiter(self, analyzer):
+        """
+        Varying the serial on every call defeats the pid+serial dedup, but
+        the dedicated rate limiter still bounds how many distinct forged
+        certificates get fully processed (extracted/logged/published) per
+        second, regardless of how fast the uprobe fires.
+        """
+        import unittest.mock as mock
+        from agent.analyzer import _TokenBucket
+        analyzer._uprobe_cert_rate_limiter = _TokenBucket(rate=2)
+
+        processed = 0
+        for i in range(5):
+            _, der = self._cert_der(cn=f'forged{i}.example.com')
+            tmpl, ck_cert, _ = self._cert_template(der)
+            event = self._make_event('NSC_CreateObject', [0, self.TMPL_ADDR, 2])
+            with mock.patch.object(analyzer, '_read_process_memory',
+                                   side_effect=[tmpl, ck_cert, der]):
+                if analyzer._handle_nsc_create_object(event):
+                    processed += 1
+        assert processed == 2, "only the burst capacity (2 tokens) should be fully processed"
+        assert len(analyzer.known_certs) == 2
+
+    def test_create_object_redetection_not_rate_limited(self, analyzer):
+        """
+        Re-detecting an already-known cert returns True even with the uprobe
+        rate limiter fully exhausted -- only *new* discoveries are gated,
+        matching the file-based pipeline's own re-access-is-free semantics.
+        """
+        import unittest.mock as mock
+        from agent.analyzer import _TokenBucket
+        _, der = self._cert_der(cn='fips-redetect.example.com')
+        tmpl, ck_cert, _ = self._cert_template(der)
+        event = self._make_event('NSC_CreateObject', [0, self.TMPL_ADDR, 2])
+        with mock.patch.object(analyzer, '_read_process_memory',
+                               side_effect=[tmpl, ck_cert, der]):
+            analyzer._handle_nsc_create_object(event)
+        assert len(analyzer.known_certs) == 1
+
+        bucket = _TokenBucket(rate=1)
+        bucket._tokens = 0
+        analyzer._uprobe_cert_rate_limiter = bucket
         with mock.patch.object(analyzer, '_read_process_memory',
                                side_effect=[tmpl, ck_cert, der]):
             result = analyzer._handle_nsc_create_object(event)


### PR DESCRIPTION
…view

Two fixes from a thorough thread-safety/performance/security review of the post-split agent/ package (finding #1 and #3; #4/#5 left as follow-ups).

#1 -- Uprobe-based cert-discovery paths had no rate limit (MEDIUM): _handle_nsc_create_object and _handle_uprobe_in_memory_cert (agent/java_fips.py) deliberately bypass the file-pipeline's rate limiter, on the assumption these events are inherently low-volume. Their only dedup is a synthetic pid+serial path, trivially defeated by a compromised or malicious process on the node forging a different serial on every call -- with no ceiling of its own, that path had no bound on how much extract_certificate_info/logging/Kafka-publish cost it could force per second. Added a dedicated _uprobe_cert_rate_limiter (_TokenBucket, kept separate from _new_cert_rate_limiter so a flood of forged uprobe captures can't also starve real file-based discovery), configurable via UPROBE_CERT_EVENTS_PER_SECOND / [certificates] uprobe_cert_events_per_second (default 50/sec, matching the existing file-pipeline default). Throttled captures are dropped (not queued -- the underlying bytes were only ever transiently in the discovering process's memory, so there's nothing to usefully replay later) with the same throttled-logging pattern _log_rate_limited_new_cert already uses. Already-known re-detections remain free, matching the file pipeline's own semantics.

#3 -- LRUCache's on_evict/on_set callbacks can leave _known_paths transiently stale (LOW): LRUCache.__setitem__ (agent/cache.py) fires its callbacks *after* releasing its own internal lock, so known_certs's `_known_paths` secondary index (populated by those callbacks) can briefly disagree with known_certs's actual contents -- two independently-locked pieces of state that don't move together atomically. Three call sites treat "known_paths says known" as a reason to skip work: process_event's known-file loop, periodic_scan, and the retry-queue drainer. A false positive there would silently and *permanently* drop legitimate work rather than just delay it. Added _path_has_live_known_cert, which confirms a _known_paths hit against known_certs itself (the same defensive pattern process_event's loop already applied per-key) before trusting it, and used it in periodic_scan and the retry-queue drainer. process_event's own loop now tracks whether any candidate key actually resolved and falls through to the new-file path instead of unconditionally returning if every one of them turned out to be stale.

Fixing #3 exposed a test (test_drainer_skips_entry_already_known_via_other_path) that simulated "already known" by seeding _known_paths directly without a matching known_certs entry -- exactly the stale state the fix now correctly refuses to trust. Updated it to seed a real known_certs entry, matching what "already known via another route" actually looks like in production.

Added 14 new tests covering both fixes (rate-limiting and redetection-stays- free behavior for both uprobe handlers; _path_has_live_known_cert directly; process_event's stale-index fallthrough vs. the genuinely-live control case).

Verified: full test suite (566 passed), flake8 --select=E9,F63,F7,F82 (0 issues), bandit (0 issues).