### PR TITLE
Fix/triage CodeQL code-scanning alerts (#10-#12, #18-#39)

### DIFF
--- a/agent/tls_probe.py
+++ b/agent/tls_probe.py
@@ -144,6 +144,7 @@ class _TlsProbeMixin:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 
         # KNOWN LIMITATION (mitigated for 'connect' below when sni_capture_enabled):
         # server_hostname defaults to the raw destination IP, not the real

--- a/extras/cert_analyzer_load_test.py
+++ b/extras/cert_analyzer_load_test.py
@@ -162,6 +162,8 @@ def write_jks(path: str, cert, password: str = 'changeit'):
     entry += struct.pack('>I', len(cert_der))  + cert_der
 
     body     = struct.pack('>III', 0xFEEDFEED, 2, 1) + entry
+    # SHA-1 + this exact salt is mandated by Oracle's JKS binary format for
+    # its tamper-detection digest, not a choice made here.
     pw_bytes = b''.join(struct.pack('>H', ord(c)) for c in password)
     digest   = hashlib.sha1(pw_bytes + b'Mighty Aphrodite' + body).digest()
 

--- a/extras/test-server/server.py
+++ b/extras/test-server/server.py
@@ -180,6 +180,11 @@ def make_handler(broadcaster: Optional[EventBroadcaster], prometheus_url: str, m
             self.wfile.write(data)
 
         def _serve_source(self, filename):
+            # filename comes straight from the URL path, but the exact-match
+            # membership check above rejects anything that isn't one of
+            # SOURCE_FILES' fixed literal names -- a traversal payload like
+            # "../../etc/passwd" is simply not a member and 404s before ever
+            # reaching the filesystem, so no path outside APP_DIR is reachable.
             if filename not in SOURCE_FILES:
                 self.send_error(404, f"no such source file '{filename}'")
                 return

--- a/extras/test-server/tcp_connect_probe_helper.py
+++ b/extras/test-server/tcp_connect_probe_helper.py
@@ -79,6 +79,7 @@ def main() -> int:
     lifetime = float(lifetime_str)
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         context.load_cert_chain(certfile=certfile, keyfile=keyfile)
     except Exception as e:

--- a/extras/test-server/tcp_connect_sni_probe_helper.py
+++ b/extras/test-server/tcp_connect_sni_probe_helper.py
@@ -106,7 +106,9 @@ def main() -> int:
     lifetime = float(lifetime_str)
 
     real_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    real_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     fallback_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    fallback_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         real_ctx.load_cert_chain(certfile=real_certfile, keyfile=real_keyfile)
         fallback_ctx.load_cert_chain(certfile=fallback_certfile, keyfile=fallback_keyfile)
@@ -153,6 +155,7 @@ def main() -> int:
     client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     client_ctx.check_hostname = False
     client_ctx.verify_mode = ssl.CERT_NONE
+    client_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         with socket.create_connection(("127.0.0.1", port), timeout=3) as raw_sock:
             with client_ctx.wrap_socket(raw_sock, server_hostname=real_hostname):

--- a/extras/test-server/tls_probe_helper.py
+++ b/extras/test-server/tls_probe_helper.py
@@ -54,6 +54,7 @@ def main() -> int:
     lifetime = float(lifetime_str)
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         context.load_cert_chain(certfile=certfile, keyfile=keyfile)
     except Exception as e:

--- a/extras/test-server/tls_probe_helper_non_fips_cipher.py
+++ b/extras/test-server/tls_probe_helper_non_fips_cipher.py
@@ -48,6 +48,7 @@ def main() -> int:
     # 1.3 would otherwise prefer it over anything offered here regardless of
     # this cipher list. Capping maximum_version forces negotiation down to
     # 1.2, where this single-entry cipher list actually takes effect.
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.maximum_version = ssl.TLSVersion.TLSv1_2
     context.set_ciphers(_NON_FIPS_CIPHER)
 

--- a/extras/test_analyzer.py
+++ b/extras/test_analyzer.py
@@ -142,6 +142,8 @@ def generate_test_jks(days_valid: int, output_path: str, cn: str = None, passwor
     body = struct.pack('>III', 0xFEEDFEED, 2, 1) + entry      # header + 1 entry
 
     # JKS integrity digest: SHA1(pw_as_java_chars + "Mighty Aphrodite" + body)
+    # -- mandated by Oracle's JKS binary format, not a choice made here; a
+    # different algorithm produces a file real JKS parsers can't recognize.
     pw_bytes = b''.join(struct.pack('>H', ord(c)) for c in password)
     digest   = hashlib.sha1(pw_bytes + b'Mighty Aphrodite' + body).digest()
 

--- a/perf_tests/cert_analyzer_perf_comparison.py
+++ b/perf_tests/cert_analyzer_perf_comparison.py
@@ -95,6 +95,9 @@ class ConfigResult:
 def _make_cert(cn: str, key_size: int, days: int = 365) -> x509.Certificate:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
+        # key_size is deliberately as low as 1024 here (see build_cert_pool's
+        # fips_mix) to synthesize non-FIPS-compliant throwaway test certs --
+        # never used for anything but this in-process perf comparison.
         key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
     nvb = datetime.utcnow()
     nva = datetime.utcnow() + timedelta(days=days)

--- a/probe_tests/test_tcp_connect_probe.py
+++ b/probe_tests/test_tcp_connect_probe.py
@@ -58,6 +58,7 @@ def _serve(cert_path: str, key_path: str, bind_ip: str, port: int,
            ready: threading.Event, stop: threading.Event) -> None:
     """Accept TLS connections on bind_ip:port until stop is set."""
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.load_cert_chain(cert_path, key_path)
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as raw:

--- a/probe_tests/test_tls_port_probe.py
+++ b/probe_tests/test_tls_port_probe.py
@@ -41,6 +41,7 @@ _PROBE_WAIT  = 5   # seconds to allow cert_analyzer to probe after the bind
 def _serve(cert_path: str, key_path: str, port: int, stop: threading.Event) -> None:
     """Accept TLS connections on port until stop is set."""
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.load_cert_chain(cert_path, key_path)
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as raw:

--- a/test-cert-generator/test_analyzer.py
+++ b/test-cert-generator/test_analyzer.py
@@ -144,6 +144,8 @@ def generate_test_jks(days_valid: int, output_path: str, cn: str = None, passwor
     body = struct.pack('>III', 0xFEEDFEED, 2, 1) + entry      # header + 1 entry
 
     # JKS integrity digest: SHA1(pw_as_java_chars + "Mighty Aphrodite" + body)
+    # -- mandated by Oracle's JKS binary format, not a choice made here; a
+    # different algorithm produces a file real JKS parsers can't recognize.
     pw_bytes = b''.join(struct.pack('>H', ord(c)) for c in password)
     digest   = hashlib.sha1(pw_bytes + b'Mighty Aphrodite' + body).digest()
 
@@ -155,6 +157,9 @@ def generate_test_jks(days_valid: int, output_path: str, cn: str = None, passwor
     print(f"           CN={cn}")
     print(f"           Valid: {not_valid_before.strftime('%Y-%m-%d')} → {not_valid_after.strftime('%Y-%m-%d')}")
     print(f"           Status: {status}")
+    # password is always the hardcoded 'changeit' default (no CLI flag feeds
+    # a real secret into this generator) -- printed only so a developer
+    # running this test-fixture tool knows what unlocks the file it just wrote.
     print(f"           Password: {password}")
 
 
@@ -207,6 +212,9 @@ def generate_test_pkcs12(days_valid: int, output_path: str, cn: str = None, pass
     print(f"           CN={cn}")
     print(f"           Valid: {not_valid_before.strftime('%Y-%m-%d')} → {not_valid_after.strftime('%Y-%m-%d')}")
     print(f"           Status: {status}")
+    # password is always the hardcoded 'changeit' default (no CLI flag feeds
+    # a real secret into this generator) -- printed only so a developer
+    # running this test-fixture tool knows what unlocks the file it just wrote.
     print(f"           Password: {password}")
 
 

--- a/test_cert_analyzer.py
+++ b/test_cert_analyzer.py
@@ -1489,6 +1489,10 @@ class TestPKCS12Parsing:
             c.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
             for c in certs
         ]
+        # These check a locally-parsed test certificate's CN against an
+        # expected literal -- not a URL authorization/redirect decision --
+        # so the substring-check shape isn't the security anti-pattern
+        # py/incomplete-url-substring-sanitization targets.
         assert "server.example.com" in common_names
         assert "Intermediate CA" in common_names
         assert "Root CA" in common_names
@@ -1661,6 +1665,8 @@ class TestCABundles:
         assert len(cert_infos) == 3
         assert "Root CA" in cert_infos[0].common_name
         assert "Intermediate CA" in cert_infos[1].common_name
+        # Same non-issue as test_ca_bundle_with_chain above -- a locally
+        # generated test cert's CN, not a URL trust decision.
         assert "server.example.com" in cert_infos[2].common_name
     
     def test_expired_intermediate_in_chain(self, analyzer, temp_dir):
@@ -2173,6 +2179,10 @@ def _make_jks_truststore(cert: x509.Certificate, password: str = 'changeit') -> 
 
     body   = struct.pack('>III', 0xFEEDFEED, 2, 1) + entry      # header + 1 entry
 
+    # SHA-1 + this exact salt is mandated by Oracle's JKS binary format for
+    # its tamper-detection digest, not a choice made here -- a different
+    # algorithm would produce a file real JKS parsers (including the one
+    # under test) can't recognize.
     pw_bytes = b''.join(struct.pack('>H', ord(c)) for c in password)
     digest   = hashlib.sha1(pw_bytes + b'Mighty Aphrodite' + body).digest()
 
@@ -2203,6 +2213,8 @@ def _make_jks_truststore_multi(certs: list, password: str = 'changeit') -> bytes
 
     body = struct.pack('>III', 0xFEEDFEED, 2, len(certs)) + entries
 
+    # SHA-1 + this exact salt is mandated by Oracle's JKS binary format for
+    # its tamper-detection digest -- see _make_jks_truststore above.
     pw_bytes = b''.join(struct.pack('>H', ord(c)) for c in password)
     digest   = hashlib.sha1(pw_bytes + b'Mighty Aphrodite' + body).digest()
 
@@ -2439,6 +2451,8 @@ class TestJKSParsing:
             c.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
             for c in certs
         ]
+        # Same non-issue as test_ca_bundle_with_chain above -- locally
+        # generated test certs' CNs, not a URL trust decision.
         assert "ca-root.example.com"  in common_names
         assert "ca-inter.example.com" in common_names
         assert "leaf.example.com"     in common_names
@@ -5947,6 +5961,8 @@ class TestCertificateParsingExceptions:
         # Two valid certs should come through; broken one silently skipped
         assert len(cert_infos) == 2
         common_names = [c.common_name for c in cert_infos]
+        # Same non-issue as test_ca_bundle_with_chain above -- locally
+        # generated test certs' CNs, not a URL trust decision.
         assert "valid1.example.com" in common_names
         assert "valid2.example.com" in common_names
 
@@ -7989,6 +8005,8 @@ class TestOpensslUprobeHooking:
         analyzer._handle_uprobe_in_memory_cert(event)
 
         info = list(analyzer.known_certs.values())[0]
+        # Same non-issue as test_ca_bundle_with_chain above -- a locally
+        # generated test cert's subject DN, not a URL trust decision.
         assert 'fields.example.com' in info.subject
         assert info.pid == 42
         assert info.process == '/usr/bin/python3'
@@ -9177,6 +9195,7 @@ class TestPortProbe:
 
         def _serve():
             ctx = _ssl.SSLContext(_ssl.PROTOCOL_TLS_SERVER)
+            ctx.minimum_version = _ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(cert_path, key_path)
             with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as raw:
                 raw.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
@@ -9372,6 +9391,7 @@ class TestPortProbe:
 
         def _serve():
             ctx = _ssl.SSLContext(_ssl.PROTOCOL_TLS_SERVER)
+            ctx.minimum_version = _ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(cert_path, key_path)
             ctx.sni_callback = _sni_callback
             with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as raw:


### PR DESCRIPTION
Investigated every alert reported after enabling code scanning:

- Explicit ctx.minimum_version = TLSv1_2 on every SSLContext/ create_default_context() call that lacked one (8 sites across agent/tls_probe.py, the test-server probe helpers, probe_tests scripts, and test_cert_analyzer.py) -- a real hardening gap even though modern Python/OpenSSL already default to TLS 1.2+.

- Suppressed with an explanatory comment where the flagged code is a deliberate, non-exploitable pattern:
  - perf_tests/cert_analyzer_perf_comparison.py: RSA-1024 generation to simulate non-FIPS-compliant certs for a throughput comparison.
  - 5 sites implementing Oracle's JKS binary keystore format's mandatory SHA-1 integrity digest (format-dictated, not a choice).
  - extras/test-server/server.py: filename is checked against a hardcoded literal allowlist before any filesystem read, so no traversal payload can reach it -- verified given this endpoint is public on the AWS demo box.
  - test-cert-generator/test_analyzer.py: the "password" logged is always the hardcoded 'changeit' JKS/PKCS12 default, never a real secret.
  - 8 sites in test_cert_analyzer.py doing "literal" in <parsed test cert field> as a correctness assertion, not a URL-authorization substring check.

Full test_cert_analyzer.py suite (554 tests) passes after these changes.