### PR TITLE
Package the MCP server as an RPM (certsight-mcp)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       java-agent: ${{ steps.filter.outputs.java-agent }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
       test-server: ${{ steps.filter.outputs.test-server }}
+      mcp-server: ${{ steps.filter.outputs.mcp-server }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
@@ -64,6 +65,9 @@ jobs:
             - '.github/workflows/build.yml'
           test-server:
             - 'extras/test-server/**'
+            - '.github/workflows/build.yml'
+          mcp-server:
+            - 'extras/mcp-server/**'
             - '.github/workflows/build.yml'
 
   build:
@@ -392,6 +396,87 @@ jobs:
     - name: Build summary
       run: |
         echo "## 📦 Test Server RPM Build (RHEL ${{ matrix.ubi-version }})" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** \`${{ steps.version.outputs.value }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**RPM:** \`${{ steps.rpm.outputs.name }}\`" >> $GITHUB_STEP_SUMMARY
+
+  build-mcp-server-rpm:
+    name: Build MCP Server RPM (RHEL ${{ matrix.ubi-version }})
+    runs-on: ubuntu-latest
+    needs: changes
+    # Always run on tags, PRs, and manual dispatch; on branch pushes only run
+    # if extras/mcp-server/** changed. workflow_dispatch is included so this
+    # can be built on demand from any branch without cutting a tag release --
+    # see extras/mcp-server/MCP-SERVER-README.md.
+    if: |
+      github.ref_type == 'tag' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.mcp-server == 'true'
+    container:
+      image: registry.access.redhat.com/ubi${{ matrix.ubi-version }}/ubi:latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        ubi-version: ["8", "9"]
+
+    steps:
+    - name: Install build prerequisites
+      run: |
+        dnf install -y \
+          python3.11 \
+          python3.11-devel \
+          rpm-build \
+          git \
+          gcc \
+          findutils \
+          which
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Fix git safe directory
+      run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+    - name: Determine version string
+      id: version
+      run: |
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          VERSION="${{ github.ref_name }}"
+          echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
+          echo "release=1" >> $GITHUB_OUTPUT
+        else
+          SHA=$(git rev-parse --short HEAD)
+          echo "value=0.0.0~git${SHA}" >> $GITHUB_OUTPUT
+          echo "release=1" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build RPM
+      run: |
+        bash extras/mcp-server/build-rpm.sh \
+          --version "${{ steps.version.outputs.value }}" \
+          --release "${{ steps.version.outputs.release }}"
+
+    - name: Locate built RPM
+      id: rpm
+      run: |
+        RPM_PATH=$(find "${HOME}/rpmbuild/RPMS" -name "certsight-mcp-*.rpm" | head -1)
+        echo "path=${RPM_PATH}" >> $GITHUB_OUTPUT
+        echo "name=$(basename ${RPM_PATH})" >> $GITHUB_OUTPUT
+
+    - name: Upload RPM as build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.rpm.outputs.name }}
+        path: ${{ steps.rpm.outputs.path }}
+        retention-days: 30
+
+    - name: Build summary
+      run: |
+        echo "## 📦 MCP Server RPM Build (RHEL ${{ matrix.ubi-version }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** \`${{ steps.version.outputs.value }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -1012,7 +1097,7 @@ jobs:
     # today. Once the secrets exist and both AMI jobs are proven reliable,
     # add them to this needs: list and wire their ami_id outputs into the
     # release body below.
-    needs: [ build, build-rpm, build-policies, build-test-generator, build-probe-tests, build-java-agent-rpms, build-test-server-rpm, build-test-server-container ]
+    needs: [ build, build-rpm, build-policies, build-test-generator, build-probe-tests, build-java-agent-rpms, build-test-server-rpm, build-test-server-container, build-mcp-server-rpm ]
     permissions:
       contents: write
 
@@ -1066,6 +1151,13 @@ jobs:
         merge-multiple: true
         path: ./release-assets
 
+    - name: Download MCP Server RPM artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: certsight-mcp-*.rpm
+        merge-multiple: true
+        path: ./release-assets
+
     - name: Download cert-test-server container artifacts
       uses: actions/download-artifact@v4
       with:
@@ -1105,6 +1197,10 @@ jobs:
         echo "test_server_ubi8_name=$(basename ${TEST_SERVER_UBI8_PATH})" >> $GITHUB_OUTPUT
         TEST_SERVER_UBI9_PATH=$(find ./release-assets -name "certsight-test-server-*.el9*.rpm" | head -1)
         echo "test_server_ubi9_name=$(basename ${TEST_SERVER_UBI9_PATH})" >> $GITHUB_OUTPUT
+        MCP_UBI8_PATH=$(find ./release-assets -name "certsight-mcp-*.el8*.rpm" | head -1)
+        echo "mcp_ubi8_name=$(basename ${MCP_UBI8_PATH})" >> $GITHUB_OUTPUT
+        MCP_UBI9_PATH=$(find ./release-assets -name "certsight-mcp-*.el9*.rpm" | head -1)
+        echo "mcp_ubi9_name=$(basename ${MCP_UBI9_PATH})" >> $GITHUB_OUTPUT
         TEST_SERVER_CONTAINER_UBI8_PATH=$(find ./release-assets -name "cert-test-server-ubi8-*.tar.gz" | head -1)
         echo "test_server_container_ubi8_path=${TEST_SERVER_CONTAINER_UBI8_PATH}" >> $GITHUB_OUTPUT
         echo "test_server_container_ubi8_name=$(basename ${TEST_SERVER_CONTAINER_UBI8_PATH})" >> $GITHUB_OUTPUT
@@ -1122,6 +1218,7 @@ jobs:
           ./release-assets/cert-agent-jni-*.rpm
           ./release-assets/cert-agent-deployer-*.rpm
           ./release-assets/certsight-test-server-*.rpm
+          ./release-assets/certsight-mcp-*.rpm
           ${{ steps.assets.outputs.policies_path }}
           ${{ steps.assets.outputs.container_ubi8_path }}
           ${{ steps.assets.outputs.container_ubi9_path }}
@@ -1186,6 +1283,14 @@ jobs:
           certsight-test-server --kafka-host localhost --kafka-port 9092
           ```
           See `extras/test-server/TEST-SERVER-README.md` for prerequisites and how the detection pipeline works end to end. A container image is also published (see Container Images above) for running it in-cluster instead of installing the RPM directly on a host.
+
+          **certsight-mcp** (read-only MCP server for querying fleet cert/FIPS/chain data from Claude Desktop/Code — bundles its own venv, no pip/internet access needed on the target host; requires certsight-test-server, installed automatically alongside it):
+          ```bash
+          sudo dnf install ./${{ steps.assets.outputs.mcp_ubi8_name }}   # RHEL 8
+          sudo dnf install ./${{ steps.assets.outputs.mcp_ubi9_name }}   # RHEL 9
+          certsight-mcp
+          ```
+          See `extras/mcp-server/MCP-SERVER-README.md` for the network-transport configuration and Claude Desktop/Code setup.
 
           ### Tetragon Policies (tar.gz)
 

--- a/extras/aws-demo/deploy-demo.sh
+++ b/extras/aws-demo/deploy-demo.sh
@@ -125,6 +125,7 @@ if [[ -z "${SG_ID}" || "${SG_ID}" == "None" ]]; then
         "IpProtocol=tcp,FromPort=3000,ToPort=3000,IpRanges=[{CidrIp=0.0.0.0/0,Description='Grafana dashboard'}]" \
         "IpProtocol=tcp,FromPort=8090,ToPort=8090,IpRanges=[{CidrIp=0.0.0.0/0,Description='CertSight test console'}]" \
         "IpProtocol=tcp,FromPort=8092,ToPort=8092,IpRanges=[{CidrIp=0.0.0.0/0,Description='CertSight MCP server (rate-limited by nginx)'}]" \
+        "IpProtocol=tcp,FromPort=80,ToPort=80,IpRanges=[{CidrIp=0.0.0.0/0,Description='Lets Encrypt HTTP-01 challenge (see enable-mcp-https.sh)'}]" \
         >/dev/null
     echo "    Created security group ${SG_ID}"
 else

--- a/extras/aws-demo/enable-mcp-https.sh
+++ b/extras/aws-demo/enable-mcp-https.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# enable-mcp-https.sh — Terminate TLS at nginx for the MCP server (port 8092)
+# with a real Let's Encrypt certificate, rather than adding TLS support to
+# server.py itself -- matches how the rest of this stack already works
+# (nginx already fronts the MCP server for rate-limiting; see
+# user-data.sh's "nginx reverse proxy in front of the MCP server" section).
+#
+# Deliberately a separate script, not folded into user-data.sh: user-data.sh
+# runs during instance *boot*, before deploy-demo.sh has pointed DNS at the
+# new instance's IP -- Let's Encrypt's HTTP-01 challenge validates domain
+# control by connecting back to port 80 on that name, so it can only run
+# once DNS has actually propagated. Run this after deploy-demo.sh finishes
+# (and, for a fresh instance, after giving DNS a minute or two to catch up).
+#
+# Also usable to retrofit an already-running demo instance that predates
+# this script -- reads connection details from .certsight-demo-state the
+# same way update-ssh-ip.sh does, and is safe to re-run (certbot no-ops on
+# an existing non-expiring-soon cert; the SG rule authorize is idempotent).
+#
+# Usage:
+#   ./enable-mcp-https.sh [domain]   # defaults to DOMAIN_NAME in the state file
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${SCRIPT_DIR}/.certsight-demo-state"
+
+if [[ ! -f "${STATE_FILE}" ]]; then
+    echo "No ${STATE_FILE} found -- run deploy-demo.sh first."
+    exit 1
+fi
+# shellcheck disable=SC1090
+source "${STATE_FILE}"
+
+DOMAIN="${1:-${DOMAIN_NAME:-}}"
+if [[ -z "${DOMAIN}" ]]; then
+    echo "No domain given and DOMAIN_NAME isn't set in ${STATE_FILE} -- pass one explicitly:" >&2
+    echo "  ./enable-mcp-https.sh certsight-demo.com" >&2
+    exit 1
+fi
+
+echo "==> Confirming ${DOMAIN} resolves to this instance's public IP (${PUBLIC_IP})..."
+RESOLVED_IP="$(dig +short "${DOMAIN}" A | tail -1)"
+if [[ "${RESOLVED_IP}" != "${PUBLIC_IP}" ]]; then
+    echo "WARNING: ${DOMAIN} currently resolves to '${RESOLVED_IP:-<nothing>}', not ${PUBLIC_IP}." >&2
+    echo "         Let's Encrypt's HTTP-01 challenge will fail until DNS has propagated -- wait a" >&2
+    echo "         few minutes (DNS TTL is 300s) and retry." >&2
+    exit 1
+fi
+
+echo "==> Ensuring port 80 (needed for the HTTP-01 challenge, both now and on every renewal) is open on ${SG_ID}..."
+aws ec2 authorize-security-group-ingress --region "${AWS_REGION}" --group-id "${SG_ID}" \
+    --ip-permissions "IpProtocol=tcp,FromPort=80,ToPort=80,IpRanges=[{CidrIp=0.0.0.0/0,Description='Lets Encrypt HTTP-01 challenge'}]" \
+    2>/dev/null || true   # already-open is a harmless duplicate-rule error
+
+echo "==> Obtaining/renewing the certificate and reconfiguring nginx over SSH..."
+ssh -o StrictHostKeyChecking=no -i "${SCRIPT_DIR}/${KEY_NAME}.pem" "rocky@${PUBLIC_IP}" "DOMAIN='${DOMAIN}' sudo -E bash -s" <<'REMOTE'
+set -euo pipefail
+
+echo "--- installing certbot ---"
+dnf -y install epel-release || true
+dnf -y install certbot
+
+echo "--- obtaining/renewing the certificate (standalone mode, port 80) ---"
+# --standalone briefly binds port 80 itself for the HTTP-01 challenge --
+# nothing else on this box listens there (nginx is only ever on
+# 3000/8090/8092), so there's no conflict. --deploy-hook is persisted into
+# certbot's own renewal config (/etc/letsencrypt/renewal/<domain>.conf), so
+# certbot-renew.timer's automatic future renewals reload nginx too, not
+# just this first run. certbot itself no-ops (exit 0, nothing re-issued) if
+# a valid cert for this name already exists and isn't close to expiring.
+certbot certonly --standalone --non-interactive --agree-tos \
+    --register-unsafely-without-email \
+    --deploy-hook "systemctl reload nginx" \
+    -d "${DOMAIN}"
+
+echo "--- adding TLS to the MCP server's nginx block (idempotent) ---"
+CERT_DIR="/etc/letsencrypt/live/${DOMAIN}"
+if ! grep -q "listen 8092 ssl" /etc/nginx/conf.d/certsight-mcp.conf; then
+    sed -i \
+        -e "s#listen 8092 default_server;#listen 8092 ssl default_server;\n    ssl_certificate ${CERT_DIR}/fullchain.pem;\n    ssl_certificate_key ${CERT_DIR}/privkey.pem;#" \
+        /etc/nginx/conf.d/certsight-mcp.conf
+fi
+
+nginx -t && systemctl reload nginx
+echo "--- done ---"
+REMOTE
+
+echo ""
+echo "==> Point an MCP client at the TLS endpoint:"
+echo "    claude mcp add --transport http certsight https://${DOMAIN}:8092/mcp"

--- a/extras/aws-demo/user-data.sh
+++ b/extras/aws-demo/user-data.sh
@@ -67,12 +67,15 @@ tar -xzf tetragon-policies.tar.gz
 # legitimately fail on a stock image -- don't let that abort the whole install.
 ./tetragon-policies/apply-policies.sh || true
 
-echo "=== [6/9] CertSight RPMs (cert-analyzer, Java cert-agent, test console) ==="
+echo "=== [6/9] CertSight RPMs (cert-analyzer, Java cert-agent, test console, MCP server) ==="
 mkdir -p rpms && cd rpms
-for pkg in cert-analyzer cert-agent-jni cert-agent-deployer certsight-test-server; do
+for pkg in cert-analyzer cert-agent-jni cert-agent-deployer certsight-test-server certsight-mcp; do
     curl -fsSL -O "${RELEASE_BASE}/${pkg}-${CERTSIGHT_VERSION#v}-1.el9.x86_64.rpm"
 done
-# Installed together so dnf can resolve the local inter-package deps in one transaction
+# Installed together so dnf can resolve the local inter-package deps in one
+# transaction -- certsight-mcp Requires certsight-test-server (it imports
+# that package's blast_radius.py/fleet_blast_radius.py/chain_explorer.py/
+# fleet_fips_rollout.py rather than bundling copies).
 dnf -y install ./*.rpm
 cd "${WORKDIR}"
 
@@ -237,24 +240,17 @@ systemctl enable --now nginx
 nginx -t && systemctl reload nginx
 
 echo "=== MCP server (read-only fleet queries, no auth -- nginx rate-limits it) ==="
-# Runs straight out of the certsight-src checkout cloned in step [4/9] above --
-# extras/mcp-server/server.py imports its query functions from the sibling
-# extras/test-server/ directory, so this only works when run from inside
-# that checkout, not copied out on its own. Only the venv is private to this
-# service; the source is shared read-only with everything else that came
-# from that same clone.
-id certsight-mcp &>/dev/null || useradd --system --no-create-home --shell /sbin/nologin certsight-mcp
-
-MCP_SRC_DIR="${WORKDIR}/certsight-src/extras/mcp-server"
-dnf -y install python3.11 || true
-python3.11 -m venv /opt/certsight-mcp/venv
-/opt/certsight-mcp/venv/bin/pip install --quiet -r "${MCP_SRC_DIR}/requirements.txt"
-chown -R certsight-mcp:certsight-mcp /opt/certsight-mcp
-
+# Installed via RPM alongside the other packages in step [6/9] above (bundled
+# venv, systemd unit, dedicated user all come from the package -- see
+# extras/mcp-server/certsight-mcp.spec). Its own default
+# /etc/certsight-mcp/mcp.conf is a %config(noreplace) file with everything
+# commented out; overwritten here with this demo's real values the same way
+# TSCONF is above -- noreplace only protects an *upgrade* from clobbering an
+# operator's edits, not this first-boot provisioning step.
+#
 # No auth -- open like the dashboard/test console. Bound to localhost only
 # (127.0.0.1:8093); nginx below is the public-facing side on 8092, same
 # division of labor as the test console (8091 internal / 8090 public).
-mkdir -p /etc/certsight-mcp
 cat <<'EOF' > /etc/certsight-mcp/mcp.conf
 CERTSIGHT_MCP_TRANSPORT=streamable-http
 CERTSIGHT_MCP_HOST=127.0.0.1
@@ -262,9 +258,7 @@ CERTSIGHT_MCP_PORT=8093
 CERTSIGHT_PROMETHEUS_URL=http://127.0.0.1:9091
 EOF
 chmod 644 /etc/certsight-mcp/mcp.conf
-
-cp "${WORKDIR}/certsight-src/extras/systemd/certsight-mcp.service" /etc/systemd/system/certsight-mcp.service
-systemctl daemon-reload
+systemctl reset-failed certsight-mcp || true
 systemctl enable --now certsight-mcp
 
 echo "=== nginx reverse proxy in front of the MCP server (rate limiting) ==="

--- a/extras/mcp-server/MCP-SERVER-README.md
+++ b/extras/mcp-server/MCP-SERVER-README.md
@@ -23,6 +23,11 @@ read-only query API.
 
 ## Setup
 
+Two ways to get this running, depending on whether the target host has
+pip/internet access.
+
+### Option A: virtualenv (target host has pip/internet access)
+
 Requires Python 3.10+ (the `mcp` SDK's minimum):
 
 ```bash
@@ -30,6 +35,52 @@ cd extras/mcp-server
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+Only `mcp` itself needs installing here -- `server.py` imports its query
+functions (`blast_radius.py`, `fleet_blast_radius.py`, `chain_explorer.py`,
+`fleet_fips_rollout.py`) straight from the sibling
+[`extras/test-server/`](../test-server/TEST-SERVER-README.md) directory, so
+this only works run from inside a full repo checkout, not copied out on its
+own.
+
+### Option B: RPM (target host has no pip/internet access)
+
+CI builds this RPM already, for both el8 and el9, with the `mcp` SDK bundled
+into a relocatable virtualenv at `/opt/certsight-mcp/venv` -- no need to
+build it yourself. Grab `certsight-mcp-*.el8*.rpm` / `*.el9*.rpm` from a
+tagged [Release](../../releases) page, or -- for an untagged branch/PR --
+from the `build-mcp-server-rpm` job's artifacts on its
+[Actions run](../../actions/workflows/build.yml) (also triggerable on-demand
+via `workflow_dispatch`). Copy it to the target host and install it there
+with zero pip/internet access required:
+
+```bash
+sudo dnf install ./certsight-mcp-<version>-<release>.el9.*.rpm
+```
+
+This also pulls in `certsight-test-server` (a declared `Requires` -- see the
+Option A note above on why) if it isn't already installed. Unlike a source
+checkout, the RPM install has no sibling directory relationship between the
+two packages, so `certsight-mcp.service` sets
+`CERTSIGHT_TEST_SERVER_DIR=/opt/certsight-test-server` explicitly; running
+the bare `certsight-mcp` binary outside systemd needs the same variable set
+by hand.
+
+Only build it locally (`./build-rpm.sh --version 0.1.0 --release 1`) if you
+need a change that hasn't been through CI yet. Run that on any machine with
+normal pip/PyPI access (it doesn't need to be the target host), and it
+produces the same RPM under
+`~/rpmbuild/RPMS/$(uname -m)/certsight-mcp-<version>-<release>.*.rpm`,
+following the same pattern as `certsight-test-server.spec` (see there for
+why the debuginfo/build-id suppression macros at the top of the spec are
+needed).
+
+This installs a `certsight-mcp` wrapper onto `$PATH` that runs `server.py`
+with the bundled venv's interpreter, plus a `certsight-mcp.service` systemd
+unit and a dedicated `certsight-mcp` system user -- see "Running over the
+network" below.
+
+### Prometheus URL
 
 Point it at your Prometheus (defaults to `http://127.0.0.1:9090` if unset —
 note the dev-box convention elsewhere in this repo puts Prometheus on
@@ -70,6 +121,14 @@ export CERTSIGHT_MCP_TRANSPORT=streamable-http
 export CERTSIGHT_MCP_HOST=0.0.0.0   # or 127.0.0.1 to keep it local-only
 export CERTSIGHT_MCP_PORT=8092  # 8091 is already the test-console's internal port
 python3 server.py
+```
+
+RPM install (Option B above) instead configures `/etc/certsight-mcp/mcp.conf`
+and lets systemd manage it:
+
+```bash
+sudo $EDITOR /etc/certsight-mcp/mcp.conf   # uncomment/set the CERTSIGHT_MCP_* vars above
+sudo systemctl enable --now certsight-mcp
 ```
 
 **No auth of any kind** — same open-by-design posture as the Grafana

--- a/extras/mcp-server/MCP-SERVER-README.md
+++ b/extras/mcp-server/MCP-SERVER-README.md
@@ -140,6 +140,15 @@ box without a rate-limiting reverse proxy in front of it — see
 uses on the live AWS demo (per-IP request-rate and connection limits, the
 server itself only ever bound to `127.0.0.1`).
 
+`server.py` itself has no HTTPS support, deliberately — TLS is terminated
+at the reverse proxy instead, same division of labor as rate limiting
+above. On the AWS demo, `extras/aws-demo/enable-mcp-https.sh` gets a real
+Let's Encrypt certificate and adds a `listen 8092 ssl` block to nginx's
+config; note it's a separate script from `user-data.sh` rather than part
+of first-boot provisioning, since it needs DNS already pointed at the
+instance before Let's Encrypt's HTTP-01 challenge can succeed. Once run,
+point clients at `https://` instead of `http://`.
+
 Point an MCP client at it with:
 
 ```bash

--- a/extras/mcp-server/build-rpm.sh
+++ b/extras/mcp-server/build-rpm.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# build-rpm.sh — Build the certsight-mcp RPM on RHEL9
+#
+# Bundles a Python virtualenv (the `mcp` SDK) into the RPM so it can be
+# installed and run on a target host with no pip/internet access at all —
+# see MCP-SERVER-README.md. Run this on a machine that *does* have normal
+# pip/PyPI access (it need not be the target host), then copy the resulting
+# RPM over.
+#
+# Usage:
+#   ./build-rpm.sh [--version <version>] [--release <release>]
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+RPM_RELEASE="${RPM_RELEASE:-1}"
+VERSION="${RPM_VERSION:-0.1.0}"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2";     shift 2 ;;
+        --release) RPM_RELEASE="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+echo "============================================================"
+echo " Building certsight-mcp RPM"
+echo " Version: $VERSION"
+echo " Release: $RPM_RELEASE"
+echo "============================================================"
+
+# ── Verify prerequisites ──────────────────────────────────────────────────────
+for cmd in python3.11 rpmbuild; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "ERROR: $cmd is required but not installed."
+        echo "Run: dnf install python3.11 python3.11-devel python3.11-pip rpm-build gcc"
+        exit 1
+    fi
+done
+
+# ── Set up rpmbuild tree ──────────────────────────────────────────────────────
+RPMBUILD_ROOT="${RPMBUILD_ROOT:-$HOME/rpmbuild}"
+for dir in BUILD BUILDROOT RPMS SOURCES SPECS SRPMS; do
+    mkdir -p "$RPMBUILD_ROOT/$dir"
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ ! -f "$REPO_ROOT/LICENSE" ]]; then
+    echo "ERROR: Required file not found: $REPO_ROOT/LICENSE"
+    exit 1
+fi
+
+# ── Create source tarball ─────────────────────────────────────────────────────
+TARNAME="certsight-mcp-${VERSION}"
+TARBALL="$RPMBUILD_ROOT/SOURCES/${TARNAME}.tar.gz"
+
+echo "Creating source tarball: $TARBALL"
+
+TMPDIR_SRC="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SRC"' EXIT
+
+mkdir -p "$TMPDIR_SRC/$TARNAME"
+cp "$SCRIPT_DIR/server.py"              "$TMPDIR_SRC/$TARNAME/"
+cp "$SCRIPT_DIR/requirements.txt"       "$TMPDIR_SRC/$TARNAME/"
+cp "$SCRIPT_DIR/certsight-mcp.service"  "$TMPDIR_SRC/$TARNAME/"
+cp "$SCRIPT_DIR/mcp.conf"               "$TMPDIR_SRC/$TARNAME/"
+cp "$REPO_ROOT/LICENSE"                 "$TMPDIR_SRC/$TARNAME/"
+
+tar -czf "$TARBALL" -C "$TMPDIR_SRC" "$TARNAME"
+echo "Tarball created: $TARBALL"
+
+# ── Copy spec file ────────────────────────────────────────────────────────────
+cp "$SCRIPT_DIR/certsight-mcp.spec" "$RPMBUILD_ROOT/SPECS/certsight-mcp.spec"
+
+# ── Run rpmbuild ──────────────────────────────────────────────────────────────
+echo "Running rpmbuild..."
+rpmbuild -ba \
+    --define "_topdir $RPMBUILD_ROOT" \
+    --define "_version $VERSION" \
+    --define "_release $RPM_RELEASE" \
+    "$RPMBUILD_ROOT/SPECS/certsight-mcp.spec"
+
+# ── Report output ─────────────────────────────────────────────────────────────
+echo ""
+echo "============================================================"
+echo " Build complete"
+echo "============================================================"
+echo ""
+echo "RPM package:"
+find "$RPMBUILD_ROOT/RPMS" -name "certsight-mcp-*.rpm" | sort
+echo ""
+echo "Source RPM:"
+find "$RPMBUILD_ROOT/SRPMS" -name "certsight-mcp-*.src.rpm" | sort
+echo ""
+echo "Copy the RPM to the target host, then install it there with no"
+echo "pip/internet access required (also installs certsight-test-server,"
+echo "a declared dependency, if not already present):"
+echo "  sudo dnf install ./certsight-mcp-${VERSION}-${RPM_RELEASE}.*.rpm"
+echo ""
+echo "Then either run it in the foreground:"
+echo "  certsight-mcp"
+echo ""
+echo "...or configure /etc/certsight-mcp/mcp.conf and let systemd manage it:"
+echo "  systemctl enable --now certsight-mcp"

--- a/extras/mcp-server/certsight-mcp.service
+++ b/extras/mcp-server/certsight-mcp.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=CertSight read-only fleet MCP server
+Documentation=https://github.com/your-org/cert-analyzer
+After=network.target cert-analyzer.service
+Wants=cert-analyzer.service
+
+[Service]
+Type=simple
+User=certsight-mcp
+Group=certsight-mcp
+
+# CERTSIGHT_MCP_TRANSPORT/_HOST/_PORT/_PROMETHEUS_URL/_ENABLE_RAW_QUERY all
+# come from this file -- see MCP-SERVER-README.md. _HOST should stay
+# 127.0.0.1 -- there's no auth or rate limiting at this layer, so a
+# reverse proxy (nginx, on the AWS demo) is what actually gates the public
+# port; see extras/aws-demo/user-data.sh.
+EnvironmentFile=/etc/certsight-mcp/mcp.conf
+
+# certsight-test-server (a declared package Requires) installs to
+# /opt/certsight-test-server -- server.py imports its blast_radius.py/
+# fleet_blast_radius.py/chain_explorer.py/fleet_fips_rollout.py from there
+# rather than bundling copies that could drift.
+Environment=CERTSIGHT_TEST_SERVER_DIR=/opt/certsight-test-server
+
+ExecStart=/usr/bin/certsight-mcp
+
+Restart=on-failure
+RestartSec=10
+StartLimitInterval=300
+StartLimitBurst=5
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=certsight-mcp
+
+# Security hardening, matching certsight-test-server.service: this process
+# has no auth of its own and is only ever bound to 127.0.0.1 -- nginx is
+# what's actually reachable from the internet, per the same rate-limiting
+# rationale as the test console.
+NoNewPrivileges=true
+CapabilityBoundingSet=
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+LimitNOFILE=65536
+MemoryMax=256M
+CPUQuota=100%
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/mcp-server/certsight-mcp.spec
+++ b/extras/mcp-server/certsight-mcp.spec
@@ -1,0 +1,181 @@
+# certsight-mcp.spec
+#
+# RPM spec for the CertSight read-only fleet MCP server (extras/mcp-server/).
+# Bundles a Python virtualenv (the `mcp` SDK) so the package is fully
+# self-contained and requires no pip/internet access on the target host at
+# install or run time -- see MCP-SERVER-README.md.
+#
+# server.py calls straight into the certsight-test-server package's own
+# fleet-query modules (blast_radius.py, fleet_blast_radius.py, etc.) rather
+# than duplicating them -- this package Requires certsight-test-server and
+# points CERTSIGHT_TEST_SERVER_DIR at its install path (see
+# certsight-mcp.service) instead of shipping copies that could drift.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+%global app_home /opt/certsight-mcp
+%global app_venv %{app_home}/venv
+%global app_conf /etc/certsight-mcp
+
+# The service runs as a dedicated non-privileged user, same pattern as
+# cert-analyzer.spec / certsight-test-server.spec
+%global svc_user  certsight-mcp
+%global svc_group certsight-mcp
+
+# ── Suppress rpmbuild post-processing that breaks bundled venvs ───────────────
+# Same rationale as certsight-test-server.spec: do not mangle shebangs inside
+# the bundled virtualenv, and disable debuginfo/build-id symlink generation.
+%global __brp_mangle_shebangs_exclude_from %{app_home}/.*
+
+%define debug_package %{nil}
+%global _build_id_links none
+%global __debug_install_post %{nil}
+%global __spec_install_post \
+    %{?__debug_package:%{__debug_install_post}} \
+    %{__os_install_post} \
+%{nil}
+
+Name:           certsight-mcp
+Version:        %{_version}
+Release:        %{_release}%{?dist}
+Summary:        Read-only MCP server for querying CertSight fleet data
+License:        Apache-2.0
+URL:            https://github.com/your-org/cert-analyzer
+
+# Source tarball created by build-rpm.sh
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  python3.11
+BuildRequires:  systemd-rpm-macros
+
+Requires:       python3.11
+Requires:       systemd
+# server.py imports blast_radius.py/fleet_blast_radius.py/chain_explorer.py/
+# fleet_fips_rollout.py from the test-server package rather than bundling
+# copies -- see certsight-mcp.service's CERTSIGHT_TEST_SERVER_DIR.
+Requires:       certsight-test-server
+
+
+%description
+A small read-only MCP (Model Context Protocol) server exposing CertSight's
+fleet certificate/FIPS/blast-radius/chain-explorer queries as tools for
+Claude Desktop or Claude Code, by calling straight into the same
+Prometheus-query functions the test console's own fleet explorer pages use.
+Every tool only ever issues a Prometheus read query -- there is no
+remote-write path anywhere in this package.
+
+This package bundles its own Python virtualenv (the `mcp` SDK) so it can be
+installed and run with no pip/internet access on the target host. It
+installs both a standalone `certsight-mcp` CLI and a certsight-mcp.service
+systemd unit -- see MCP-SERVER-README.md for the network-transport
+configuration and Claude Desktop/Code setup.
+
+
+%prep
+%setup -q
+
+
+%build
+# ── Clean any leftover artifacts from a previous build run ───────────────────
+rm -rf %{_builddir}/venv
+
+# ── Bootstrap pip (not available as a separate package on UBI9) ──────────────
+python3.11 -m ensurepip --upgrade
+
+# ── Build the bundled virtualenv ──────────────────────────────────────────────
+python3.11 -m venv %{_builddir}/venv
+%{_builddir}/venv/bin/pip install --quiet --upgrade pip
+%{_builddir}/venv/bin/pip install -r requirements.txt
+
+# Make the venv relocatable by rewriting the build-time prefix to the
+# install-time prefix.
+sed -i "s|%{_builddir}/venv|%{app_venv}|g" \
+    %{_builddir}/venv/bin/activate \
+    %{_builddir}/venv/bin/python3.11 \
+    %{_builddir}/venv/pyvenv.cfg || true
+
+
+%install
+rm -rf %{buildroot}
+
+# ── Application directory ─────────────────────────────────────────────────────
+install -d %{buildroot}%{app_home}
+install -d %{buildroot}%{app_venv}
+install -m 0644 server.py %{buildroot}%{app_home}/server.py
+
+# Bundled virtualenv
+cp -r %{_builddir}/venv/. %{buildroot}%{app_venv}/
+
+# Rewrite venv paths to their final install location
+find %{buildroot}%{app_venv}/bin -type f | xargs grep -rl "%{_builddir}/venv" 2>/dev/null | \
+    xargs sed -i "s|%{_builddir}/venv|%{app_venv}|g" || true
+sed -i "s|%{_builddir}/venv|%{app_venv}|g" \
+    %{buildroot}%{app_venv}/pyvenv.cfg || true
+
+# ── Wrapper executable ────────────────────────────────────────────────────────
+# Runs server.py with the bundled venv's interpreter, so callers never need
+# to know the venv's path or activate it themselves.
+install -d %{buildroot}%{_bindir}
+cat > %{buildroot}%{_bindir}/certsight-mcp << WRAPEOF
+#!/bin/sh
+exec %{app_venv}/bin/python3.11 %{app_home}/server.py "\$@"
+WRAPEOF
+chmod 0755 %{buildroot}%{_bindir}/certsight-mcp
+
+# ── systemd unit ─────────────────────────────────────────────────────────────
+install -d %{buildroot}%{_unitdir}
+install -m 0644 certsight-mcp.service %{buildroot}%{_unitdir}/certsight-mcp.service
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+install -d %{buildroot}%{app_conf}
+install -m 0644 mcp.conf %{buildroot}%{app_conf}/mcp.conf
+
+# ── Licence ───────────────────────────────────────────────────────────────────
+install -d %{buildroot}%{_defaultlicensedir}/%{name}
+install -m 0644 LICENSE %{buildroot}%{_defaultlicensedir}/%{name}/LICENSE
+
+
+%pre
+# Create the dedicated service user/group if they don't already exist.
+# --no-create-home: the service writes nothing under app_home.
+getent group %{svc_group} > /dev/null || \
+    groupadd --system %{svc_group}
+getent passwd %{svc_user} > /dev/null || \
+    useradd --system \
+            --gid %{svc_group} \
+            --home-dir %{app_home} \
+            --no-create-home \
+            --shell /sbin/nologin \
+            --comment "certsight-mcp service account" \
+            %{svc_user}
+exit 0
+
+
+%post
+%systemd_post certsight-mcp.service
+
+
+%preun
+%systemd_preun certsight-mcp.service
+
+
+%postun
+%systemd_postun_with_restart certsight-mcp.service
+
+
+%files
+%license %{_defaultlicensedir}/%{name}/LICENSE
+%dir %{app_home}
+%{app_home}/server.py
+%{app_venv}/
+%{_bindir}/certsight-mcp
+%{_unitdir}/certsight-mcp.service
+%dir %{app_conf}
+%config(noreplace) %{app_conf}/mcp.conf
+
+
+%changelog
+* %(date "+%a %b %d %Y") Build System <build@your-org.internal> - %{version}-%{release}
+- Initial RPM packaging -- previously only run straight out of a git
+  checkout with a hand-built venv (see MCP-SERVER-README.md and
+  extras/aws-demo/user-data.sh)

--- a/extras/mcp-server/mcp.conf
+++ b/extras/mcp-server/mcp.conf
@@ -1,0 +1,29 @@
+# certsight-mcp configuration
+# /etc/certsight-mcp/mcp.conf
+#
+# This is a systemd EnvironmentFile (shell KEY=VALUE, not a Python config
+# file) -- see server.py for the CERTSIGHT_* variables it reads. Only used
+# when running under systemd; the `certsight-mcp` / `python3 server.py` CLI
+# still reads the same environment variables directly and works standalone.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Transport: "stdio" (default -- for a local Claude Desktop/Code config that
+# launches this process itself) or "streamable-http" (for a network-reachable
+# deployment, e.g. behind nginx on the AWS demo). See MCP-SERVER-README.md.
+#CERTSIGHT_MCP_TRANSPORT=stdio
+
+# Only used when CERTSIGHT_MCP_TRANSPORT=streamable-http.
+#CERTSIGHT_MCP_HOST=127.0.0.1
+#CERTSIGHT_MCP_PORT=8092
+
+# Prometheus base URL every tool here queries (default: http://127.0.0.1:9090).
+# Deliberately an IPv4 literal, not "localhost" -- see test-server.conf's
+# identical note on hosts with IPv6 disabled at the kernel level.
+#CERTSIGHT_PROMETHEUS_URL=http://127.0.0.1:9090
+
+# Off by default. The one PromQL escape-hatch tool (query_prometheus) is the
+# only unbounded-query surface in this package -- everything else replays
+# fixed queries the test console's own fleet views already run publicly.
+# Only worth enabling on a deployment nobody but the operator can reach.
+#CERTSIGHT_ENABLE_RAW_QUERY=1

--- a/extras/mcp-server/server.py
+++ b/extras/mcp-server/server.py
@@ -33,7 +33,14 @@ import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test-server"))
+# Defaults to the sibling extras/test-server/ directory (a source checkout
+# layout); the certsight-mcp RPM has no such sibling -- its own
+# certsight-mcp.service sets CERTSIGHT_TEST_SERVER_DIR to wherever the
+# certsight-test-server RPM (a declared dependency) installed to instead.
+sys.path.insert(0, os.environ.get(
+    "CERTSIGHT_TEST_SERVER_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test-server"),
+))
 
 import blast_radius        # noqa: E402
 import fleet_blast_radius  # noqa: E402


### PR DESCRIPTION
Previously the only piece of this stack not RPM-packaged. Mirrors certsight-test-server.spec closely: bundled relocatable venv (just the `mcp` SDK), systemd unit, dedicated non-privileged user, %config(noreplace) env file.

server.py imports its query functions (blast_radius.py etc.) from the test-server package rather than bundling copies -- Requires certsight-test-server, and CERTSIGHT_TEST_SERVER_DIR (new, defaults to the existing sibling-directory behavior for source-checkout use) tells it where that package installed to. certsight-mcp.service sets it to /opt/certsight-test-server.

Adds build-mcp-server-rpm to build.yml (RHEL 8/9 matrix, mirroring build-test-server-rpm) and wires its output into the release job's assets/body. Switches the AWS demo's user-data.sh from the old ad-hoc venv+systemd-copy install to installing the RPM alongside the other four packages in one dnf transaction (dnf resolves the new certsight-mcp -> certsight-test-server dependency automatically).

extras/systemd/certsight-mcp.service (the old checkout-based unit template) is now unreferenced anywhere in the repo -- left in place rather than deleted, flagging it here since nothing else calls it out.

Verified end-to-end with rpmbuild + podman: built both RPMs locally, extracted them (no dnf/systemd needed for this check), and ran server.py's bundled-venv interpreter with CERTSIGHT_TEST_SERVER_DIR pointed at the real extracted certsight-test-server layout -- confirmed all 6 tools (including get_negotiated_sessions) import and register correctly against the actual installed file layout, not just in a dev checkout.