### PR TITLE
Add --kafka-port/KAFKA_PORT and --host-network/HOST_NETWORK to test-s…

### DIFF
--- a/extras/openshift/scripts/deploy-test-server-from-release.sh
+++ b/extras/openshift/scripts/deploy-test-server-from-release.sh
@@ -10,7 +10,7 @@ MANIFEST="$REPO_ROOT/extras/openshift/test-server-pod.yaml"
 step() { echo; echo "==> $*"; }
 
 usage() {
-    echo "Usage: $0 --image-tar <path> [--kafka-host <ip>]" >&2
+    echo "Usage: $0 --image-tar <path> [--kafka-host <ip>] [--kafka-port <port>] [--host-network]" >&2
     echo >&2
     echo "  --image-tar   Path to a cert-test-server-ubi{8,9}-<version>.tar.gz asset downloaded" >&2
     echo "                from this repo's GitHub Releases page (docker save/gzip format)." >&2
@@ -21,6 +21,8 @@ usage() {
 
 IMAGE_TAR=""
 KAFKA_HOST_ARG=""
+KAFKA_PORT="${KAFKA_PORT:-9092}"
+HOST_NETWORK="${HOST_NETWORK:-false}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --image-tar)
@@ -37,6 +39,22 @@ while [[ $# -gt 0 ]]; do
             ;;
         --kafka-host=*)
             KAFKA_HOST_ARG="${1#*=}"
+            shift
+            ;;
+        --kafka-port)
+            KAFKA_PORT="$2"
+            shift 2
+            ;;
+        --kafka-port=*)
+            KAFKA_PORT="${1#*=}"
+            shift
+            ;;
+        --host-network)
+            HOST_NETWORK="true"
+            shift
+            ;;
+        --host-network=*)
+            HOST_NETWORK="${1#*=}"
             shift
             ;;
         -h|--help)
@@ -67,8 +85,15 @@ else
     echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
 fi
 
+step "Resolving the Kafka port and hostNetwork"
+echo "Using Kafka port: $KAFKA_PORT (override with --kafka-port <port> or KAFKA_PORT)"
+echo "hostNetwork: $HOST_NETWORK (override with --host-network or HOST_NETWORK=true)"
+
 render_manifest() {
-    sed "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" "$MANIFEST"
+    sed -e "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" \
+        -e "s#__TEST_SERVER_KAFKA_PORT__#$KAFKA_PORT#g" \
+        -e "s#__TEST_SERVER_HOST_NETWORK__#$HOST_NETWORK#g" \
+        "$MANIFEST"
 }
 
 step "Checking cluster login"

--- a/extras/openshift/scripts/deploy-test-server.sh
+++ b/extras/openshift/scripts/deploy-test-server.sh
@@ -10,6 +10,8 @@ MANIFEST="$REPO_ROOT/extras/openshift/test-server-pod.yaml"
 step() { echo; echo "==> $*"; }
 
 KAFKA_HOST_ARG=""
+KAFKA_PORT="${KAFKA_PORT:-9092}"
+HOST_NETWORK="${HOST_NETWORK:-false}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --kafka-host)
@@ -20,9 +22,25 @@ while [[ $# -gt 0 ]]; do
             KAFKA_HOST_ARG="${1#*=}"
             shift
             ;;
+        --kafka-port)
+            KAFKA_PORT="$2"
+            shift 2
+            ;;
+        --kafka-port=*)
+            KAFKA_PORT="${1#*=}"
+            shift
+            ;;
+        --host-network)
+            HOST_NETWORK="true"
+            shift
+            ;;
+        --host-network=*)
+            HOST_NETWORK="${1#*=}"
+            shift
+            ;;
         *)
             echo "Unknown argument: $1" >&2
-            echo "Usage: $0 [--kafka-host <ip>]" >&2
+            echo "Usage: $0 [--kafka-host <ip>] [--kafka-port <port>] [--host-network]" >&2
             exit 1
             ;;
     esac
@@ -45,8 +63,15 @@ else
     echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
 fi
 
+step "Resolving the Kafka port and hostNetwork"
+echo "Using Kafka port: $KAFKA_PORT (override with --kafka-port <port> or KAFKA_PORT)"
+echo "hostNetwork: $HOST_NETWORK (override with --host-network or HOST_NETWORK=true)"
+
 render_manifest() {
-    sed "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" "$MANIFEST"
+    sed -e "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" \
+        -e "s#__TEST_SERVER_KAFKA_PORT__#$KAFKA_PORT#g" \
+        -e "s#__TEST_SERVER_HOST_NETWORK__#$HOST_NETWORK#g" \
+        "$MANIFEST"
 }
 
 step "Checking cluster login"

--- a/extras/openshift/scripts/restart-test-server.sh
+++ b/extras/openshift/scripts/restart-test-server.sh
@@ -10,6 +10,8 @@ MANIFEST="$REPO_ROOT/extras/openshift/test-server-pod.yaml"
 step() { echo; echo "==> $*"; }
 
 KAFKA_HOST_ARG=""
+KAFKA_PORT="${KAFKA_PORT:-9092}"
+HOST_NETWORK="${HOST_NETWORK:-false}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --kafka-host)
@@ -20,9 +22,25 @@ while [[ $# -gt 0 ]]; do
             KAFKA_HOST_ARG="${1#*=}"
             shift
             ;;
+        --kafka-port)
+            KAFKA_PORT="$2"
+            shift 2
+            ;;
+        --kafka-port=*)
+            KAFKA_PORT="${1#*=}"
+            shift
+            ;;
+        --host-network)
+            HOST_NETWORK="true"
+            shift
+            ;;
+        --host-network=*)
+            HOST_NETWORK="${1#*=}"
+            shift
+            ;;
         *)
             echo "Unknown argument: $1" >&2
