### PR TITLE
Add tls-bind-probe-non-fips-cipher test-server use case

### DIFF
--- a/extras/test-server/TEST-SERVER-README.md
+++ b/extras/test-server/TEST-SERVER-README.md
@@ -523,6 +523,26 @@ endpoint may have no authentication (see the `--bind`/systemd warnings
 above), and unlike writing a file, this spins up a real process and a
 real listening socket per click.
 
+### bind a TLS service that negotiates a non-FIPS cipher
+
+Same bind-probe mechanics as above (own process for PID attribution, own
+`_MAX_CONCURRENT_NON_FIPS_CIPHER_PROBES` cap), served by
+`tls_probe_helper_non_fips_cipher.py` instead of `tls_probe_helper.py`. The
+only difference is the served cert is otherwise unremarkable and
+FIPS-compliant on its own (2048-bit RSA/SHA-256); the helper's `SSLContext`
+caps `maximum_version` at TLS 1.2 and calls `set_ciphers("ECDHE-RSA-CHACHA20-POLY1305")`
+-- a cipher NIST SP 800-52 Rev. 2 doesn't approve for TLS 1.2 regardless of
+the certificate's own strength.
+
+cert-analyzer connects back the same way as the plain bind-probe case
+(`ssl.create_default_context()`), and since the helper offers exactly one
+cipher on TLS 1.2, that's what gets negotiated. `agent/tls_probe.py` records
+the negotiated protocol/cipher as the `tls_certificate_negotiated_protocol`
+metric alongside the certificate's own (compliant) FIPS check -- see
+[Fleet FIPS rollout](#fleet-fips-rollout) below for where that combination
+shows up: a node flagged critical purely on cipher drift, with every
+certificate on it individually passing FIPS on its own.
+
 ### dial out to a TLS port and let CertSight discover it
 
 This exercises cert-analyzer's *outbound* detection path -- the mirror

--- a/extras/test-server/certsight-test-server.spec
+++ b/extras/test-server/certsight-test-server.spec
@@ -213,6 +213,16 @@ exit 0
 
 %changelog
 * %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
+- Add tls-bind-probe-non-fips-cipher use case
+  (tls_probe_helper_non_fips_cipher.py) exercising CertSight's inbound
+  [port_probe] bind_probe_enabled detection path with a listener pinned to
+  TLS 1.2 + ECDHE-RSA-CHACHA20-POLY1305 -- a cipher NIST SP 800-52 Rev. 2
+  doesn't approve for TLS 1.2, regardless of the served certificate's own
+  (compliant) key/signature strength. Demonstrates the "cipher drift" case
+  the Fleet FIPS rollout explorer flags: an individually FIPS-compliant
+  certificate whose live TLS session still negotiates a non-approved
+  cipher
+* %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
 - Add a "Fleet FIPS rollout" link to the console header
   (fleet_fips_rollout.py), generated live on click against Prometheus --
   groups every certificate by node_name (the closest available

--- a/extras/test-server/tls_probe_helper_non_fips_cipher.py
+++ b/extras/test-server/tls_probe_helper_non_fips_cipher.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Standalone helper spawned by use_cases.py's "bind a non-FIPS-cipher TLS
+service" use case.
+
+Identical to tls_probe_helper.py (same module docstring rationale applies
+for running as a separate process, binding the wildcard address, and picking
+an explicit nonzero port) except for one thing: the SSLContext below is
+deliberately pinned to TLS 1.2 and a single cipher --
+ECDHE-RSA-CHACHA20-POLY1305 -- which is NOT in fleet_fips_rollout.py's
+_APPROVED_TLS12_CIPHERS allowlist (NIST SP 800-52 Rev. 2 approves
+AES-GCM/AES-CBC combinations for TLS 1.2, not ChaCha20-Poly1305, regardless
+of TLS version). The certificate served here is otherwise unremarkable and
+individually FIPS-compliant -- the point is to demonstrate the "cipher
+drift" case the FIPS rollout explorer flags: a compliant certificate on a
+node whose live TLS session still negotiates a non-approved cipher.
+
+Usage:
+    tls_probe_helper_non_fips_cipher.py <certfile> <keyfile> <lifetime_seconds>
+"""
+import random
+import socket
+import ssl
+import sys
+import time
+
+_PORT_RANGE = (49152, 65535)
+_BIND_ATTEMPTS = 10
+_NON_FIPS_CIPHER = "ECDHE-RSA-CHACHA20-POLY1305"
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"ERROR usage: {sys.argv[0]} <certfile> <keyfile> <lifetime_seconds>", flush=True)
+        return 2
+    certfile, keyfile, lifetime_str = sys.argv[1:4]
+    lifetime = float(lifetime_str)
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    try:
+        context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    except Exception as e:
+        print(f"ERROR failed to load cert/key: {e}", flush=True)
+        return 1
+
+    # set_ciphers() only governs TLS <=1.2 suite selection -- TLS 1.3
+    # ciphersuites aren't controllable through it, and a client capable of
+    # 1.3 would otherwise prefer it over anything offered here regardless of
+    # this cipher list. Capping maximum_version forces negotiation down to
+    # 1.2, where this single-entry cipher list actually takes effect.
+    context.maximum_version = ssl.TLSVersion.TLSv1_2
+    context.set_ciphers(_NON_FIPS_CIPHER)
+
+    sock = None
+    last_err = None
+    for _ in range(_BIND_ATTEMPTS):
+        candidate = random.randint(*_PORT_RANGE)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.bind(("0.0.0.0", candidate))  # nosec B104 - see tls_probe_helper.py's docstring for why wildcard, not loopback
+            s.listen(4)
+            sock = s
+            break
+        except OSError as e:
+            last_err = e
+            s.close()
+    if sock is None:
+        print(f"ERROR bind/listen failed after {_BIND_ATTEMPTS} attempts: {last_err}", flush=True)
+        return 1
+
+    port = sock.getsockname()[1]
+    print(f"PORT {port}", flush=True)
+
+    deadline = time.monotonic() + lifetime
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        sock.settimeout(remaining)
+        try:
+            conn, _addr = sock.accept()
+        except socket.timeout:
+            break
+        try:
+            with context.wrap_socket(conn, server_side=True):
+                pass
+        except (ssl.SSLError, OSError):
+            conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -613,6 +613,105 @@ def _bind_tls_service_for_discovery(params: dict) -> UseCaseResult:
     )
 
 
+# Same rationale and mechanics as _bind_tls_service_for_discovery above (own
+# process for PID attribution, own concurrency cap), but the listener it
+# spawns pins TLS 1.2 + ECDHE-RSA-CHACHA20-POLY1305 -- a cipher NIST SP
+# 800-52 Rev. 2 doesn't approve for TLS 1.2, regardless of the cert's own
+# key/signature strength. Its own tracking state is kept separate from the
+# plain bind-probe use case's so the two can run concurrently without
+# fighting over the same counter/cap.
+_NON_FIPS_CIPHER_HELPER_SCRIPT = Path(__file__).resolve().parent / "tls_probe_helper_non_fips_cipher.py"
+_MAX_CONCURRENT_NON_FIPS_CIPHER_PROBES = 2
+_NON_FIPS_CIPHER_PROBE_LIFETIME_SECONDS = 12.0
+_NON_FIPS_CIPHER_PROBE_READY_TIMEOUT_SECONDS = 5.0
+_active_non_fips_cipher_probe_lock = threading.Lock()
+_active_non_fips_cipher_probe_count = 0
+
+
+def _bind_non_fips_cipher_tls_service_for_discovery(params: dict) -> UseCaseResult:
+    global _active_non_fips_cipher_probe_count
+    with _active_non_fips_cipher_probe_lock:
+        if _active_non_fips_cipher_probe_count >= _MAX_CONCURRENT_NON_FIPS_CIPHER_PROBES:
+            return UseCaseResult(
+                ok=False,
+                detail=f"{_MAX_CONCURRENT_NON_FIPS_CIPHER_PROBES} non-FIPS-cipher TLS probe "
+                "listener(s) are already running -- wait a few seconds for one to finish and try again",
+            )
+        _active_non_fips_cipher_probe_count += 1
+
+    def _release():
+        global _active_non_fips_cipher_probe_count
+        with _active_non_fips_cipher_probe_lock:
+            _active_non_fips_cipher_probe_count -= 1
+
+    token = _resolve_token(params)
+    cn = f"certsight-test-nonfips-cipher-{token}.local"
+    cert_path = _GENERATED_CERT_DIR / f"nonfips-cipher-probe-{token}.crt"
+    key_path = _GENERATED_CERT_DIR / f"nonfips-cipher-probe-{token}.key"
+
+    # 2048-bit RSA + SHA-256 -- deliberately unremarkable and FIPS-compliant
+    # on its own, so the resulting Kafka event's fips_compliant=true makes
+    # the live session's cipher drift the only thing wrong with this node.
+    cert_pem, key_pem = _generate_self_signed_cert(cn, key_size=2048)
+
+    _GENERATED_CERT_DIR.mkdir(parents=True, exist_ok=True)
+    _GENERATED_CERT_DIR.chmod(0o755)
+    cert_path.write_bytes(cert_pem)
+    cert_path.chmod(0o644)
+    key_path.write_bytes(key_pem)
+    key_path.chmod(0o600)
+
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, str(_NON_FIPS_CIPHER_HELPER_SCRIPT), str(cert_path), str(key_path),
+             str(_NON_FIPS_CIPHER_PROBE_LIFETIME_SECONDS)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as e:
+        _release()
+        return UseCaseResult(ok=False, detail=f"failed to spawn non-FIPS-cipher TLS probe helper: {e}")
+
+    ready_q: queue.Queue = queue.Queue()
+    threading.Thread(target=lambda: ready_q.put(proc.stdout.readline()), daemon=True).start()
+
+    try:
+        first_line = ready_q.get(timeout=_NON_FIPS_CIPHER_PROBE_READY_TIMEOUT_SECONDS).strip()
+    except queue.Empty:
+        proc.kill()
+        _release()
+        return UseCaseResult(ok=False, detail="non-FIPS-cipher TLS probe helper didn't report readiness in time")
+
+    if not first_line.startswith("PORT "):
+        proc.kill()
+        _release()
+        return UseCaseResult(ok=False, detail=f"non-FIPS-cipher TLS probe helper failed to start: {first_line or '(no output)'}")
+
+    port = first_line.split(" ", 1)[1]
+
+    def _reap():
+        proc.wait()
+        _release()
+
+    threading.Thread(target=_reap, daemon=True).start()
+
+    return UseCaseResult(
+        ok=True,
+        detail=(
+            f"spawned PID {proc.pid}, listening on 0.0.0.0:{port} for up to "
+            f"{int(_NON_FIPS_CIPHER_PROBE_LIFETIME_SECONDS)}s (CN={cn}), TLS 1.2 pinned to "
+            "ECDHE-RSA-CHACHA20-POLY1305 only -- if cert-analyzer has [port_probe] "
+            "bind_probe_enabled = true, it should connect within ~2s and negotiate that same "
+            "cipher. The cert itself stays FIPS-compliant (2048-bit RSA/SHA-256), so check the "
+            "[fleet FIPS rollout explorer](/fleet-fips-rollout) for this node to be flagged "
+            "'critical' on cipher drift alone -- click through to see the negotiated "
+            "TLSv1.2/ECDHE-RSA-CHACHA20-POLY1305 session listed against an otherwise-compliant cert"
+        ),
+        token=token,
+    )
+
+
 # tcp_connect_probe_helper.py runs as its own OS process for the same PID-
 # attribution reason as the bind-probe helper above. Its candidate ports are
 # a fixed subset of tcp-connect-tls.yaml's DPort filter (see that helper's
@@ -1283,6 +1382,70 @@ USE_CASES: List[UseCase] = [
             "Server-Sent Events stream, where it lands in the right-hand "
             "pane -- compare its 'pid' field against the PID shown in the "
             "status line above.",
+        ],
+    ),
+    UseCase(
+        id="tls-bind-probe-non-fips-cipher",
+        label="bind a TLS service that negotiates a non-FIPS cipher",
+        description=(
+            "Same bind-probe mechanics as above, but the listener is pinned "
+            "to TLS 1.2 + ECDHE-RSA-CHACHA20-POLY1305 -- a cipher NIST SP "
+            "800-52 Rev. 2 doesn't approve for TLS 1.2. The certificate "
+            "itself stays FIPS-compliant (2048-bit RSA/SHA-256); only the "
+            "live session's negotiated cipher is non-approved. Requires the "
+            "same [port_probe] bind_probe_enabled = true and "
+            "tls-service-tracking.yaml TracingPolicy as the plain bind-probe "
+            "use case, plus [metrics] fips_compliance_enabled = true for "
+            "the fleet FIPS rollout explorer to show it."
+        ),
+        run=_bind_non_fips_cipher_tls_service_for_discovery,
+        pipeline=[
+            "This server generates a fresh, ordinary self-signed X.509 cert "
+            f"(2048-bit RSA, SHA-256) + private key, and writes both to "
+            f"{_GENERATED_CERT_DIR}/ -- deliberately unremarkable and "
+            "FIPS-compliant on its own.",
+
+            "This server spawns tls_probe_helper_non_fips_cipher.py as a "
+            "separate OS process, same PID-attribution reasoning as the "
+            "plain bind-probe use case.",
+
+            "That helper process binds a random high port on 0.0.0.0, "
+            "same as the plain bind-probe helper, but builds its "
+            "SSLContext differently:\n"
+            "```python\n"
+            "context.maximum_version = ssl.TLSVersion.TLSv1_2\n"
+            "context.set_ciphers(\"ECDHE-RSA-CHACHA20-POLY1305\")\n"
+            "```\n"
+            "capping the protocol at 1.2 (set_ciphers() doesn't govern TLS "
+            "1.3 ciphersuite selection) and offering exactly one cipher -- "
+            "full source: "
+            "[tls_probe_helper_non_fips_cipher.py](/source/tls_probe_helper_non_fips_cipher.py)",
+
+            "Tetragon's security_socket_bind kprobe fires on that bind() "
+            "call, same as the plain bind-probe use case.",
+
+            "CertSight connects back with ssl.create_default_context() -- "
+            "since the helper offers only one cipher on TLS 1.2, that's "
+            "exactly what gets negotiated. agent/tls_probe.py reads "
+            "ssock.version() ('TLSv1.2') and cipher()[0] "
+            "('ECDHE-RSA-CHACHA20-POLY1305') off the completed handshake "
+            "and records them via Metrics.record_tls_negotiation, alongside "
+            "parsing the certificate itself exactly like any other "
+            "discovery (subject, issuer, key algorithm/size, FIPS "
+            "compliance, etc).",
+
+            "The certificate's own FIPS check passes (2048-bit RSA/SHA-256), "
+            "so the resulting Kafka event reads fips_compliant=true -- the "
+            "cert is fine. The negotiated cipher is published separately as "
+            "the tls_certificate_negotiated_protocol metric.",
+
+            "The [fleet FIPS rollout explorer](/fleet-fips-rollout) cross-"
+            "checks that metric against NIST SP 800-52 Rev. 2's approved "
+            "cipher list (extras/test-server/fleet_fips_rollout.py) and "
+            "flags this node 'critical' on cipher drift alone: an "
+            "individually-compliant cert whose live TLS session still "
+            "negotiated a non-approved cipher -- open it and click through "
+            "to this node to see both facts side by side.",
         ],
     ),
     UseCase(


### PR DESCRIPTION
Demonstrates the "cipher drift" case the fleet FIPS rollout explorer flags: a bind-probe listener with an individually FIPS-compliant certificate (2048-bit RSA/SHA-256) whose SSLContext is pinned to TLS 1.2
+ ECDHE-RSA-CHACHA20-POLY1305, a cipher NIST SP 800-52 Rev. 2 doesn't approve for TLS 1.2. cert-analyzer's own probe negotiates that cipher against its default context, so the resulting node gets flagged critical purely on the negotiated session, with the certificate itself passing its own FIPS check.