### PR TITLE
Add get_negotiated_sessions MCP tool for per-session protocol/cipher …

### DIFF
--- a/extras/mcp-server/MCP-SERVER-README.md
+++ b/extras/mcp-server/MCP-SERVER-README.md
@@ -100,6 +100,7 @@ public, controls who can reach the endpoint.
 | `get_expiring_certs(max_days=30)` | What's expiring soon, soonest first |
 | `get_blast_radius(query)` | "What's exposed if this cert/key is compromised?" — groups by shared SPKI/checksum across the fleet |
 | `get_fips_rollout_status(node?)` | Per-node FIPS compliance + "cipher drift" (live non-approved cipher despite a compliant cert) |
+| `get_negotiated_sessions(node?, drift_only=false)` | Per-session negotiated protocol/cipher + the process/pod that negotiated it; `drift_only=true` for just the non-approved ones |
 | `explain_chain(query)` | Chain length, role of each cert, and any missing/cross-file-resolved issuer |
 | `query_prometheus(promql)` | Raw PromQL escape hatch |
 

--- a/extras/mcp-server/server.py
+++ b/extras/mcp-server/server.py
@@ -177,6 +177,50 @@ def get_fips_rollout_status(node: str = "") -> str:
 
 
 @mcp.tool()
+def get_negotiated_sessions(node: str = "", drift_only: bool = False) -> str:
+    """List every live TLS session cert-analyzer has actually negotiated (via
+    bind_probe_enabled/connect_probe_enabled), one row per session: the
+    certificate it served, the process that negotiated it (with pod/namespace
+    where available), and the protocol/cipher actually negotiated -- distinct
+    from the certificate's own algorithm/key strength, since a compliant
+    certificate can still be served over a non-approved live session (e.g. a
+    provider silently falling back when no approved cipher is available).
+    Set drift_only=True to see only sessions that negotiated a cipher/protocol
+    NIST SP 800-52 Rev. 2 doesn't approve. Optionally filter to one node
+    (substring match, case-insensitive)."""
+    certs = _load_fleet_certs()
+    for cert in certs.values():
+        cert["fips_compliant"] = None
+        cert["negotiations"] = []
+    fleet_fips_rollout._fetch_fleet_fips(PROMETHEUS_URL, certs)
+    fleet_fips_rollout._fetch_fleet_negotiated(PROMETHEUS_URL, certs)
+
+    node_l = node.lower()
+    out = []
+    for cert in certs.values():
+        if node_l and node_l not in cert["node_name"].lower():
+            continue
+        for neg in cert["negotiations"]:
+            if drift_only and neg["approved"]:
+                continue
+            leaf = next((l for l in cert["leaves"] if l["process"] == neg["process"]), None)
+            out.append({
+                "common_name": cert["common_name"],
+                "cert_path": cert["cert_path"],
+                "node_name": cert["node_name"],
+                "serial": cert["serial"],
+                "fips_compliant": cert["fips_compliant"],
+                "process": neg["process"],
+                "pod_name": leaf["pod_name"] if leaf else "",
+                "namespace": leaf["namespace"] if leaf else "",
+                "protocol": neg["protocol"],
+                "cipher": neg["cipher"],
+                "approved": neg["approved"],
+            })
+    return json.dumps(out, indent=2)
+
+
+@mcp.tool()
 def explain_chain(query: str) -> str:
     """Explain the certificate chain for a given cert_path or common-name
     (substring match): chain length, each cert's role (root / intermediate

--- a/extras/test-server/TEST-SERVER-README.md
+++ b/extras/test-server/TEST-SERVER-README.md
@@ -371,12 +371,12 @@ you've made to it.
 
 | Use case | Action | Detection exercised |
 |---|---|---|
-| generate + read a fresh test certificate | Generates a new self-signed cert at a unique path under `/dev/shm`, then `cat`s it | File-access detection via the `certificate-file-access.yaml` Tetragon policy (`fd_install` kprobe); pick an **RSA key size** below 2048 bits to also trigger a `fips_compliant=false` finding |
+| generate + read a fresh test certificate and let CertSight discover it | Generates a new self-signed cert at a unique path under `/dev/shm`, then `cat`s it | File-access detection via the `certificate-file-access.yaml` Tetragon policy (`fd_install` kprobe); pick an **RSA key size** below 2048 bits to also trigger a `fips_compliant=false` finding |
 | bind a TLS service and let CertSight discover it | Spawns `tls_probe_helper.py` as a separate process, which generates its own self-signed cert and binds a real TLS listener on `127.0.0.1:<random high port>` | Inbound bind detection via the `tls-service-tracking.yaml` Tetragon policy (`security_socket_bind` LSM hook) plus cert-analyzer's `[port_probe]` TLS handshake probe |
 | dial out to a TLS port and let CertSight discover it | Spawns `tcp_connect_probe_helper.py` as a separate process, which binds a real TLS listener on one of `tcp-connect-tls.yaml`'s TLS ports and then connects back to itself | Outbound connect detection via the `tcp-connect-tls.yaml` Tetragon policy (`tcp_connect` kprobe) plus cert-analyzer's `[port_probe]` TLS handshake probe |
-| dial out with a real SNI hostname behind a CDN-style edge | Spawns `tcp_connect_sni_probe_helper.py`, which binds a TLS listener that serves a different cert depending on the SNI it receives, then connects back to itself presenting a real hostname as SNI | The `SSL_ctrl` uprobe fix for connect-probe's CDN fallback-cert gap: compare the Kafka event's CN to see whether cert-analyzer's probe used the real hostname (`[port_probe] sni_capture_enabled = true`) or the raw destination IP (the default) |
-| load a certificate straight into memory (no file) | Generates a fresh self-signed cert as DER bytes and calls `SSL_CTX_use_certificate_ASN1()` directly against the system libssl via `ctypes` -- no file is ever written | In-memory cert detection via the `openssl3-cert-load.yaml` Tetragon policy (`SSL_CTX_use_certificate_ASN1` uprobe); cert-analyzer builds a synthetic `uprobe://SSL_CTX_use_certificate_ASN1/<pid>/<serial>` path since there's no real one |
-| load a certificate into a Java KeyStore (JCA) | Spawns a JVM (`CertAgentTest`), jattaches CertSight's cert-agent Java instrumentation into it, then watches it call `KeyStore.setCertificateEntry()` on a fresh in-memory cert every few seconds | In-memory JCA cert detection via the `java-non-fips-cert.yaml` Tetragon policy (`java_cert_agent_write` uprobe); cert-analyzer builds a synthetic `uprobe://java_cert_agent_write/<pid>/<serial>` path since there's no real file |
+| dial out with a real SNI hostname behind a CDN-style edge and let CertSight discover it | Spawns `tcp_connect_sni_probe_helper.py`, which binds a TLS listener that serves a different cert depending on the SNI it receives, then connects back to itself presenting a real hostname as SNI | The `SSL_ctrl` uprobe fix for connect-probe's CDN fallback-cert gap: compare the Kafka event's CN to see whether cert-analyzer's probe used the real hostname (`[port_probe] sni_capture_enabled = true`) or the raw destination IP (the default) |
+| load a certificate straight into memory (no file) and let CertSight discover it | Generates a fresh self-signed cert as DER bytes and calls `SSL_CTX_use_certificate_ASN1()` directly against the system libssl via `ctypes` -- no file is ever written | In-memory cert detection via the `openssl3-cert-load.yaml` Tetragon policy (`SSL_CTX_use_certificate_ASN1` uprobe); cert-analyzer builds a synthetic `uprobe://SSL_CTX_use_certificate_ASN1/<pid>/<serial>` path since there's no real one |
+| load a certificate into a Java KeyStore (JCA) and let CertSight discover it | Spawns a JVM (`CertAgentTest`), jattaches CertSight's cert-agent Java instrumentation into it, then watches it call `KeyStore.setCertificateEntry()` on a fresh in-memory cert every few seconds | In-memory JCA cert detection via the `java-non-fips-cert.yaml` Tetragon policy (`java_cert_agent_write` uprobe); cert-analyzer builds a synthetic `uprobe://java_cert_agent_write/<pid>/<serial>` path since there's no real file |
 
 The RSA key size is selectable (1024/2048/3072/4096 bits) via a dropdown
 next to the button, both in the UI and as a `{"key_size": "1024"}` JSON
@@ -587,7 +587,7 @@ At most 2 of these can run concurrently
 (`_MAX_CONCURRENT_CONNECT_PROBES` in `use_cases.py`), for the same
 unauthenticated-endpoint reason as the bind-probe use case's own cap.
 
-### dial out with a real SNI hostname behind a CDN-style edge
+### dial out with a real SNI hostname behind a CDN-style edge and let CertSight discover it
 
 Verifies the `SSL_ctrl` uprobe fix on branch `connect_probe_sni_capture`
 for connect-probe's CDN fallback-cert gap (see
@@ -639,7 +639,7 @@ tells the two outcomes apart is the CN inside the resulting Kafka event,
 which `use_cases.py`'s result message reports back alongside the port so
 you know what to look for either way.
 
-### load a certificate straight into memory (no file)
+### load a certificate straight into memory (no file) and let CertSight discover it
 
 Unlike the other two use cases, this one exercises a **uprobe**, not a
 kprobe -- `openssl3-cert-load.yaml` hooks `SSL_CTX_use_certificate_ASN1`
@@ -676,7 +676,7 @@ This use case has no `--pause`/concurrency limit like the bind-probe one:
 it's a single in-process library call with no child process or listening
 socket, so nothing to bound.
 
-### load a certificate into a Java KeyStore (JCA)
+### load a certificate into a Java KeyStore (JCA) and let CertSight discover it
 
 Unlike every other use case here, the certificate is never handled by this
 Python process at all -- it's loaded by a **separate JVM**, and detection

--- a/extras/test-server/use_cases.py
+++ b/extras/test-server/use_cases.py
@@ -1144,7 +1144,7 @@ def _run_java_keystore_cert(params: dict) -> UseCaseResult:
 USE_CASES: List[UseCase] = [
     UseCase(
         id="fresh-test-cert",
-        label="generate + read a fresh test certificate",
+        label="generate + read a fresh test certificate and let CertSight discover it",
         description=(
             f"Generates a new self-signed certificate at a unique path under "
             f"{_GENERATED_CERT_DIR} and cat's it. Guaranteed to be a first-time "
@@ -1373,7 +1373,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="tcp-connect-sni-capture",
-        label="dial out with a real SNI hostname behind a CDN-style edge",
+        label="dial out with a real SNI hostname behind a CDN-style edge and let CertSight discover it",
         description=(
             "Verifies the SSL_ctrl uprobe fix for connect-probe's CDN "
             "fallback-cert gap. Spawns a separate process that binds a real "
@@ -1479,7 +1479,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="in-memory-asn1-cert",
-        label="load a certificate straight into memory (no file)",
+        label="load a certificate straight into memory (no file) and let CertSight discover it",
         description=(
             "Generates a fresh self-signed certificate as raw DER bytes and "
             "hands them straight to libssl's SSL_CTX_use_certificate_ASN1() "
@@ -1545,7 +1545,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="java-jca-keystore",
-        label="load a certificate into a Java KeyStore (JCA)",
+        label="load a certificate into a Java KeyStore (JCA) and let CertSight discover it",
         description=(
             "Spawns a real JVM running CertAgentTest, jattaches CertSight's "
             "cert-agent Java instrumentation into it, then watches it call "
@@ -1619,7 +1619,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="cert-chain-missing-intermediates",
-        label="generate a 5-cert chain with missing intermediates",
+        label="generate a 5-cert chain with missing intermediates and let CertSight discover it",
         description=(
             "Builds a full 5-certificate chain (root CA -> 3 intermediate CAs "
             "-> leaf) and writes only some of it to a single PEM bundle, "
@@ -1684,7 +1684,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="cert-chain-across-multiple-files",
-        label="generate a 5-cert chain split across several files",
+        label="generate a 5-cert chain split across several files and let CertSight discover it",
         description=(
             "Same 5-certificate chain and same missing-intermediates drop "
             "rule as the use case above, but instead of writing the "
@@ -1748,7 +1748,7 @@ USE_CASES: List[UseCase] = [
     ),
     UseCase(
         id="spki-key-reuse",
-        label="reuse one key across two unrelated certs",
+        label="reuse one key across two unrelated certs and let CertSight discover it",
         description=(
             "Generates two certificates from the same RSA key but with "
             "different subjects, simulating the same private key backing "


### PR DESCRIPTION
…queries

Surfaces fleet_fips_rollout.py's per-session negotiated protocol/cipher data (previously only reachable by scraping the /fleet-fips-rollout HTML page) as a proper MCP tool: one row per negotiated TLS session, with the process/pod that negotiated it and whether the cipher is NIST SP 800-52 Rev. 2 approved, independent of the served certificate's own FIPS judgement. drift_only=true filters to just the non-approved sessions.