-            echo "Usage: $0 [--kafka-host <ip>]" >&2
+            echo "Usage: $0 [--kafka-host <ip>] [--kafka-port <port>] [--host-network]" >&2
             exit 1
             ;;
     esac
@@ -47,8 +65,15 @@ else
     echo "Auto-detected: $KAFKA_HOST (override with --kafka-host <ip>)"
 fi
 
+step "Resolving the Kafka port and hostNetwork"
+echo "Using Kafka port: $KAFKA_PORT (override with --kafka-port <port> or KAFKA_PORT)"
+echo "hostNetwork: $HOST_NETWORK (override with --host-network or HOST_NETWORK=true)"
+
 render_manifest() {
-    sed "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" "$MANIFEST"
+    sed -e "s#__TEST_SERVER_KAFKA_HOST__#$KAFKA_HOST#g" \
+        -e "s#__TEST_SERVER_KAFKA_PORT__#$KAFKA_PORT#g" \
+        -e "s#__TEST_SERVER_HOST_NETWORK__#$HOST_NETWORK#g" \
+        "$MANIFEST"
 }
 
 step "Picking an image tag to redeploy"

--- a/extras/openshift/test-server-pod.yaml
+++ b/extras/openshift/test-server-pod.yaml
@@ -13,12 +13,12 @@
 #   sudo podman push --tls-verify=false "$HOST/certsight/cert-test-server:latest"
 #
 # Deploy:
-#   bash extras/openshift/scripts/deploy-test-server.sh [--kafka-host <ip>]
+#   bash extras/openshift/scripts/deploy-test-server.sh [--kafka-host <ip>] [--kafka-port <port>] [--host-network]
 #
-#   TEST_SERVER_KAFKA_HOST below is a substitution placeholder -- the script
-#   fills it in (with --kafka-host if given, else the host's auto-detected
-#   default-route IP) before applying. Don't 'oc apply' this file directly;
-#   the raw placeholder would be taken as a literal, unreachable hostname.
+#   TEST_SERVER_KAFKA_HOST/TEST_SERVER_KAFKA_PORT/hostNetwork below are substitution
+#   placeholders -- the script fills them in (from --kafka-host/--kafka-port/--host-network,
+#   or the KAFKA_PORT/HOST_NETWORK env vars, or their defaults) before applying. Don't
+#   'oc apply' this file directly; the raw placeholders would be taken as literal values.
 #
 # Drive it:
 #   oc port-forward -n certsight pod/cert-test-server 8090:8090
@@ -68,6 +68,11 @@ metadata:
     app: cert-test-server
 spec:
   serviceAccountName: cert-test-server
+  # Off by default (false); substituted by the deploy scripts via --host-network/HOST_NETWORK
+  # for scenarios that need this Pod on the node's real network namespace instead of the pod
+  # network. Not required for Tetragon detection to work either way -- see the hostNetwork
+  # comment near the bottom of this file.
+  hostNetwork: __TEST_SERVER_HOST_NETWORK__
   # A bare Pod with no controller to recreate it -- if the scheduler preempts it (see the
   # priorityClassName comment on cert-expiry-monitor in daemonset.yaml for why that happens
   # on memory-constrained single-node CRC), it's just gone until someone notices and reruns
@@ -107,7 +112,9 @@ spec:
       # tracked by this repo).
       value: "__TEST_SERVER_KAFKA_HOST__"
     - name: TEST_SERVER_KAFKA_PORT
-      value: "9092"
+      # Substituted by the deploy scripts -- see the Deploy note above. Defaults to 9092
+      # unless overridden with --kafka-port/KAFKA_PORT.
+      value: "__TEST_SERVER_KAFKA_PORT__"
     - name: TEST_SERVER_PROMETHEUS_URL
       # server.py defaults to http://127.0.0.1:9090, correct only in the
       # standalone deployment where a real Prometheus and cert-analyzer share
@@ -160,11 +167,12 @@ spec:
     hostPath:
       path: /var/certsight-test-server
       type: DirectoryOrCreate
-  # hostNetwork/hostPID still aren't needed -- Tetragon's node-wide fd_install /
-  # tcp_connect kprobes (see tetragon-policies/certificate-file-access.yaml and
-  # tcp-connect-tls.yaml) have no path or namespace filter, so they fire for
-  # this Pod's real file/network activity same as they would for any other
-  # process on the node. hostPath above is only there so a file this Pod
+  # hostNetwork (spec.hostNetwork above, off by default) and hostPID aren't required for
+  # detection either way -- Tetragon's node-wide fd_install / tcp_connect kprobes (see
+  # tetragon-policies/certificate-file-access.yaml and tcp-connect-tls.yaml) have no path or
+  # namespace filter, so they fire for this Pod's real file/network activity same as they
+  # would for any other process on the node, whichever network namespace it's in. hostPath
+  # above is only there so a file this Pod
   # writes is resolvable through cert-analyzer's /host bind mount -- without
   # it, cert-analyzer would see the Tetragon event but the path would never
   # resolve to a readable file (logged as "Skipping non-regular-file cert


### PR DESCRIPTION
…erver scripts

Lets the cert-test-server Pod's Kafka port and hostNetwork be overridden via flag or env var (both default to today's values: 9092, false) across deploy-test-server.sh, deploy-test-server-from-release.sh, and restart-test-server.sh, matching the existing --kafka-host pattern