### PR TITLE
Drop UBI_VERSION -- fold into a single UBI_PYTHON_IMAGE arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          UBI_VERSION=${{ matrix.ubi-version }}
+          UBI_PYTHON_IMAGE=registry.access.redhat.com/ubi${{ matrix.ubi-version }}/python-${{ matrix.python-version }}:latest
           PYTHON_VERSION=${{ matrix.python-version }}
           TETRAGON_VERSION=${{ env.TETRAGON_VERSION }}
           VERSION=${{ steps.version.outputs.value }}

--- a/Containerfile
+++ b/Containerfile
@@ -4,12 +4,17 @@
 # ./fetch-tetragon-src.sh) into Python bindings using grpcio-tools.
 # grpcio-tools is NOT carried forward into the runtime image.
 # =============================================================================
-ARG UBI_VERSION=9
+# PYTHON_VERSION also drives the optional Python bootstrap below (see
+# BOOTSTRAP_PYTHON), independent of where UBI_PYTHON_IMAGE points -- so it
+# stays a separate arg rather than being folded into UBI_PYTHON_IMAGE.
 ARG PYTHON_VERSION=311
-# Override to point at a corporate mirror/proxy of the UBI Python image
-# (e.g. registry.corp.example.com/ubi9/python-311:latest) instead of the
-# public Red Hat registry.
-ARG UBI_PYTHON_IMAGE=registry.access.redhat.com/ubi${UBI_VERSION}/python-${PYTHON_VERSION}:latest
+# Full image reference -- override to build against a specific UBI major
+# version (registry.access.redhat.com/ubi8/python-311:latest) or point at a
+# corporate mirror/proxy, possibly a bare RHEL 8/9 image with no Python
+# preinstalled (see BOOTSTRAP_PYTHON below) instead of the public Red Hat
+# registry's UBI "S2I Python" flavor. CI passes this explicitly per matrix
+# entry rather than relying on this default -- see build.yml's `build` job.
+ARG UBI_PYTHON_IMAGE=registry.access.redhat.com/ubi9/python-${PYTHON_VERSION}:latest
 
 FROM ${UBI_PYTHON_IMAGE} AS proto-builder
 


### PR DESCRIPTION
UBI_VERSION was only ever used to build UBI_PYTHON_IMAGE's default string, and anyone overriding for a corporate mirror already bypassed that construction by setting UBI_PYTHON_IMAGE directly. PYTHON_VERSION stays separate since the Python bootstrap block needs it independent of where the base image comes from.

build.yml's `build` job (the one building this Containerfile) now constructs the full ubi<N>/python-<ver> reference itself per matrix entry instead of relying on the Containerfile's internal interpolation -- matrix.ubi-version is unchanged everywhere else (job name, tag suffix, cache scope). The test-server-container and test-generator jobs build different Containerfiles and are untouched.

Verified with podman: default build (no args) unaffected; explicit UBI_PYTHON_IMAGE=.../ubi8/python-311:latest (matching what CI now passes for the ubi8 matrix entry) builds cleanly with both sanity checks passing.